### PR TITLE
Make ServiceApiSettings provider interfaces public

### DIFF
--- a/src/main/java/com/google/api/gax/core/ConnectionSettings.java
+++ b/src/main/java/com/google/api/gax/core/ConnectionSettings.java
@@ -57,18 +57,6 @@ import java.util.List;
 public abstract class ConnectionSettings {
 
   /**
-   * Provides an interface to hold and acquire the credentials that will be used to call the
-   * service.
-   */
-  public interface CredentialsProvider {
-    /**
-     * Gets the credentials which will be used to call the service. If the credentials have not been
-     * acquired yet, then they will be acquired when this function is called.
-     */
-    Credentials getCredentials() throws IOException;
-  }
-
-  /**
    * Gets the credentials which will be used to call the service. If the credentials have not been
    * acquired yet, then they will be acquired when this function is called.
    */

--- a/src/main/java/com/google/api/gax/core/ConnectionSettings.java
+++ b/src/main/java/com/google/api/gax/core/ConnectionSettings.java
@@ -56,25 +56,31 @@ import java.util.List;
 @AutoValue
 public abstract class ConnectionSettings {
 
-  /*
-   * package-private so that the AutoValue derived class can access it
+  /**
+   * Provides an interface to hold and acquire the credentials that will be used to call the
+   * service.
    */
-  interface CredentialsProvider {
+  public interface CredentialsProvider {
+    /**
+     * Gets the credentials which will be used to call the service. If the credentials have not been
+     * acquired yet, then they will be acquired when this function is called.
+     */
     Credentials getCredentials() throws IOException;
   }
 
   /**
-   * Gets the credentials which will be used to call the service. If the credentials
-   * have not been acquired yet, then they will be acquired when this function is called.
+   * Gets the credentials which will be used to call the service. If the credentials have not been
+   * acquired yet, then they will be acquired when this function is called.
    */
-  public Credentials getCredentials() throws IOException {
+  public Credentials getOrBuildCredentials() throws IOException {
     return getCredentialsProvider().getCredentials();
   }
 
-  /*
-   * package-private so that the AutoValue derived class can access it
+  /**
+   * The credentials to use in order to call the service. Credentials will not be acquired until
+   * they are required.
    */
-  abstract CredentialsProvider getCredentialsProvider();
+  public abstract CredentialsProvider getCredentialsProvider();
 
   /**
    * The address used to reach the service.
@@ -97,10 +103,10 @@ public abstract class ConnectionSettings {
   @AutoValue.Builder
   public abstract static class Builder {
 
-    /*
-     * package-private so that the AutoValue derived class can access it
+    /**
+     * Set the credentials to use in order to call the service.
      */
-    abstract Builder setCredentialsProvider(CredentialsProvider provider);
+    public abstract Builder setCredentialsProvider(CredentialsProvider provider);
 
     /**
      * Sets the credentials to use in order to call the service.

--- a/src/main/java/com/google/api/gax/core/ConnectionSettings.java
+++ b/src/main/java/com/google/api/gax/core/ConnectionSettings.java
@@ -60,7 +60,7 @@ public abstract class ConnectionSettings {
    * Gets the credentials which will be used to call the service. If the credentials have not been
    * acquired yet, then they will be acquired when this function is called.
    */
-  public Credentials getOrBuildCredentials() throws IOException {
+  public Credentials getCredentials() throws IOException {
     return getCredentialsProvider().getCredentials();
   }
 

--- a/src/main/java/com/google/api/gax/core/CredentialsProvider.java
+++ b/src/main/java/com/google/api/gax/core/CredentialsProvider.java
@@ -1,0 +1,16 @@
+package com.google.api.gax.core;
+
+import com.google.auth.Credentials;
+
+import java.io.IOException;
+
+/**
+ * Provides an interface to hold and acquire the credentials that will be used to call the service.
+ */
+public interface CredentialsProvider {
+  /**
+   * Gets the credentials which will be used to call the service. If the credentials have not been
+   * acquired yet, then they will be acquired when this function is called.
+   */
+  Credentials getCredentials() throws IOException;
+}

--- a/src/main/java/com/google/api/gax/grpc/ApiCallSettingsTyped.java
+++ b/src/main/java/com/google/api/gax/grpc/ApiCallSettingsTyped.java
@@ -7,7 +7,6 @@ import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 
-import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
@@ -39,7 +38,7 @@ abstract class ApiCallSettingsTyped<RequestT, ResponseT> extends ApiCallSettings
   }
 
   protected ApiCallable<RequestT, ResponseT> createBaseCallable(
-      ManagedChannel channel, ScheduledExecutorService executor) throws IOException {
+      ManagedChannel channel, ScheduledExecutorService executor) {
     ClientCallFactory<RequestT, ResponseT> clientCallFactory =
         new DescriptorClientCallFactory<>(methodDescriptor);
     ApiCallable<RequestT, ResponseT> callable =

--- a/src/main/java/com/google/api/gax/grpc/ApiCallSettingsTyped.java
+++ b/src/main/java/com/google/api/gax/grpc/ApiCallSettingsTyped.java
@@ -39,13 +39,11 @@ abstract class ApiCallSettingsTyped<RequestT, ResponseT> extends ApiCallSettings
   }
 
   protected ApiCallable<RequestT, ResponseT> createBaseCallable(
-      ServiceApiSettings serviceSettings) throws IOException {
+      ManagedChannel channel, ScheduledExecutorService executor) throws IOException {
     ClientCallFactory<RequestT, ResponseT> clientCallFactory =
         new DescriptorClientCallFactory<>(methodDescriptor);
     ApiCallable<RequestT, ResponseT> callable =
         new ApiCallable<>(new DirectCallable<>(clientCallFactory), this);
-    ManagedChannel channel = serviceSettings.getOrBuildChannel();
-    ScheduledExecutorService executor = serviceSettings.getOrBuildExecutor();
     if (getRetryableCodes() != null) {
       callable = callable.retryableOn(ImmutableSet.copyOf(getRetryableCodes()));
     }

--- a/src/main/java/com/google/api/gax/grpc/ApiCallSettingsTyped.java
+++ b/src/main/java/com/google/api/gax/grpc/ApiCallSettingsTyped.java
@@ -44,8 +44,8 @@ abstract class ApiCallSettingsTyped<RequestT, ResponseT> extends ApiCallSettings
         new DescriptorClientCallFactory<>(methodDescriptor);
     ApiCallable<RequestT, ResponseT> callable =
         new ApiCallable<>(new DirectCallable<>(clientCallFactory), this);
-    ManagedChannel channel = serviceSettings.getChannel();
-    ScheduledExecutorService executor = serviceSettings.getExecutor();
+    ManagedChannel channel = serviceSettings.getOrBuildChannel();
+    ScheduledExecutorService executor = serviceSettings.getOrBuildExecutor();
     if (getRetryableCodes() != null) {
       callable = callable.retryableOn(ImmutableSet.copyOf(getRetryableCodes()));
     }

--- a/src/main/java/com/google/api/gax/grpc/ApiCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/ApiCallable.java
@@ -109,7 +109,7 @@ public final class ApiCallable<RequestT, ResponseT> {
    * @param simpleCallSettings {@link com.google.api.gax.grpc.SimpleCallSettings} to configure the
    * method-level settings with.
    * @param channel {@link ManagedChannel} to use to connect to the service.
-   * @param executor {@link ScheduledExecutorService} to use to when connecting to the service.
+   * @param executor {@link ScheduledExecutorService} to use when connecting to the service.
    * @return {@link com.google.api.gax.grpc.ApiCallable} callable object.
    */
   public static <RequestT, ResponseT> ApiCallable<RequestT, ResponseT> create(

--- a/src/main/java/com/google/api/gax/grpc/ApiCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/ApiCallable.java
@@ -46,7 +46,6 @@ import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 
-import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
 
 import javax.annotation.Nullable;
@@ -104,68 +103,71 @@ public final class ApiCallable<RequestT, ResponseT> {
   private final ApiCallSettings settings;
 
   /**
-   * Create a callable object that represents a simple API method.
-   * Public only for technical reasons - for advanced usage
+   * Create a callable object that represents a simple API method. Public only for technical reasons
+   * - for advanced usage
    *
-   * @param simpleCallSettings {@link com.google.api.gax.grpc.SimpleCallSettings} to configure
-   * the method-level settings with.
-   * @param serviceSettings{@link com.google.api.gax.grpc.ServiceApiSettings}
-   * to configure the service-level settings with.
+   * @param simpleCallSettings {@link com.google.api.gax.grpc.SimpleCallSettings} to configure the
+   * method-level settings with.
+   * @param channel {@link ManagedChannel} to use to connect to the service.
+   * @param executor {@link ScheduledExecutorService} to use to when connecting to the service.
    * @return {@link com.google.api.gax.grpc.ApiCallable} callable object.
    */
   public static <RequestT, ResponseT> ApiCallable<RequestT, ResponseT> create(
       SimpleCallSettings<RequestT, ResponseT> simpleCallSettings,
-      ManagedChannel channel, ScheduledExecutorService executor) throws IOException {
+      ManagedChannel channel,
+      ScheduledExecutorService executor) {
      return simpleCallSettings.create(channel, executor);
   }
 
   /**
-   * Create a paged callable object that represents a page-streaming API method.
-   * Public only for technical reasons - for advanced usage
+   * Create a paged callable object that represents a page-streaming API method. Public only for
+   * technical reasons - for advanced usage
    *
    * @param pageStreamingCallSettings {@link com.google.api.gax.grpc.PageStreamingCallSettings} to
    * configure the page-streaming related settings with.
-   * @param serviceSettings{@link com.google.api.gax.grpc.ServiceApiSettings}
-   * to configure the service-level settings with.
+   * @param channel {@link ManagedChannel} to use to connect to the service.
+   * @param executor {@link ScheduledExecutorService} to use to when connecting to the service.
    * @return {@link com.google.api.gax.grpc.ApiCallable} callable object.
    */
   public static <RequestT, ResponseT, ResourceT>
       ApiCallable<RequestT, PageAccessor<ResourceT>> createPagedVariant(
           PageStreamingCallSettings<RequestT, ResponseT, ResourceT> pageStreamingCallSettings,
-          ManagedChannel channel, ScheduledExecutorService executor) throws IOException {
+          ManagedChannel channel,
+          ScheduledExecutorService executor) {
     return pageStreamingCallSettings.createPagedVariant(channel, executor);
   }
 
   /**
-   * Create a base callable object that represents a page-streaming API method.
-   * Public only for technical reasons - for advanced usage
+   * Create a base callable object that represents a page-streaming API method. Public only for
+   * technical reasons - for advanced usage
    *
    * @param pageStreamingCallSettings {@link com.google.api.gax.grpc.PageStreamingCallSettings} to
    * configure the page-streaming related settings with.
-   * @param serviceSettings{@link com.google.api.gax.grpc.ServiceApiSettings}
-   * to configure the service-level settings with.
+   * @param channel {@link ManagedChannel} to use to connect to the service.
+   * @param executor {@link ScheduledExecutorService} to use to when connecting to the service.
    * @return {@link com.google.api.gax.grpc.ApiCallable} callable object.
    */
-  public static <RequestT, ResponseT, ResourceT>
-      ApiCallable<RequestT, ResponseT> create(
-          PageStreamingCallSettings<RequestT, ResponseT, ResourceT> pageStreamingCallSettings,
-          ManagedChannel channel, ScheduledExecutorService executor) throws IOException {
+  public static <RequestT, ResponseT, ResourceT> ApiCallable<RequestT, ResponseT> create(
+      PageStreamingCallSettings<RequestT, ResponseT, ResourceT> pageStreamingCallSettings,
+      ManagedChannel channel,
+      ScheduledExecutorService executor) {
     return pageStreamingCallSettings.create(channel, executor);
   }
 
   /**
-   * Create a callable object that represents a bundling API method.
-   * Public only for technical reasons - for advanced usage
+   * Create a callable object that represents a bundling API method. Public only for technical
+   * reasons - for advanced usage
    *
-   * @param bundlingCallSettings {@link com.google.api.gax.grpc.BundlingSettings} to configure
-   * the bundling related settings with.
-   * @param serviceSettings{@link com.google.api.gax.grpc.ServiceApiSettings}
-   * to configure the service-level settings with.
+   * @param bundlingCallSettings {@link com.google.api.gax.grpc.BundlingSettings} to configure the
+   * bundling related settings with.
+   * @param channel {@link ManagedChannel} to use to connect to the service.
+   * @param executor {@link ScheduledExecutorService} to use to when connecting to the service.
    * @return {@link com.google.api.gax.grpc.ApiCallable} callable object.
    */
   public static <RequestT, ResponseT> ApiCallable<RequestT, ResponseT> create(
       BundlingCallSettings<RequestT, ResponseT> bundlingCallSettings,
-      ManagedChannel channel, ScheduledExecutorService executor) throws IOException {
+      ManagedChannel channel,
+      ScheduledExecutorService executor) {
     return bundlingCallSettings.create(channel, executor);
   }
 

--- a/src/main/java/com/google/api/gax/grpc/ApiCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/ApiCallable.java
@@ -42,6 +42,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import io.grpc.Channel;
+import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 
@@ -114,8 +115,8 @@ public final class ApiCallable<RequestT, ResponseT> {
    */
   public static <RequestT, ResponseT> ApiCallable<RequestT, ResponseT> create(
       SimpleCallSettings<RequestT, ResponseT> simpleCallSettings,
-      ServiceApiSettings serviceSettings) throws IOException {
-     return simpleCallSettings.create(serviceSettings);
+      ManagedChannel channel, ScheduledExecutorService executor) throws IOException {
+     return simpleCallSettings.create(channel, executor);
   }
 
   /**
@@ -131,8 +132,8 @@ public final class ApiCallable<RequestT, ResponseT> {
   public static <RequestT, ResponseT, ResourceT>
       ApiCallable<RequestT, PageAccessor<ResourceT>> createPagedVariant(
           PageStreamingCallSettings<RequestT, ResponseT, ResourceT> pageStreamingCallSettings,
-          ServiceApiSettings serviceSettings) throws IOException {
-    return pageStreamingCallSettings.createPagedVariant(serviceSettings);
+          ManagedChannel channel, ScheduledExecutorService executor) throws IOException {
+    return pageStreamingCallSettings.createPagedVariant(channel, executor);
   }
 
   /**
@@ -148,8 +149,8 @@ public final class ApiCallable<RequestT, ResponseT> {
   public static <RequestT, ResponseT, ResourceT>
       ApiCallable<RequestT, ResponseT> create(
           PageStreamingCallSettings<RequestT, ResponseT, ResourceT> pageStreamingCallSettings,
-          ServiceApiSettings serviceSettings) throws IOException {
-    return pageStreamingCallSettings.create(serviceSettings);
+          ManagedChannel channel, ScheduledExecutorService executor) throws IOException {
+    return pageStreamingCallSettings.create(channel, executor);
   }
 
   /**
@@ -164,8 +165,8 @@ public final class ApiCallable<RequestT, ResponseT> {
    */
   public static <RequestT, ResponseT> ApiCallable<RequestT, ResponseT> create(
       BundlingCallSettings<RequestT, ResponseT> bundlingCallSettings,
-      ServiceApiSettings serviceSettings) throws IOException {
-    return bundlingCallSettings.create(serviceSettings);
+      ManagedChannel channel, ScheduledExecutorService executor) throws IOException {
+    return bundlingCallSettings.create(channel, executor);
   }
 
   /**

--- a/src/main/java/com/google/api/gax/grpc/ApiException.java
+++ b/src/main/java/com/google/api/gax/grpc/ApiException.java
@@ -38,7 +38,9 @@ import io.grpc.Status;
 /**
  * Represents an exception thrown during an RPC call.
  *
- * <p>It stores information useful for functionalities in {@link ApiCallable}.
+ * <p>
+ * It stores information useful for functionalities in {@link ApiCallable}. For more information
+ * about the status codes returned by the underlying grpc exception see {@link Status}.
  */
 public class ApiException extends RuntimeException {
   private final Status.Code statusCode;
@@ -58,9 +60,9 @@ public class ApiException extends RuntimeException {
   }
 
   /**
-   * Returns the status code of the underlying grpc exception. In cases
-   * where the underlying exception is not of type StatusException or
-   * StatusRuntimeException, the status code will be Status.Code.UNKNOWN
+   * Returns the status code of the underlying grpc exception. In cases where the underlying
+   * exception is not of type StatusException or StatusRuntimeException, the status code will be
+   * Status.Code.UNKNOWN. For more information about status codes see {@link Status}.
    */
   public Status.Code getStatusCode() {
     return statusCode;

--- a/src/main/java/com/google/api/gax/grpc/BundlingCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/BundlingCallSettings.java
@@ -3,11 +3,13 @@ package com.google.api.gax.grpc;
 import com.google.api.gax.core.RetrySettings;
 import com.google.common.collect.ImmutableSet;
 
+import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 
 import java.io.IOException;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * A settings class to configure an ApiCallable for calls to an API method that supports
@@ -22,9 +24,9 @@ public final class BundlingCallSettings<RequestT, ResponseT>
   /**
    * Package-private, for use by ApiCallable.
    */
-  ApiCallable<RequestT, ResponseT> create(
-      ServiceApiSettings serviceSettings) throws IOException {
-    ApiCallable<RequestT, ResponseT> baseCallable = createBaseCallable(serviceSettings);
+  ApiCallable<RequestT, ResponseT> create(ManagedChannel channel, ScheduledExecutorService executor)
+      throws IOException {
+    ApiCallable<RequestT, ResponseT> baseCallable = createBaseCallable(channel, executor);
     bundlerFactory = new BundlerFactory<>(bundlingDescriptor, bundlingSettings);
     return baseCallable.bundling(bundlingDescriptor, bundlerFactory);
   }

--- a/src/main/java/com/google/api/gax/grpc/BundlingCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/BundlingCallSettings.java
@@ -7,7 +7,6 @@ import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 
-import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -24,8 +23,8 @@ public final class BundlingCallSettings<RequestT, ResponseT>
   /**
    * Package-private, for use by ApiCallable.
    */
-  ApiCallable<RequestT, ResponseT> create(ManagedChannel channel, ScheduledExecutorService executor)
-      throws IOException {
+  ApiCallable<RequestT, ResponseT> create(
+      ManagedChannel channel, ScheduledExecutorService executor) {
     ApiCallable<RequestT, ResponseT> baseCallable = createBaseCallable(channel, executor);
     bundlerFactory = new BundlerFactory<>(bundlingDescriptor, bundlingSettings);
     return baseCallable.bundling(bundlingDescriptor, bundlerFactory);

--- a/src/main/java/com/google/api/gax/grpc/ChannelProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/ChannelProvider.java
@@ -40,9 +40,9 @@ public interface ChannelProvider {
    * channel does not already exist, it will be created.
    *
    * If the {@link ChannelProvider} is configured to return a fixed {@link ManagedChannel} object
-   * and to return shouldAutoClose as true, then after the first call to {@link #getChannel},
+   * and to return shouldAutoClose as true, then after the first call to {@link #getOrBuildChannel},
    * subsequent calls should throw an {@link IllegalStateException}. See interface level docs for
    * {@link ChannelProvider} for more details.
    */
-  ManagedChannel getOrBuildChannel(Executor executor) throws IOException, IllegalStateException;
+  ManagedChannel getOrBuildChannel(Executor executor) throws IOException;
 }

--- a/src/main/java/com/google/api/gax/grpc/ChannelProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/ChannelProvider.java
@@ -37,7 +37,9 @@ public interface ChannelProvider {
 
   /**
    * Get the channel to be used to connect to the service. The first time this is called, if the
-   * channel does not already exist, it will be created.
+   * channel does not already exist, it will be created. The {@link Executor} will only be used when
+   * the channel is created. For implementations returning a fixed {@link ManagedChannel} object,
+   * the executor is unused.
    *
    * If the {@link ChannelProvider} is configured to return a fixed {@link ManagedChannel} object
    * and to return shouldAutoClose as true, then after the first call to {@link #getOrBuildChannel},

--- a/src/main/java/com/google/api/gax/grpc/ChannelProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/ChannelProvider.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.util.concurrent.Executor;
 
 import javax.annotation.Nullable;
-import javax.naming.OperationNotSupportedException;
 
 /**
  * Provides an interface to hold and build the channel that will be used. If the channel does not
@@ -19,9 +18,9 @@ import javax.naming.OperationNotSupportedException;
  * where the same {@link ManagedChannel} instance is returned, for example by a
  * {@link ChannelProvider} created using the {@link ServiceApiSettings}
  * provideChannelWith(ManagedChannel, boolean) method, and shouldAutoClose returns true, the
- * {@link #getChannel} method will throw an {@link OperationNotSupportedException} if it is called
- * more than once. This is to prevent the same {@link ManagedChannel} being closed prematurely when
- * it is used by multiple client objects.
+ * {@link #getChannel} method will throw an {@link IllegalStateException} if it is called more than
+ * once. This is to prevent the same {@link ManagedChannel} being closed prematurely when it is used
+ * by multiple client objects.
  */
 public interface ChannelProvider {
   /**
@@ -42,8 +41,8 @@ public interface ChannelProvider {
    *
    * If the {@link ChannelProvider} is configured to return a fixed {@link ManagedChannel} object
    * and to return shouldAutoClose as true, then after the first call to {@link #getChannel},
-   * subsequent calls should throw an {@link OperationNotSupportedException}. See interface level
-   * docs for {@link ChannelProvider} for more details.
+   * subsequent calls should throw an {@link IllegalStateException}. See interface level docs for
+   * {@link ChannelProvider} for more details.
    */
-  ManagedChannel getChannel(Executor executor) throws IOException, OperationNotSupportedException;
+  ManagedChannel getChannel(Executor executor) throws IOException, IllegalStateException;
 }

--- a/src/main/java/com/google/api/gax/grpc/ChannelProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/ChannelProvider.java
@@ -1,0 +1,49 @@
+package com.google.api.gax.grpc;
+
+import com.google.api.gax.core.ConnectionSettings;
+
+import io.grpc.ManagedChannel;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+
+import javax.annotation.Nullable;
+import javax.naming.OperationNotSupportedException;
+
+/**
+ * Provides an interface to hold and build the channel that will be used. If the channel does not
+ * already exist, it will be constructed when {@link #getChannel} is called.
+ *
+ * Implementations of {@link ChannelProvider} may choose to create a new {@link ManagedChannel} for
+ * each call to {@link #getChannel}, or may return a fixed {@link ManagedChannel} instance. In cases
+ * where the same {@link ManagedChannel} instance is returned, for example by a
+ * {@link ChannelProvider} created using the
+ * {@link ServiceApiSettings#provideChannelWith(ManagedChannel, boolean)} method, and
+ * shouldAutoClose returns true, the {@link #getChannel} method will throw an
+ * {@link OperationNotSupportedException} if it is called more than once. This is to prevent the
+ * same {@link ManagedChannel} being closed prematurely when it is used by multiple client objects.
+ */
+public interface ChannelProvider {
+  /**
+   * Connection settings used to build the channel. If a channel is provided directly this will be
+   * set to null.
+   */
+  @Nullable
+  ConnectionSettings connectionSettings();
+
+  /**
+   * Indicates whether the channel should be closed by the containing API class.
+   */
+  boolean shouldAutoClose();
+
+  /**
+   * Get the channel to be used to connect to the service. The first time this is called, if the
+   * channel does not already exist, it will be created.
+   *
+   * If the {@link ChannelProvider} is configured to return a fixed {@link ManagedChannel} object
+   * and to return shouldAutoClose as true, then after the first call to {@link #getChannel},
+   * subsequent calls should throw an {@link OperationNotSupportedException}. See interface level
+   * docs for {@link ChannelProvider} for more details.
+   */
+  ManagedChannel getChannel(Executor executor) throws IOException, OperationNotSupportedException;
+}

--- a/src/main/java/com/google/api/gax/grpc/ChannelProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/ChannelProvider.java
@@ -17,11 +17,11 @@ import javax.naming.OperationNotSupportedException;
  * Implementations of {@link ChannelProvider} may choose to create a new {@link ManagedChannel} for
  * each call to {@link #getChannel}, or may return a fixed {@link ManagedChannel} instance. In cases
  * where the same {@link ManagedChannel} instance is returned, for example by a
- * {@link ChannelProvider} created using the
- * {@link ServiceApiSettings#provideChannelWith(ManagedChannel, boolean)} method, and
- * shouldAutoClose returns true, the {@link #getChannel} method will throw an
- * {@link OperationNotSupportedException} if it is called more than once. This is to prevent the
- * same {@link ManagedChannel} being closed prematurely when it is used by multiple client objects.
+ * {@link ChannelProvider} created using the {@link ServiceApiSettings}
+ * provideChannelWith(ManagedChannel, boolean) method, and shouldAutoClose returns true, the
+ * {@link #getChannel} method will throw an {@link OperationNotSupportedException} if it is called
+ * more than once. This is to prevent the same {@link ManagedChannel} being closed prematurely when
+ * it is used by multiple client objects.
  */
 public interface ChannelProvider {
   /**

--- a/src/main/java/com/google/api/gax/grpc/ChannelProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/ChannelProvider.java
@@ -11,16 +11,16 @@ import javax.annotation.Nullable;
 
 /**
  * Provides an interface to hold and build the channel that will be used. If the channel does not
- * already exist, it will be constructed when {@link #getChannel} is called.
+ * already exist, it will be constructed when {@link #getOrBuildChannel} is called.
  *
  * Implementations of {@link ChannelProvider} may choose to create a new {@link ManagedChannel} for
- * each call to {@link #getChannel}, or may return a fixed {@link ManagedChannel} instance. In cases
- * where the same {@link ManagedChannel} instance is returned, for example by a
+ * each call to {@link #getOrBuildChannel}, or may return a fixed {@link ManagedChannel} instance.
+ * In cases where the same {@link ManagedChannel} instance is returned, for example by a
  * {@link ChannelProvider} created using the {@link ServiceApiSettings}
  * provideChannelWith(ManagedChannel, boolean) method, and shouldAutoClose returns true, the
- * {@link #getChannel} method will throw an {@link IllegalStateException} if it is called more than
- * once. This is to prevent the same {@link ManagedChannel} being closed prematurely when it is used
- * by multiple client objects.
+ * {@link #getOrBuildChannel} method will throw an {@link IllegalStateException} if it is called
+ * more than once. This is to prevent the same {@link ManagedChannel} being closed prematurely when
+ * it is used by multiple client objects.
  */
 public interface ChannelProvider {
   /**
@@ -44,5 +44,5 @@ public interface ChannelProvider {
    * subsequent calls should throw an {@link IllegalStateException}. See interface level docs for
    * {@link ChannelProvider} for more details.
    */
-  ManagedChannel getChannel(Executor executor) throws IOException, IllegalStateException;
+  ManagedChannel getOrBuildChannel(Executor executor) throws IOException, IllegalStateException;
 }

--- a/src/main/java/com/google/api/gax/grpc/ExecutorProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/ExecutorProvider.java
@@ -32,5 +32,5 @@ public interface ExecutorProvider {
    * {@link IllegalStateException}. See interface level docs for {@link ExecutorProvider} for more
    * details.
    */
-  ScheduledExecutorService getOrBuildExecutor() throws IllegalStateException;
+  ScheduledExecutorService getOrBuildExecutor();
 }

--- a/src/main/java/com/google/api/gax/grpc/ExecutorProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/ExecutorProvider.java
@@ -11,12 +11,11 @@ import javax.naming.OperationNotSupportedException;
  * Implementations of ExecutorProvider may choose to create a new {@link ScheduledExecutorService}
  * for each call to {@link #getExecutor}, or may return a fixed {@link ScheduledExecutorService}
  * instance. In cases where the same {@link ScheduledExecutorService} instance is returned, for
- * example by an {@link ExecutorProvider} created using the
- * {@link ServiceApiSettings#provideExecutorWith(ScheduledExecutorService, boolean)} method, and
- * shouldAutoClose returns true, the {@link #getExecutor} method will throw an
- * {@link OperationNotSupportedException} if it is called more than once. This is to prevent the
- * same {@link ScheduledExecutorService} being closed prematurely when it is used by multiple client
- * objects.
+ * example by an {@link ExecutorProvider} created using the {@link ServiceApiSettings}
+ * provideExecutorWith(ScheduledExecutorService, boolean) method, and shouldAutoClose returns true,
+ * the {@link #getExecutor} method will throw an {@link OperationNotSupportedException} if it is
+ * called more than once. This is to prevent the same {@link ScheduledExecutorService} being closed
+ * prematurely when it is used by multiple client objects.
  */
 public interface ExecutorProvider {
   /**

--- a/src/main/java/com/google/api/gax/grpc/ExecutorProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/ExecutorProvider.java
@@ -1,0 +1,37 @@
+package com.google.api.gax.grpc;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import javax.naming.OperationNotSupportedException;
+
+/**
+ * Provides an interface to hold and create the Executor to be used. If the executor does not
+ * already exist, it will be constructed when {@link #getExecutor} is called.
+ *
+ * Implementations of ExecutorProvider may choose to create a new {@link ScheduledExecutorService}
+ * for each call to {@link #getExecutor}, or may return a fixed {@link ScheduledExecutorService}
+ * instance. In cases where the same {@link ScheduledExecutorService} instance is returned, for
+ * example by an {@link ExecutorProvider} created using the
+ * {@link ServiceApiSettings#provideExecutorWith(ScheduledExecutorService, boolean)} method, and
+ * shouldAutoClose returns true, the {@link #getExecutor} method will throw an
+ * {@link OperationNotSupportedException} if it is called more than once. This is to prevent the
+ * same {@link ScheduledExecutorService} being closed prematurely when it is used by multiple client
+ * objects.
+ */
+public interface ExecutorProvider {
+  /**
+   * Indicates whether the channel should be closed by the containing API class.
+   */
+  boolean shouldAutoClose();
+
+  /**
+   * Get the executor to be used to connect to the service. The first time this is called, if the
+   * executor does not already exist, it will be created.
+   *
+   * If the {@link ExecutorProvider} is configured to return a fixed
+   * {@link ScheduledExecutorService} object and to return shouldAutoClose as true, then after the
+   * first call to {@link #getExecutor}, subsequent calls should throw an {@link ExecutorProvider}.
+   * See interface level docs for {@link ExecutorProvider} for more details.
+   */
+  ScheduledExecutorService getExecutor() throws OperationNotSupportedException;
+}

--- a/src/main/java/com/google/api/gax/grpc/ExecutorProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/ExecutorProvider.java
@@ -2,8 +2,6 @@ package com.google.api.gax.grpc;
 
 import java.util.concurrent.ScheduledExecutorService;
 
-import javax.naming.OperationNotSupportedException;
-
 /**
  * Provides an interface to hold and create the Executor to be used. If the executor does not
  * already exist, it will be constructed when {@link #getExecutor} is called.
@@ -13,9 +11,9 @@ import javax.naming.OperationNotSupportedException;
  * instance. In cases where the same {@link ScheduledExecutorService} instance is returned, for
  * example by an {@link ExecutorProvider} created using the {@link ServiceApiSettings}
  * provideExecutorWith(ScheduledExecutorService, boolean) method, and shouldAutoClose returns true,
- * the {@link #getExecutor} method will throw an {@link OperationNotSupportedException} if it is
- * called more than once. This is to prevent the same {@link ScheduledExecutorService} being closed
- * prematurely when it is used by multiple client objects.
+ * the {@link #getExecutor} method will throw an {@link IllegalStateException} if it is called more
+ * than once. This is to prevent the same {@link ScheduledExecutorService} being closed prematurely
+ * when it is used by multiple client objects.
  */
 public interface ExecutorProvider {
   /**
@@ -29,8 +27,9 @@ public interface ExecutorProvider {
    *
    * If the {@link ExecutorProvider} is configured to return a fixed
    * {@link ScheduledExecutorService} object and to return shouldAutoClose as true, then after the
-   * first call to {@link #getExecutor}, subsequent calls should throw an {@link ExecutorProvider}.
-   * See interface level docs for {@link ExecutorProvider} for more details.
+   * first call to {@link #getExecutor}, subsequent calls should throw an
+   * {@link IllegalStateException}. See interface level docs for {@link ExecutorProvider} for more
+   * details.
    */
-  ScheduledExecutorService getExecutor() throws OperationNotSupportedException;
+  ScheduledExecutorService getExecutor() throws IllegalStateException;
 }

--- a/src/main/java/com/google/api/gax/grpc/ExecutorProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/ExecutorProvider.java
@@ -4,16 +4,17 @@ import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Provides an interface to hold and create the Executor to be used. If the executor does not
- * already exist, it will be constructed when {@link #getExecutor} is called.
+ * already exist, it will be constructed when {@link #getOrBuildExecutor} is called.
  *
  * Implementations of ExecutorProvider may choose to create a new {@link ScheduledExecutorService}
- * for each call to {@link #getExecutor}, or may return a fixed {@link ScheduledExecutorService}
- * instance. In cases where the same {@link ScheduledExecutorService} instance is returned, for
- * example by an {@link ExecutorProvider} created using the {@link ServiceApiSettings}
- * provideExecutorWith(ScheduledExecutorService, boolean) method, and shouldAutoClose returns true,
- * the {@link #getExecutor} method will throw an {@link IllegalStateException} if it is called more
- * than once. This is to prevent the same {@link ScheduledExecutorService} being closed prematurely
- * when it is used by multiple client objects.
+ * for each call to {@link #getOrBuildExecutor}, or may return a fixed
+ * {@link ScheduledExecutorService} instance. In cases where the same
+ * {@link ScheduledExecutorService} instance is returned, for example by an {@link ExecutorProvider}
+ * created using the {@link ServiceApiSettings} provideExecutorWith(ScheduledExecutorService,
+ * boolean) method, and shouldAutoClose returns true, the {@link #getOrBuildExecutor} method will
+ * throw an {@link IllegalStateException} if it is called more than once. This is to prevent the
+ * same {@link ScheduledExecutorService} being closed prematurely when it is used by multiple client
+ * objects.
  */
 public interface ExecutorProvider {
   /**
@@ -27,9 +28,9 @@ public interface ExecutorProvider {
    *
    * If the {@link ExecutorProvider} is configured to return a fixed
    * {@link ScheduledExecutorService} object and to return shouldAutoClose as true, then after the
-   * first call to {@link #getExecutor}, subsequent calls should throw an
+   * first call to {@link #getOrBuildExecutor}, subsequent calls should throw an
    * {@link IllegalStateException}. See interface level docs for {@link ExecutorProvider} for more
    * details.
    */
-  ScheduledExecutorService getExecutor() throws IllegalStateException;
+  ScheduledExecutorService getOrBuildExecutor() throws IllegalStateException;
 }

--- a/src/main/java/com/google/api/gax/grpc/PageStreamingCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/PageStreamingCallSettings.java
@@ -8,7 +8,6 @@ import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 
-import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -24,8 +23,8 @@ public final class PageStreamingCallSettings<RequestT, ResponseT, ResourceT>
   /**
    * Package-private, for use by ApiCallable.
    */
-  ApiCallable<RequestT, ResponseT> create(ManagedChannel channel, ScheduledExecutorService executor)
-      throws IOException {
+  ApiCallable<RequestT, ResponseT> create(
+      ManagedChannel channel, ScheduledExecutorService executor) {
     return createBaseCallable(channel, executor);
   }
 
@@ -33,7 +32,7 @@ public final class PageStreamingCallSettings<RequestT, ResponseT, ResourceT>
    * Package-private, for use by ApiCallable.
    */
   ApiCallable<RequestT, PageAccessor<ResourceT>> createPagedVariant(
-      ManagedChannel channel, ScheduledExecutorService executor) throws IOException {
+      ManagedChannel channel, ScheduledExecutorService executor) {
     ApiCallable<RequestT, ResponseT> baseCallable = createBaseCallable(channel, executor);
     return baseCallable.pageStreaming(pageDescriptor);
   }

--- a/src/main/java/com/google/api/gax/grpc/PageStreamingCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/PageStreamingCallSettings.java
@@ -4,11 +4,13 @@ import com.google.api.gax.core.PageAccessor;
 import com.google.api.gax.core.RetrySettings;
 import com.google.common.collect.ImmutableSet;
 
+import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 
 import java.io.IOException;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 
 
 /**
@@ -22,17 +24,17 @@ public final class PageStreamingCallSettings<RequestT, ResponseT, ResourceT>
   /**
    * Package-private, for use by ApiCallable.
    */
-  ApiCallable<RequestT, ResponseT> create(
-      ServiceApiSettings serviceSettings) throws IOException {
-    return createBaseCallable(serviceSettings);
+  ApiCallable<RequestT, ResponseT> create(ManagedChannel channel, ScheduledExecutorService executor)
+      throws IOException {
+    return createBaseCallable(channel, executor);
   }
 
   /**
    * Package-private, for use by ApiCallable.
    */
   ApiCallable<RequestT, PageAccessor<ResourceT>> createPagedVariant(
-      ServiceApiSettings serviceSettings) throws IOException {
-    ApiCallable<RequestT, ResponseT> baseCallable = createBaseCallable(serviceSettings);
+      ManagedChannel channel, ScheduledExecutorService executor) throws IOException {
+    ApiCallable<RequestT, ResponseT> baseCallable = createBaseCallable(channel, executor);
     return baseCallable.pageStreaming(pageDescriptor);
   }
 

--- a/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
@@ -136,7 +136,7 @@ public abstract class ServiceApiSettings {
       executorProvider =
           new ExecutorProvider() {
             @Override
-            public ScheduledExecutorService getExecutor() {
+            public ScheduledExecutorService getOrBuildExecutor() {
               return MoreExecutors.getExitingScheduledExecutorService(
                   new ScheduledThreadPoolExecutor(DEFAULT_EXECUTOR_THREADS));
             }
@@ -162,7 +162,7 @@ public abstract class ServiceApiSettings {
             private volatile boolean executorProvided = false;
 
             @Override
-            public ScheduledExecutorService getExecutor() throws IllegalStateException {
+            public ScheduledExecutorService getOrBuildExecutor() throws IllegalStateException {
               if (executorProvided) {
                 if (shouldAutoClose) {
                   throw new IllegalStateException(
@@ -275,9 +275,9 @@ public abstract class ServiceApiSettings {
     private ChannelProvider createChannelProvider(final ConnectionSettings settings) {
       return new ChannelProvider() {
         @Override
-        public ManagedChannel getChannel(Executor executor) throws IOException {
+        public ManagedChannel getOrBuildChannel(Executor executor) throws IOException {
           List<ClientInterceptor> interceptors = Lists.newArrayList();
-          interceptors.add(new ClientAuthInterceptor(settings.getOrBuildCredentials(), executor));
+          interceptors.add(new ClientAuthInterceptor(settings.getCredentials(), executor));
           interceptors.add(new HeaderInterceptor(serviceHeader()));
 
           return NettyChannelBuilder.forAddress(settings.getServiceAddress(), settings.getPort())
@@ -322,7 +322,7 @@ public abstract class ServiceApiSettings {
         private boolean channelProvided = false;
 
         @Override
-        public ManagedChannel getChannel(Executor executor) throws IllegalStateException {
+        public ManagedChannel getOrBuildChannel(Executor executor) throws IllegalStateException {
           if (channelProvided) {
             if (shouldAutoClose) {
               throw new IllegalStateException(

--- a/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
@@ -329,10 +329,12 @@ public abstract class ServiceApiSettings {
           interceptors.add(new ClientAuthInterceptor(settings.getOrBuildCredentials(), executor));
           interceptors.add(new HeaderInterceptor(serviceHeader()));
 
-          channel = NettyChannelBuilder.forAddress(settings.getServiceAddress(), settings.getPort())
-              .negotiationType(NegotiationType.TLS)
-              .intercept(interceptors)
-              .build();
+          channel =
+              NettyChannelBuilder.forAddress(settings.getServiceAddress(), settings.getPort())
+                  .negotiationType(NegotiationType.TLS)
+                  .intercept(interceptors)
+                  .executor(executor)
+                  .build();
           return channel;
         }
 

--- a/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
@@ -76,27 +76,11 @@ public abstract class ServiceApiSettings {
   }
 
   /**
-   * Return the channel to be used to connect to the service, retrieved using the channelProvider.
-   * If no channel was set, a default channel will be instantiated.
-   */
-  public final ManagedChannel getOrBuildChannel() throws IOException, IllegalStateException {
-    return getChannelProvider().getChannel(getOrBuildExecutor());
-  }
-
-  /**
    * Return the channel provider. If no channel provider was set, the default channel provider will
    * be returned.
    */
   public final ChannelProvider getChannelProvider() {
     return channelProvider;
-  }
-
-  /**
-   * The Executor used for channels, retries, and bundling, retrieved using the executorProvider. If
-   * no executor was set, a default executor will be instantiated.
-   */
-  public final ScheduledExecutorService getOrBuildExecutor() throws IllegalStateException {
-    return getExecutorProvider().getExecutor();
   }
 
   /**
@@ -136,6 +120,7 @@ public abstract class ServiceApiSettings {
     protected Builder(ServiceApiSettings settings) {
       this();
       this.channelProvider = settings.channelProvider;
+      this.executorProvider = settings.executorProvider;
       this.clientLibName = settings.clientLibName;
       this.clientLibVersion = settings.clientLibVersion;
       this.serviceGeneratorName = settings.generatorName;

--- a/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
@@ -162,7 +162,7 @@ public abstract class ServiceApiSettings {
             private volatile boolean executorProvided = false;
 
             @Override
-            public ScheduledExecutorService getOrBuildExecutor() throws IllegalStateException {
+            public ScheduledExecutorService getOrBuildExecutor() {
               if (executorProvided) {
                 if (shouldAutoClose) {
                   throw new IllegalStateException(
@@ -322,7 +322,7 @@ public abstract class ServiceApiSettings {
         private boolean channelProvided = false;
 
         @Override
-        public ManagedChannel getOrBuildChannel(Executor executor) throws IllegalStateException {
+        public ManagedChannel getOrBuildChannel(Executor executor) {
           if (channelProvided) {
             if (shouldAutoClose) {
               throw new IllegalStateException(

--- a/src/main/java/com/google/api/gax/grpc/SimpleCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/SimpleCallSettings.java
@@ -7,7 +7,6 @@ import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 
-import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -21,8 +20,8 @@ public final class SimpleCallSettings<RequestT, ResponseT>
   /**
    * Package-private, for use by ApiCallable.
    */
-  ApiCallable<RequestT, ResponseT> create(ManagedChannel channel, ScheduledExecutorService executor)
-      throws IOException {
+  ApiCallable<RequestT, ResponseT> create(
+      ManagedChannel channel, ScheduledExecutorService executor) {
     return createBaseCallable(channel, executor);
   }
 

--- a/src/main/java/com/google/api/gax/grpc/SimpleCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/SimpleCallSettings.java
@@ -3,11 +3,13 @@ package com.google.api.gax.grpc;
 import com.google.api.gax.core.RetrySettings;
 import com.google.common.collect.ImmutableSet;
 
+import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 
 import java.io.IOException;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * A settings class to configure an ApiCallable for calls to a simple API method (i.e. that
@@ -19,9 +21,9 @@ public final class SimpleCallSettings<RequestT, ResponseT>
   /**
    * Package-private, for use by ApiCallable.
    */
-  ApiCallable<RequestT, ResponseT> create(
-      ServiceApiSettings serviceSettings) throws IOException {
-    return createBaseCallable(serviceSettings);
+  ApiCallable<RequestT, ResponseT> create(ManagedChannel channel, ScheduledExecutorService executor)
+      throws IOException {
+    return createBaseCallable(channel, executor);
   }
 
   private SimpleCallSettings(ImmutableSet<Status.Code> retryableCodes,

--- a/src/test/java/com/google/api/gax/grpc/ServiceApiSettingsTest.java
+++ b/src/test/java/com/google/api/gax/grpc/ServiceApiSettingsTest.java
@@ -95,9 +95,9 @@ public class ServiceApiSettingsTest {
             .provideChannelWith(channel, true)
             .build();
     ChannelProvider channelProvider = settings.getChannelProvider();
-    ScheduledExecutorService executor = settings.getExecutorProvider().getExecutor();
-    ManagedChannel channelA = channelProvider.getChannel(executor);
-    ManagedChannel channelB = channelProvider.getChannel(executor);
+    ScheduledExecutorService executor = settings.getExecutorProvider().getOrBuildExecutor();
+    ManagedChannel channelA = channelProvider.getOrBuildChannel(executor);
+    ManagedChannel channelB = channelProvider.getOrBuildChannel(executor);
   }
 
   @Test
@@ -108,9 +108,9 @@ public class ServiceApiSettingsTest {
             .provideChannelWith(channel, false)
             .build();
     ChannelProvider channelProvider = settings.getChannelProvider();
-    ScheduledExecutorService executor = settings.getExecutorProvider().getExecutor();
-    ManagedChannel channelA = channelProvider.getChannel(executor);
-    ManagedChannel channelB = channelProvider.getChannel(executor);
+    ScheduledExecutorService executor = settings.getExecutorProvider().getOrBuildExecutor();
+    ManagedChannel channelA = channelProvider.getOrBuildChannel(executor);
+    ManagedChannel channelB = channelProvider.getOrBuildChannel(executor);
     Truth.assertThat(channelA).isEqualTo(channelB);
   }
 
@@ -119,8 +119,8 @@ public class ServiceApiSettingsTest {
     FakeSettings settings =
         FakeSettings.createBuilder(FakeSettings.DEFAULT_CONNECTION_SETTINGS).build();
     ExecutorProvider executorProvider = settings.getExecutorProvider();
-    ScheduledExecutorService executorA = executorProvider.getExecutor();
-    ScheduledExecutorService executorB = executorProvider.getExecutor();
+    ScheduledExecutorService executorA = executorProvider.getOrBuildExecutor();
+    ScheduledExecutorService executorB = executorProvider.getOrBuildExecutor();
     Truth.assertThat(executorA).isNotEqualTo(executorB);
   }
 
@@ -133,8 +133,8 @@ public class ServiceApiSettingsTest {
             .provideExecutorWith(executor, true)
             .build();
     ExecutorProvider executorProvider = settings.getExecutorProvider();
-    ScheduledExecutorService executorA = executorProvider.getExecutor();
-    ScheduledExecutorService executorB = executorProvider.getExecutor();
+    ScheduledExecutorService executorA = executorProvider.getOrBuildExecutor();
+    ScheduledExecutorService executorB = executorProvider.getOrBuildExecutor();
   }
 
   @Test
@@ -145,8 +145,8 @@ public class ServiceApiSettingsTest {
             .provideExecutorWith(executor, false)
             .build();
     ExecutorProvider executorProvider = settings.getExecutorProvider();
-    ScheduledExecutorService executorA = executorProvider.getExecutor();
-    ScheduledExecutorService executorB = executorProvider.getExecutor();
+    ScheduledExecutorService executorA = executorProvider.getOrBuildExecutor();
+    ScheduledExecutorService executorB = executorProvider.getOrBuildExecutor();
     Truth.assertThat(executorA).isEqualTo(executorB);
   }
 }

--- a/src/test/java/com/google/api/gax/grpc/ServiceApiSettingsTest.java
+++ b/src/test/java/com/google/api/gax/grpc/ServiceApiSettingsTest.java
@@ -1,0 +1,153 @@
+package com.google.api.gax.grpc;
+
+import com.google.api.gax.core.ConnectionSettings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.truth.Truth;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+import io.grpc.ManagedChannel;
+
+import java.io.IOException;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Tests for {@link ServiceApiSettings}.
+ */
+@RunWith(JUnit4.class)
+public class ServiceApiSettingsTest {
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static class FakeSettings extends ServiceApiSettings {
+
+    public static final String DEFAULT_SERVICE_ADDRESS = "pubsub-experimental.googleapis.com";
+    public static final int DEFAULT_SERVICE_PORT = 443;
+    public static final ImmutableList<String> DEFAULT_SERVICE_SCOPES =
+        ImmutableList.<String>builder()
+            .add("https://www.googleapis.com/auth/pubsub")
+            .add("https://www.googleapis.com/auth/cloud-platform")
+            .build();
+    public static final ConnectionSettings DEFAULT_CONNECTION_SETTINGS =
+        ConnectionSettings.newBuilder()
+            .setServiceAddress(DEFAULT_SERVICE_ADDRESS)
+            .setPort(DEFAULT_SERVICE_PORT)
+            .provideCredentialsWith(DEFAULT_SERVICE_SCOPES)
+            .build();
+
+    public static Builder createBuilder(ConnectionSettings connectionSettings) {
+      return new Builder(connectionSettings);
+    }
+
+    private FakeSettings(Builder settingsBuilder) throws IOException {
+      super(
+          settingsBuilder.getChannelProvider(),
+          settingsBuilder.getExecutorProvider(),
+          settingsBuilder.getGeneratorName(),
+          settingsBuilder.getGeneratorVersion(),
+          settingsBuilder.getClientLibName(),
+          settingsBuilder.getClientLibVersion());
+    }
+
+    private static class Builder extends ServiceApiSettings.Builder {
+
+      private Builder(ConnectionSettings connectionSettings) {
+        super(connectionSettings);
+      }
+
+      @Override
+      public FakeSettings build() throws IOException {
+        return new FakeSettings(this);
+      }
+
+      @Override
+      public Builder provideExecutorWith(
+          final ScheduledExecutorService executor, boolean shouldAutoClose) {
+        super.provideExecutorWith(executor, shouldAutoClose);
+        return this;
+      }
+
+      @Override
+      public Builder provideChannelWith(ManagedChannel channel, boolean shouldAutoClose) {
+        super.provideChannelWith(channel, shouldAutoClose);
+        return this;
+      }
+
+      @Override
+      public Builder provideChannelWith(ConnectionSettings settings) {
+        super.provideChannelWith(settings);
+        return this;
+      }
+    }
+  }
+
+  @Test
+  public void fixedChannelAutoClose() throws IOException {
+    thrown.expect(IllegalStateException.class);
+    ManagedChannel channel = Mockito.mock(ManagedChannel.class);
+    FakeSettings settings =
+        FakeSettings.createBuilder(FakeSettings.DEFAULT_CONNECTION_SETTINGS)
+            .provideChannelWith(channel, true)
+            .build();
+    ChannelProvider channelProvider = settings.getChannelProvider();
+    ScheduledExecutorService executor = settings.getExecutorProvider().getExecutor();
+    ManagedChannel channelA = channelProvider.getChannel(executor);
+    ManagedChannel channelB = channelProvider.getChannel(executor);
+  }
+
+  @Test
+  public void fixedChannelNoAutoClose() throws IOException {
+    ManagedChannel channel = Mockito.mock(ManagedChannel.class);
+    FakeSettings settings =
+        FakeSettings.createBuilder(FakeSettings.DEFAULT_CONNECTION_SETTINGS)
+            .provideChannelWith(channel, false)
+            .build();
+    ChannelProvider channelProvider = settings.getChannelProvider();
+    ScheduledExecutorService executor = settings.getExecutorProvider().getExecutor();
+    ManagedChannel channelA = channelProvider.getChannel(executor);
+    ManagedChannel channelB = channelProvider.getChannel(executor);
+    Truth.assertThat(channelA).isEqualTo(channelB);
+  }
+
+  @Test
+  public void defaultExecutor() throws IOException {
+    FakeSettings settings =
+        FakeSettings.createBuilder(FakeSettings.DEFAULT_CONNECTION_SETTINGS).build();
+    ExecutorProvider executorProvider = settings.getExecutorProvider();
+    ScheduledExecutorService executorA = executorProvider.getExecutor();
+    ScheduledExecutorService executorB = executorProvider.getExecutor();
+    Truth.assertThat(executorA).isNotEqualTo(executorB);
+  }
+
+  @Test
+  public void fixedExecutorAutoClose() throws IOException {
+    thrown.expect(IllegalStateException.class);
+    ScheduledExecutorService executor = Mockito.mock(ScheduledExecutorService.class);
+    FakeSettings settings =
+        FakeSettings.createBuilder(FakeSettings.DEFAULT_CONNECTION_SETTINGS)
+            .provideExecutorWith(executor, true)
+            .build();
+    ExecutorProvider executorProvider = settings.getExecutorProvider();
+    ScheduledExecutorService executorA = executorProvider.getExecutor();
+    ScheduledExecutorService executorB = executorProvider.getExecutor();
+  }
+
+  @Test
+  public void fixedExecutorNoAutoClose() throws IOException {
+    ScheduledExecutorService executor = Mockito.mock(ScheduledExecutorService.class);
+    FakeSettings settings =
+        FakeSettings.createBuilder(FakeSettings.DEFAULT_CONNECTION_SETTINGS)
+            .provideExecutorWith(executor, false)
+            .build();
+    ExecutorProvider executorProvider = settings.getExecutorProvider();
+    ScheduledExecutorService executorA = executorProvider.getExecutor();
+    ScheduledExecutorService executorB = executorProvider.getExecutor();
+    Truth.assertThat(executorA).isEqualTo(executorB);
+  }
+}
+


### PR DESCRIPTION
Make ChannelProvider, ExecutorProvider and CredentialsProvider
interfaces public. This allows the ApiSettings object to be
constructed without instantiating the channel, executor or
credentials until they are required by the Api object.