### PR TITLE
Add grpc streaming test support to GAX

### DIFF
--- a/src/main/java/com/google/api/gax/testing/MockStreamObserver.java
+++ b/src/main/java/com/google/api/gax/testing/MockStreamObserver.java
@@ -30,20 +30,21 @@
  */
 package com.google.api.gax.testing;
 
+import com.google.common.util.concurrent.SettableFuture;
+
 import io.grpc.stub.StreamObserver;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * An implementation of gRPC StreamObserver used by testing.
  */
 public class MockStreamObserver<T> implements StreamObserver<T> {
 
-  public CompletableFuture<List<T>> future = new CompletableFuture<>();
-  public boolean hasErrors = false;
+  public SettableFuture<List<T>> future = SettableFuture.create();
   public List<T> actualMessages = new ArrayList<>();
+  public List<Throwable> errors = new ArrayList<>();
 
   @Override
   public void onNext(T message) {
@@ -52,11 +53,11 @@ public class MockStreamObserver<T> implements StreamObserver<T> {
 
   @Override
   public void onError(Throwable t) {
-    hasErrors = true;
+    errors.add(t);
   }
 
   @Override
   public void onCompleted() {
-    future.complete(actualMessages);
+    future.set(actualMessages);
   }
 }

--- a/src/main/java/com/google/api/gax/testing/MockStreamObserver.java
+++ b/src/main/java/com/google/api/gax/testing/MockStreamObserver.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.testing;
+
+import io.grpc.stub.StreamObserver;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An implementation of gRPC StreamObserver used by testing.
+ */
+public class MockStreamObserver<T> implements StreamObserver<T> {
+
+  public CompletableFuture<List<T>> future = new CompletableFuture<>();
+  public boolean hasErrors = false;
+  public List<T> actualMessages = new ArrayList<>();
+
+  @Override
+  public void onNext(T message) {
+    actualMessages.add(message);
+  }
+
+  @Override
+  public void onError(Throwable t) {
+    hasErrors = true;
+  }
+
+  @Override
+  public void onCompleted() {
+    future.complete(actualMessages);
+  }
+}

--- a/src/main/java/com/google/api/gax/testing/MockStreamObserver.java
+++ b/src/main/java/com/google/api/gax/testing/MockStreamObserver.java
@@ -42,8 +42,8 @@ import java.util.List;
  */
 public class MockStreamObserver<T> implements StreamObserver<T> {
 
-  public final SettableFuture<List<T>> future = SettableFuture.create();
-  public final List<Throwable> errors = new ArrayList<>();
+  private final SettableFuture<List<T>> future = SettableFuture.create();
+  private final List<Throwable> errors = new ArrayList<>();
   private final List<T> actualMessages = new ArrayList<>();
 
   @Override
@@ -59,5 +59,15 @@ public class MockStreamObserver<T> implements StreamObserver<T> {
   @Override
   public void onCompleted() {
     future.set(actualMessages);
+  }
+
+  // Returns the list of errors encountered.
+  public List<Throwable> errors() {
+    return errors;
+  }
+
+  // Returns the SettableFuture object which can be used to retrieve received messages.
+  public SettableFuture<List<T>> future() {
+    return future;
   }
 }

--- a/src/main/java/com/google/api/gax/testing/MockStreamObserver.java
+++ b/src/main/java/com/google/api/gax/testing/MockStreamObserver.java
@@ -42,9 +42,9 @@ import java.util.List;
  */
 public class MockStreamObserver<T> implements StreamObserver<T> {
 
-  public SettableFuture<List<T>> future = SettableFuture.create();
-  public List<T> actualMessages = new ArrayList<>();
-  public List<Throwable> errors = new ArrayList<>();
+  public final SettableFuture<List<T>> future = SettableFuture.create();
+  public final List<Throwable> errors = new ArrayList<>();
+  private final List<T> actualMessages = new ArrayList<>();
 
   @Override
   public void onNext(T message) {


### PR DESCRIPTION
Create MockStreamObserver class which allows tests of grpc streaming methods.