### PR TITLE
Do not sleep before retry on deadline exceeded

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
 
   // Shortcuts for libraries we are using
   libraries = [
-      grpc: 'io.grpc:grpc-all:0.9.0',
+      grpc: 'io.grpc:grpc-all:0.14.0',
       guava: 'com.google.guava:guava:18.0',
       jsr305: 'com.google.code.findbugs:jsr305:3.0.0',
       autovalue: 'com.google.auto.value:auto-value:1.1',

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
 
   // Shortcuts for libraries we are using
   libraries = [
-      grpc: 'io.grpc:grpc-all:0.14.0',
+      grpc: 'io.grpc:grpc-all:0.9.0',
       guava: 'com.google.guava:guava:18.0',
       jsr305: 'com.google.code.findbugs:jsr305:3.0.0',
       autovalue: 'com.google.auto.value:auto-value:1.1',

--- a/src/main/java/com/google/api/gax/grpc/BundlingSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/BundlingSettings.java
@@ -31,10 +31,7 @@
 
 package com.google.api.gax.grpc;
 
-import com.google.api.gax.bundling.BundlingThreshold;
-import com.google.api.gax.bundling.ExternalThreshold;
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nullable;
 
@@ -203,5 +200,4 @@ public abstract class BundlingSettings {
       return autoBuild();
     }
   }
-
 }

--- a/src/main/java/com/google/api/gax/grpc/RetryingCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/RetryingCallable.java
@@ -52,15 +52,19 @@ import java.util.concurrent.TimeUnit;
  * The behavior is controlled by the given {@link RetrySettings}.
  */
 class RetryingCallable<RequestT, ResponseT> implements FutureCallable<RequestT, ResponseT> {
+
+  // Duration to sleep on if the error is DEADLINE_EXCEEDED.
+  static final Duration DEADLINE_SLEEP_DURATION = Duration.millis(1);
+
   private final FutureCallable<RequestT, ResponseT> callable;
   private final RetrySettings retryParams;
-  private final ScheduledExecutorService executor;
+  private final ApiCallable.Scheduler executor;
   private final NanoClock clock;
 
   RetryingCallable(
       FutureCallable<RequestT, ResponseT> callable,
       RetrySettings retrySettings,
-      ScheduledExecutorService executor,
+      ApiCallable.Scheduler executor,
       NanoClock clock) {
     this.callable = Preconditions.checkNotNull(callable);
     this.retryParams = Preconditions.checkNotNull(retrySettings);
@@ -139,6 +143,13 @@ class RetryingCallable<RequestT, ResponseT> implements FutureCallable<RequestT, 
                 result.setException(throwable);
                 return;
               }
+              if (isDeadlineExceeded(throwable)) {
+                Retryer retryer = new Retryer(context, result,
+                    retryDelay, rpcTimeout, throwable);
+                executor.schedule(retryer, DEADLINE_SLEEP_DURATION.getMillis(), TimeUnit.MILLISECONDS);
+                return;
+              }
+
               long newRetryDelay =
                   (long) (retryDelay.getMillis() *
                       retryParams.getRetryDelayMultiplier());
@@ -168,10 +179,10 @@ class RetryingCallable<RequestT, ResponseT> implements FutureCallable<RequestT, 
     CallOptions newOpt = oldOpt.withDeadlineAfter(rpcTimeout.getMillis(), TimeUnit.MILLISECONDS);
     CallContext<T> newCtx = oldCtx.withCallOptions(newOpt);
 
-    if (oldOpt.getDeadlineNanoTime() == null) {
+    if (oldOpt.getDeadline() == null) {
       return newCtx;
     }
-    if (oldOpt.getDeadlineNanoTime() < newOpt.getDeadlineNanoTime()) {
+    if (oldOpt.getDeadline().isBefore(newOpt.getDeadline())) {
       return oldCtx;
     }
     return newCtx;
@@ -183,5 +194,13 @@ class RetryingCallable<RequestT, ResponseT> implements FutureCallable<RequestT, 
     }
     ApiException apiException = (ApiException) throwable;
     return apiException.isRetryable();
+  }
+
+  private static boolean isDeadlineExceeded(Throwable throwable) {
+    if (!(throwable instanceof ApiException)) {
+      return false;
+    }
+    ApiException apiException = (ApiException) throwable;
+    return apiException.getStatusCode() == Status.Code.DEADLINE_EXCEEDED;
   }
 }

--- a/src/main/java/com/google/api/gax/grpc/RetryingCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/RetryingCallable.java
@@ -179,10 +179,10 @@ class RetryingCallable<RequestT, ResponseT> implements FutureCallable<RequestT, 
     CallOptions newOpt = oldOpt.withDeadlineAfter(rpcTimeout.getMillis(), TimeUnit.MILLISECONDS);
     CallContext<T> newCtx = oldCtx.withCallOptions(newOpt);
 
-    if (oldOpt.getDeadline() == null) {
+    if (oldOpt.getDeadlineNanoTime() == null) {
       return newCtx;
     }
-    if (oldOpt.getDeadline().isBefore(newOpt.getDeadline())) {
+    if (oldOpt.getDeadlineNanoTime() < newOpt.getDeadlineNanoTime()) {
       return oldCtx;
     }
     return newCtx;


### PR DESCRIPTION
Previously, RetryingCallable exponentially backs off if it gets
an error.
If the error is DEADLINE_EXCEEDED, it should continue immediately,
since we have already been waiting for long enough.

This commit makes RetryingCallable wait for 1ms after getting
DEADLINE_EXCEEDED error. The 1ms wait time is introduced so that
it plays nice with our fake clock used for testing.