### PR TITLE
Upgrading grpc dependency to 0.15.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,12 +20,13 @@ ext {
 
   // Shortcuts for libraries we are using
   libraries = [
-      grpc: 'io.grpc:grpc-all:0.9.0',
+      grpc: 'io.grpc:grpc-all:0.15.0',
       guava: 'com.google.guava:guava:18.0',
       jsr305: 'com.google.code.findbugs:jsr305:3.0.0',
       autovalue: 'com.google.auto.value:auto-value:1.1',
       guice: 'com.google.inject:guice:4.0',
       joda: 'joda-time:joda-time:2.8.2',
+      auth: 'com.google.auth:google-auth-library-oauth2-http:0.4.0',
 
       // Testing
       junit: 'junit:junit:4.11',
@@ -46,7 +47,8 @@ dependencies {
     libraries.guice,
     libraries.jsr305,
     libraries.autovalue,
-    libraries.joda
+    libraries.joda,
+    libraries.auth
 
   testCompile libraries.junit,
     libraries.mockito,
@@ -117,6 +119,7 @@ ext {
 
 configurations {
   codeGeneration
+  compile.exclude group: 'com.google.guava', module: 'guava-jdk5' 
 }
 
 dependencies {

--- a/src/main/java/com/google/api/gax/bundling/ThresholdBundler.java
+++ b/src/main/java/com/google/api/gax/bundling/ThresholdBundler.java
@@ -31,7 +31,7 @@
 
 package com.google.api.gax.bundling;
 
-import com.google.api.client.util.Lists;
+import com.google.common.collect.Lists;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;


### PR DESCRIPTION
Other parts of our system are already using 0.15.0 (e.g. the grpc package generation in packman), so we should match that. 