### PR TITLE
Fix a bug that cause local test helper to fail when searching an emulator with an older cloud SDK

### DIFF
--- a/src/main/java/com/google/api/gax/testing/GCloudEmulatorRunner.java
+++ b/src/main/java/com/google/api/gax/testing/GCloudEmulatorRunner.java
@@ -81,7 +81,7 @@ public class GCloudEmulatorRunner implements EmulatorRunner {
   private boolean isEmulatorUpdateToDate()
       throws IOException, InterruptedException {
     String currentVersion = installedEmulatorVersion(versionPrefix);
-    return currentVersion.compareTo(minVersion) >= 0;
+    return currentVersion != null && currentVersion.compareTo(minVersion) >= 0;
   }
 
   private String installedEmulatorVersion(String versionPrefix)


### PR DESCRIPTION
currentVersion may be null when using an older GCLOUD SDK without the searched emulator.