### PR TITLE
Update to failing retry tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ javadoc.options {
 test {
   testLogging {
     events "passed", "skipped", "failed", "standardOut", "standardError"
+    exceptionFormat = 'full'
   }
 }
 


### PR DESCRIPTION
Updated retryKeepFailing and retryNoRecover to use fake clock.

Added full exception logging to build.gradle file so that exception and test failure details are available in Travis output.