### PR TITLE
Docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Google API Extensions for Java
 [![Code Coverage](https://img.shields.io/codecov/c/github/googleapis/gax-java.svg)]
 (https://codecov.io/github/googleapis/gax-java)
 
+- [Documentation] (http://googleapis.github.io/gax-java/javadoc)
 
 Google API Extensions for Java (GAX-Java) is a set of libraries which aids the development of APIs,
 client and server, based on [GRPC](http://grpc.io) and Google API conventions.

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ task javadocJar(type: Jar) {
 
 javadoc.options {
   encoding = 'UTF-8'
-  links 'https://docs.oracle.com/javase/8/docs/api/'
+  links 'https://docs.oracle.com/javase/7/docs/api/'
 }
 
 // Test Logging


### PR DESCRIPTION
* Making oracle docs link consistent with Java version dependency.
* Adding a link to the documentation on github.io