### PR TITLE
Fix issues in ApiCallable and ServiceApiSettings.

### DIFF
--- a/src/main/java/com/google/api/gax/grpc/ApiCallSettingsTyped.java
+++ b/src/main/java/com/google/api/gax/grpc/ApiCallSettingsTyped.java
@@ -33,13 +33,13 @@ class ApiCallSettingsTyped<RequestT, ResponseT> extends ApiCallSettings {
   }
 
   protected ApiCallable<RequestT, ResponseT> createBaseCallable(
-      ServiceApiSettings.Builder serviceSettingsBuilder) throws IOException {
+      ServiceApiSettings serviceSettings) throws IOException {
     ClientCallFactory<RequestT, ResponseT> clientCallFactory =
         new DescriptorClientCallFactory<>(methodDescriptor);
     ApiCallable<RequestT, ResponseT> callable =
         new ApiCallable<>(new DirectCallable<>(clientCallFactory), this);
-    ManagedChannel channel = serviceSettingsBuilder.getOrBuildChannel();
-    ScheduledExecutorService executor = serviceSettingsBuilder.getOrBuildExecutor();
+    ManagedChannel channel = serviceSettings.getChannel();
+    ScheduledExecutorService executor = serviceSettings.getExecutor();
     if (getRetryableCodes() != null) {
       callable = callable.retryableOn(ImmutableSet.copyOf(getRetryableCodes()));
     }

--- a/src/main/java/com/google/api/gax/grpc/ApiCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/ApiCallable.java
@@ -67,14 +67,14 @@ public class ApiCallable<RequestT, ResponseT> {
    *
    * @param simpleCallSettings {@link com.google.api.gax.grpc.SimpleCallSettings} to configure
    * the method-level settings with.
-   * @param serviceSettingsBuilder {@link com.google.api.gax.grpc.ServiceApiSettings.Builder}
+   * @param serviceSettings{@link com.google.api.gax.grpc.ServiceApiSettings}
    * to configure the service-level settings with.
    * @return {@link com.google.api.gax.grpc.ApiCallable} callable object.
    */
   public static <RequestT, ResponseT> ApiCallable<RequestT, ResponseT> create(
       SimpleCallSettings<RequestT, ResponseT> simpleCallSettings,
-      ServiceApiSettings.Builder serviceSettingsBuilder) throws IOException {
-     return simpleCallSettings.create(serviceSettingsBuilder);
+      ServiceApiSettings serviceSettings) throws IOException {
+     return simpleCallSettings.create(serviceSettings);
   }
 
   /**
@@ -83,15 +83,15 @@ public class ApiCallable<RequestT, ResponseT> {
    *
    * @param pageStreamingCallSettings {@link com.google.api.gax.grpc.PageStreamingCallSettings} to
    * configure the page-streaming related settings with.
-   * @param serviceSettingsBuilder {@link com.google.api.gax.grpc.ServiceApiSettings.Builder}
+   * @param serviceSettings{@link com.google.api.gax.grpc.ServiceApiSettings}
    * to configure the service-level settings with.
    * @return {@link com.google.api.gax.grpc.ApiCallable} callable object.
    */
   public static <RequestT, ResponseT, ResourceT>
       ApiCallable<RequestT, Iterable<ResourceT>> create(
           PageStreamingCallSettings<RequestT, ResponseT, ResourceT> pageStreamingCallSettings,
-          ServiceApiSettings.Builder serviceSettingsBuilder) throws IOException {
-    return pageStreamingCallSettings.create(serviceSettingsBuilder);
+          ServiceApiSettings serviceSettings) throws IOException {
+    return pageStreamingCallSettings.create(serviceSettings);
   }
 
   /**
@@ -100,14 +100,14 @@ public class ApiCallable<RequestT, ResponseT> {
    *
    * @param bundlingCallSettings {@link com.google.api.gax.grpc.BundlingSettings} to configure
    * the bundling related settings with.
-   * @param serviceSettingsBuilder {@link com.google.api.gax.grpc.ServiceApiSettings.Builder}
+   * @param serviceSettings{@link com.google.api.gax.grpc.ServiceApiSettings}
    * to configure the service-level settings with.
    * @return {@link com.google.api.gax.grpc.ApiCallable} callable object.
    */
   public static <RequestT, ResponseT> ApiCallable<RequestT, ResponseT> create(
       BundlingCallSettings<RequestT, ResponseT> bundlingCallSettings,
-      ServiceApiSettings.Builder serviceSettingsBuilder) throws IOException {
-    return bundlingCallSettings.create(serviceSettingsBuilder);
+      ServiceApiSettings serviceSettings) throws IOException {
+    return bundlingCallSettings.create(serviceSettings);
   }
 
   /**

--- a/src/main/java/com/google/api/gax/grpc/BundlingCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/BundlingCallSettings.java
@@ -23,8 +23,8 @@ public class BundlingCallSettings<RequestT, ResponseT>
    * Package-private
    */
   ApiCallable<RequestT, ResponseT> create(
-      ServiceApiSettings.Builder serviceSettingsBuilder) throws IOException {
-    ApiCallable<RequestT, ResponseT> baseCallable = createBaseCallable(serviceSettingsBuilder);
+      ServiceApiSettings serviceSettings) throws IOException {
+    ApiCallable<RequestT, ResponseT> baseCallable = createBaseCallable(serviceSettings);
     bundlerFactory = new BundlerFactory<>(bundlingDescriptor, bundlingSettings);
     return baseCallable.bundling(bundlingDescriptor, bundlerFactory);
   }

--- a/src/main/java/com/google/api/gax/grpc/PageStreamingCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/PageStreamingCallSettings.java
@@ -22,8 +22,8 @@ public class PageStreamingCallSettings<RequestT, ResponseT, ResourceT>
    * Package-private
    */
   ApiCallable<RequestT, Iterable<ResourceT>> create(
-      ServiceApiSettings.Builder serviceSettingsBuilder) throws IOException {
-    ApiCallable<RequestT, ResponseT> baseCallable = createBaseCallable(serviceSettingsBuilder);
+      ServiceApiSettings serviceSettings) throws IOException {
+    ApiCallable<RequestT, ResponseT> baseCallable = createBaseCallable(serviceSettings);
     return baseCallable.pageStreaming(pageDescriptor);
   }
 

--- a/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
@@ -19,6 +19,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
+import javax.annotation.Nullable;
+
 /**
  * A settings class to configure a service api class.
  *
@@ -33,15 +35,33 @@ public class ServiceApiSettings {
   private final boolean shouldAutoCloseChannel;
   private final ScheduledExecutorService executor;
 
+  @Nullable
+  private final ConnectionSettings connectionSettings;
+
+  private final String generatorName;
+  private final String generatorVersion;
+  private final String clientLibName;
+  private final String clientLibVersion;
+
   /**
    * Constructs an instance of ServiceApiSettings.
    */
   protected ServiceApiSettings(ManagedChannel channel,
                                boolean shouldAutoCloseChannel,
-                               ScheduledExecutorService executor) {
+                               ScheduledExecutorService executor,
+                               ConnectionSettings connectionSettings,
+                               String generatorName,
+                               String generatorVersion,
+                               String clientLibName,
+                               String clientLibVersion) {
     this.channel = channel;
     this.executor = executor;
+    this.connectionSettings = connectionSettings;
     this.shouldAutoCloseChannel = shouldAutoCloseChannel;
+    this.clientLibName = clientLibName;
+    this.clientLibVersion = clientLibVersion;
+    this.generatorName = generatorName;
+    this.generatorVersion = generatorVersion;
   }
 
   public ManagedChannel getChannel() {
@@ -75,6 +95,7 @@ public class ServiceApiSettings {
     private ExecutorProvider executorProvider;
 
     private interface ChannelProvider {
+      ConnectionSettings connectionSettings();
       boolean shouldAutoClose();
       ManagedChannel getChannel(Executor executor) throws IOException;
     }
@@ -98,6 +119,10 @@ public class ServiceApiSettings {
         public boolean shouldAutoClose() {
           return true;
         }
+        @Override
+        public ConnectionSettings connectionSettings() {
+          return null;
+        }
       };
       executorProvider = new ExecutorProvider() {
         private ScheduledExecutorService executor = null;
@@ -111,6 +136,20 @@ public class ServiceApiSettings {
           return executor;
         }
       };
+    }
+
+    /**
+     * Create a builder from a ServiceApiSettings object.
+     */
+    protected Builder(ServiceApiSettings settings) {
+      this();
+      if (settings.connectionSettings != null) {
+        provideChannelWith(settings.connectionSettings);
+      } else {
+        provideChannelWith(settings.channel, settings.shouldAutoCloseChannel);
+      }
+      setClientLibHeader(settings.clientLibName, settings.clientLibVersion);
+      setGeneratorHeader(settings.generatorName, settings.generatorVersion);
     }
 
     /**
@@ -145,6 +184,10 @@ public class ServiceApiSettings {
         public boolean shouldAutoClose() {
           return shouldAutoClose;
         }
+        @Override
+        public ConnectionSettings connectionSettings() {
+          return null;
+        }
       };
       return this;
     }
@@ -171,6 +214,11 @@ public class ServiceApiSettings {
              .intercept(interceptors)
              .build();
          return channel;
+       }
+
+       @Override
+       public ConnectionSettings connectionSettings() {
+         return settings;
        }
 
        @Override
@@ -214,13 +262,6 @@ public class ServiceApiSettings {
     }
 
     /**
-     * Returns true if the channel should be automatically closed with the API wrapper class.
-     */
-    public boolean shouldAutoCloseChannel() {
-      return channelProvider.shouldAutoClose();
-    }
-
-    /**
      * Sets the generator name and version for the GRPC custom header.
      */
     public Builder setGeneratorHeader(String name, String version) {
@@ -236,6 +277,30 @@ public class ServiceApiSettings {
       this.clientLibName = name;
       this.clientLibVersion = version;
       return this;
+    }
+
+    public String getClientLibName() {
+      return clientLibName;
+    }
+
+    public String getClientLibVersion() {
+      return clientLibVersion;
+    }
+
+    public String getGeneratorLibName() {
+      return serviceGeneratorName;
+    }
+
+    public String getGeneratorLibVersion() {
+      return serviceGeneratorVersion;
+    }
+
+    public ConnectionSettings getConnectionSettings() {
+      return channelProvider.connectionSettings();
+    }
+
+    public boolean shouldAutoCloseChannel() {
+      return channelProvider.shouldAutoClose();
     }
 
     /**
@@ -260,8 +325,13 @@ public class ServiceApiSettings {
 
     public ServiceApiSettings build() throws IOException {
       return new ServiceApiSettings(getOrBuildChannel(),
-                                    shouldAutoCloseChannel(),
-                                    getOrBuildExecutor());
+                                    channelProvider.shouldAutoClose(),
+                                    getOrBuildExecutor(),
+                                    channelProvider.connectionSettings(),
+                                    clientLibName,
+                                    clientLibVersion,
+                                    serviceGeneratorName,
+                                    serviceGeneratorVersion);
     }
   }
 }

--- a/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
@@ -287,11 +287,11 @@ public class ServiceApiSettings {
       return clientLibVersion;
     }
 
-    public String getGeneratorLibName() {
+    public String getGeneratorName() {
       return serviceGeneratorName;
     }
 
-    public String getGeneratorLibVersion() {
+    public String getGeneratorVersion() {
       return serviceGeneratorVersion;
     }
 

--- a/src/main/java/com/google/api/gax/grpc/SimpleCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/SimpleCallSettings.java
@@ -20,8 +20,8 @@ public class SimpleCallSettings<RequestT, ResponseT>
    * Package-private
    */
   ApiCallable<RequestT, ResponseT> create(
-      ServiceApiSettings.Builder serviceSettingsBuilder) throws IOException {
-    return createBaseCallable(serviceSettingsBuilder);
+      ServiceApiSettings serviceSettings) throws IOException {
+    return createBaseCallable(serviceSettings);
   }
 
   private SimpleCallSettings(ImmutableSet<Status.Code> retryableCodes,


### PR DESCRIPTION
- Use ServiceApiSettings instead of its builder class to create callable objects.
- Add support to create ServiceApiSettings.Builder object from ServiceApiSettings object.