### PR TITLE
Fix surface issues based on Java review.

### DIFF
--- a/src/main/java/com/google/api/gax/core/BackoffParams.java
+++ b/src/main/java/com/google/api/gax/core/BackoffParams.java
@@ -33,16 +33,18 @@ package com.google.api.gax.core;
 
 import com.google.auto.value.AutoValue;
 
+import org.joda.time.Duration;
+
 /**
  * {@code BackoffParams} encapsulates parameters for exponential backoff.
  */
 @AutoValue
 public abstract class BackoffParams {
-  public abstract long getInitialDelayMillis();
+  public abstract Duration getInitialDelay();
 
   public abstract double getDelayMultiplier();
 
-  public abstract long getMaxDelayMillis();
+  public abstract Duration getMaxDelay();
 
   public static Builder newBuilder() {
     return new AutoValue_BackoffParams.Builder();
@@ -54,23 +56,23 @@ public abstract class BackoffParams {
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder setInitialDelayMillis(long initialDelayMillis);
+    public abstract Builder setInitialDelay(Duration initialDelayDuration);
 
     public abstract Builder setDelayMultiplier(double delayMultiplier);
 
-    public abstract Builder setMaxDelayMillis(long maxDelayMillis);
+    public abstract Builder setMaxDelay(Duration maxDelayDuration);
 
     abstract BackoffParams autoBuild();
 
     public BackoffParams build() {
       BackoffParams backoff = autoBuild();
-      if (backoff.getInitialDelayMillis() < 0) {
+      if (backoff.getInitialDelay().getMillis() < 0) {
         throw new IllegalStateException("initial delay must not be negative");
       }
       if (backoff.getDelayMultiplier() < 1.0) {
         throw new IllegalStateException("delay multiplier must be at least 1");
       }
-      if (backoff.getMaxDelayMillis() < backoff.getInitialDelayMillis()) {
+      if (backoff.getMaxDelay().compareTo(backoff.getInitialDelay()) < 0) {
         throw new IllegalStateException("max delay must not be smaller than initial delay");
       }
       return backoff;

--- a/src/main/java/com/google/api/gax/core/RetryParams.java
+++ b/src/main/java/com/google/api/gax/core/RetryParams.java
@@ -33,6 +33,10 @@ package com.google.api.gax.core;
 
 import com.google.auto.value.AutoValue;
 
+import org.joda.time.Duration;
+
+import java.util.concurrent.ScheduledExecutorService;
+
 /**
  * {@code RetryParams} encapsulates a retry strategy used by
  * {@link com.google.api.gax.grpc.ApiCallable#retrying(RetryParams, ScheduledExecutorService)}.
@@ -43,7 +47,7 @@ public abstract class RetryParams {
 
   public abstract BackoffParams getTimeoutBackoff();
 
-  public abstract long getTotalTimeout();
+  public abstract Duration getTotalTimeout();
 
   public static Builder newBuilder() {
     return new AutoValue_RetryParams.Builder();
@@ -59,13 +63,13 @@ public abstract class RetryParams {
 
     public abstract Builder setTimeoutBackoff(BackoffParams timeoutBackoff);
 
-    public abstract Builder setTotalTimeout(long totalTimeout);
+    public abstract Builder setTotalTimeout(Duration totalTimeout);
 
     abstract RetryParams autoBuild();
 
     public RetryParams build() {
       RetryParams params = autoBuild();
-      if (params.getTotalTimeout() < 0) {
+      if (params.getTotalTimeout().getMillis() < 0) {
         throw new IllegalStateException("total timeout must not be negative");
       }
       return params;

--- a/src/main/java/com/google/api/gax/grpc/ApiCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/ApiCallable.java
@@ -34,7 +34,6 @@ package com.google.api.gax.grpc;
 import com.google.api.gax.core.RetryParams;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -43,7 +42,6 @@ import io.grpc.ExperimentalApi;
 import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 
 import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -108,47 +106,6 @@ public class ApiCallable<RequestT, ResponseT> {
    */
   public ResponseT call(RequestT request) {
     return Futures.getUnchecked(futureCall(request));
-  }
-
-  /**
-   * Perform a call asynchronously with the given {@code observer}.
-   * If the {@link io.grpc.Channel} encapsulated in the given
-   * {@link com.google.api.gax.grpc.CallContext} is null, a channel must have already been bound,
-   * using {@link #bind(Channel)}.
-   *
-   * @param context {@link com.google.api.gax.grpc.CallContext} to make the call with
-   * @param observer Observer to interact with the result
-   */
-  public void asyncCall(CallContext<RequestT> context, final StreamObserver<ResponseT> observer) {
-    Futures.addCallback(
-        futureCall(context),
-        new FutureCallback<ResponseT>() {
-          @Override
-          public void onFailure(Throwable t) {
-            if (observer != null) {
-              observer.onError(t);
-            }
-          }
-
-          @Override
-          public void onSuccess(ResponseT result) {
-            if (observer != null) {
-              observer.onNext(result);
-              observer.onCompleted();
-            }
-          }
-        });
-  }
-
-  /**
-   * Same as {@link #asyncCall(CallContext, StreamObserver)}, with null {@link io.grpc.Channel} and
-   * default {@link io.grpc.CallOptions}.
-   *
-   * @param request request
-   * @param observer Observer to interact with the result
-   */
-  public void asyncCall(RequestT request, StreamObserver<ResponseT> observer) {
-    asyncCall(CallContext.<RequestT>of(request), observer);
   }
 
   /**

--- a/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
@@ -37,7 +37,7 @@ public class ServiceApiSettings {
   private String serviceGeneratorVersion;
   private ChannelProvider channelProvider;
   private ExecutorProvider executorProvider;
-  private final ImmutableList<? extends ApiCallSettings> allMethods;
+  private final ImmutableList<? extends ApiCallSettings> allCallSettings;
 
   /**
    * The number of threads to use with the default executor.
@@ -54,7 +54,7 @@ public class ServiceApiSettings {
   /**
    * Constructs an instance of ServiceApiSettings.
    */
-  public ServiceApiSettings(ImmutableList<? extends ApiCallSettings> allMethods) {
+  public ServiceApiSettings(ImmutableList<? extends ApiCallSettings> allCallSettings) {
     clientLibName = DEFAULT_CLIENT_LIB_NAME;
     clientLibVersion = DEFAULT_VERSION;
     serviceGeneratorName = DEFAULT_GENERATOR_NAME;
@@ -82,7 +82,7 @@ public class ServiceApiSettings {
         return executor;
       }
     };
-    this.allMethods = allMethods;
+    this.allCallSettings = allCallSettings;
   }
 
   private interface ChannelProvider {
@@ -96,7 +96,8 @@ public class ServiceApiSettings {
    *
    * See class documentation for more details on channels.
    */
-  public ServiceApiSettings provideChannelWith(final ManagedChannel channel) {
+  public ServiceApiSettings provideChannelWith(
+      final ManagedChannel channel, final boolean shouldAutoClose) {
     channelProvider = new ChannelProvider() {
       @Override
       public ManagedChannel getChannel(Executor executor) {
@@ -104,7 +105,7 @@ public class ServiceApiSettings {
       }
       @Override
       public boolean shouldAutoClose() {
-        return false;
+        return shouldAutoClose;
       }
     };
     return this;
@@ -113,7 +114,8 @@ public class ServiceApiSettings {
   /**
    * Provides the connection settings necessary to create a channel.
    */
-  public ServiceApiSettings provideChannelWith(final ConnectionSettings settings) {
+  public ServiceApiSettings provideChannelWith(
+      final ConnectionSettings settings,final boolean shouldAutoClose) {
     channelProvider = new ChannelProvider() {
       private ManagedChannel channel = null;
       @Override
@@ -135,7 +137,7 @@ public class ServiceApiSettings {
 
       @Override
       public boolean shouldAutoClose() {
-        return true;
+        return shouldAutoClose;
       }
 
       private String serviceHeader() {
@@ -208,10 +210,10 @@ public class ServiceApiSettings {
   }
 
   /**
-   * Returns all of the methods of this API, which can be individually configured.
+   * Returns all of the API call settings of this API, which can be individually configured.
    */
-  public ImmutableList<? extends ApiCallSettings> allMethods() {
-    return allMethods;
+  public ImmutableList<? extends ApiCallSettings> allCallSettings() {
+    return allCallSettings;
   }
 
   /**
@@ -225,8 +227,8 @@ public class ServiceApiSettings {
    * Sets the retry codes on all of the methods of the API.
    */
   public ServiceApiSettings setRetryableCodesOnAllMethods(Set<Status.Code> retryableCodes) {
-    for (ApiCallSettings method : allMethods) {
-      method.setRetryableCodes(retryableCodes);
+    for (ApiCallSettings settings : allCallSettings) {
+      settings.setRetryableCodes(retryableCodes);
     }
     return this;
   }
@@ -235,8 +237,8 @@ public class ServiceApiSettings {
    * Sets the retry params for all of the methods of the API.
    */
   public ServiceApiSettings setRetryParamsOnAllMethods(RetryParams retryParams) {
-    for (ApiCallSettings method : allMethods) {
-      method.setRetryParams(retryParams);
+    for (ApiCallSettings settings : allCallSettings) {
+      settings.setRetryParams(retryParams);
     }
     return this;
   }
@@ -244,16 +246,18 @@ public class ServiceApiSettings {
   /**
    * Sets the generator name and version for the GRPC custom header.
    */
-  public void setGeneratorHeader(String name, String version) {
+  public ServiceApiSettings setGeneratorHeader(String name, String version) {
     this.serviceGeneratorName = name;
     this.serviceGeneratorVersion = version;
+    return this;
   }
 
   /**
    * Sets the client library name and version for the GRPC custom header.
    */
-  public void setClientLibHeader(String name, String version) {
+  public ServiceApiSettings setClientLibHeader(String name, String version) {
     this.clientLibName = name;
     this.clientLibVersion = version;
+    return this;
   }
 }

--- a/src/test/java/com/google/api/gax/grpc/ApiCallableTest.java
+++ b/src/test/java/com/google/api/gax/grpc/ApiCallableTest.java
@@ -33,7 +33,6 @@ package com.google.api.gax.grpc;
 
 import com.google.api.gax.core.BackoffParams;
 import com.google.api.gax.core.RetryParams;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.truth.Truth;
@@ -41,22 +40,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-
-import com.google.api.gax.bundling.BundlingThreshold;
-import com.google.api.gax.bundling.BundlingThresholds;
-import com.google.api.gax.bundling.ExternalThreshold;
-
-import io.grpc.Channel;
-import io.grpc.Status;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.List;
 
 import org.joda.time.Duration;
 import org.junit.Assert;
@@ -66,6 +49,18 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
+
+import io.grpc.Channel;
+import io.grpc.Status;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 /**
  * Tests for {@link ApiCallable}.
  */
@@ -78,15 +73,15 @@ public class ApiCallableTest {
   static {
     BackoffParams backoff =
         BackoffParams.newBuilder()
-            .setInitialDelayMillis(2L)
+            .setInitialDelay(Duration.millis(2L))
             .setDelayMultiplier(1)
-            .setMaxDelayMillis(2L)
+            .setMaxDelay(Duration.millis(2L))
             .build();
     testRetryParams =
         RetryParams.newBuilder()
             .setRetryBackoff(backoff)
             .setTimeoutBackoff(backoff)
-            .setTotalTimeout(100L)
+            .setTotalTimeout(Duration.millis(100L))
             .build();
   }
 


### PR DESCRIPTION
- Mark observer asyncCall private
- Add boolean parameter for whether auto close channel
- Return this from setGeneratedHeader/setClientLibHeader
- Use Duration instead of long