### PR TITLE
Supporting cancellation of UnaryApiCallable

### DIFF
--- a/src/main/java/com/google/api/gax/grpc/RetryingCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/RetryingCallable.java
@@ -33,14 +33,23 @@ package com.google.api.gax.grpc;
 
 import com.google.api.gax.core.RetrySettings;
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
+
 import io.grpc.CallOptions;
 import io.grpc.Status;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.annotation.Nullable;
+
 import org.joda.time.Duration;
 
 /**
@@ -70,18 +79,18 @@ class RetryingCallable<RequestT, ResponseT> implements FutureCallable<RequestT, 
 
   @Override
   public ListenableFuture<ResponseT> futureCall(RequestT request, CallContext context) {
-    SettableFuture<ResponseT> result = SettableFuture.<ResponseT>create();
+    RetryingResultFuture resultFuture = new RetryingResultFuture();
     context = getCallContextWithDeadlineAfter(context, retryParams.getTotalTimeout());
     Retryer retryer =
         new Retryer(
             request,
             context,
-            result,
+            resultFuture,
             retryParams.getInitialRetryDelay(),
             retryParams.getInitialRpcTimeout(),
             null);
-    retryer.run();
-    return result;
+    resultFuture.issueCall(request, context, retryer);
+    return resultFuture;
   }
 
   @Override
@@ -89,10 +98,10 @@ class RetryingCallable<RequestT, ResponseT> implements FutureCallable<RequestT, 
     return String.format("retrying(%s)", callable);
   }
 
-  private class Retryer implements Runnable {
+  private class Retryer implements Runnable, FutureCallback<ResponseT> {
     private final RequestT request;
     private final CallContext context;
-    private final SettableFuture<ResponseT> result;
+    private final RetryingResultFuture resultFuture;
     private final Duration retryDelay;
     private final Duration rpcTimeout;
     private final Throwable savedThrowable;
@@ -100,13 +109,13 @@ class RetryingCallable<RequestT, ResponseT> implements FutureCallable<RequestT, 
     private Retryer(
         RequestT request,
         CallContext context,
-        SettableFuture<ResponseT> result,
+        RetryingResultFuture resultFuture,
         Duration retryDelay,
         Duration rpcTimeout,
         Throwable savedThrowable) {
       this.request = request;
       this.context = context;
-      this.result = result;
+      this.resultFuture = resultFuture;
       this.retryDelay = retryDelay;
       this.rpcTimeout = rpcTimeout;
       this.savedThrowable = savedThrowable;
@@ -116,58 +125,147 @@ class RetryingCallable<RequestT, ResponseT> implements FutureCallable<RequestT, 
     public void run() {
       if (context.getCallOptions().getDeadlineNanoTime() < clock.nanoTime()) {
         if (savedThrowable == null) {
-          result.setException(
+          resultFuture.setException(
               Status.DEADLINE_EXCEEDED
                   .withDescription("Total deadline exceeded without completing any call")
                   .asException());
         } else {
-          result.setException(savedThrowable);
+          resultFuture.setException(savedThrowable);
         }
         return;
       }
       CallContext deadlineContext = getCallContextWithDeadlineAfter(context, rpcTimeout);
-      Futures.addCallback(
-          callable.futureCall(request, deadlineContext),
-          new FutureCallback<ResponseT>() {
-            @Override
-            public void onSuccess(ResponseT r) {
-              result.set(r);
-            }
+      resultFuture.issueCall(request, deadlineContext, this);
+    }
 
-            @Override
-            public void onFailure(Throwable throwable) {
-              if (!canRetry(throwable)) {
-                result.setException(throwable);
-                return;
-              }
-              if (isDeadlineExceeded(throwable)) {
-                Retryer retryer =
-                    new Retryer(request, context, result, retryDelay, rpcTimeout, throwable);
-                executor.schedule(
-                    retryer, DEADLINE_SLEEP_DURATION.getMillis(), TimeUnit.MILLISECONDS);
-                return;
-              }
+    @Override
+    public void onSuccess(ResponseT r) {
+      resultFuture.set(r);
+    }
 
-              long newRetryDelay =
-                  (long) (retryDelay.getMillis() * retryParams.getRetryDelayMultiplier());
-              newRetryDelay = Math.min(newRetryDelay, retryParams.getMaxRetryDelay().getMillis());
+    @Override
+    public void onFailure(Throwable throwable) {
+      if (!canRetry(throwable)) {
+        resultFuture.setException(throwable);
+        return;
+      }
+      if (isDeadlineExceeded(throwable)) {
+        Retryer retryer =
+            new Retryer(request, context, resultFuture, retryDelay, rpcTimeout, throwable);
+        resultFuture.scheduleNext(
+            executor, retryer, DEADLINE_SLEEP_DURATION.getMillis(), TimeUnit.MILLISECONDS);
+        return;
+      }
 
-              long newRpcTimeout =
-                  (long) (rpcTimeout.getMillis() * retryParams.getRpcTimeoutMultiplier());
-              newRpcTimeout = Math.min(newRpcTimeout, retryParams.getMaxRpcTimeout().getMillis());
+      long newRetryDelay = (long) (retryDelay.getMillis() * retryParams.getRetryDelayMultiplier());
+      newRetryDelay = Math.min(newRetryDelay, retryParams.getMaxRetryDelay().getMillis());
 
-              long randomRetryDelay = ThreadLocalRandom.current().nextLong(retryDelay.getMillis());
-              Retryer retryer =
-                  new Retryer(
-                      request,
-                      context,
-                      result,
-                      Duration.millis(newRetryDelay),
-                      Duration.millis(newRpcTimeout),
-                      throwable);
-              executor.schedule(retryer, randomRetryDelay, TimeUnit.MILLISECONDS);
-            }
-          });
+      long newRpcTimeout = (long) (rpcTimeout.getMillis() * retryParams.getRpcTimeoutMultiplier());
+      newRpcTimeout = Math.min(newRpcTimeout, retryParams.getMaxRpcTimeout().getMillis());
+
+      long randomRetryDelay = ThreadLocalRandom.current().nextLong(retryDelay.getMillis());
+      Retryer retryer =
+          new Retryer(
+              request,
+              context,
+              resultFuture,
+              Duration.millis(newRetryDelay),
+              Duration.millis(newRpcTimeout),
+              throwable);
+      resultFuture.scheduleNext(executor, retryer, randomRetryDelay, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private class RetryingResultFuture extends AbstractFuture<ResponseT> {
+    private volatile Future<?> activeFuture = null;
+    private volatile boolean cancelled = false;
+    private final Lock lock = new ReentrantLock();
+
+    @Override
+    protected void interruptTask() {
+      final Lock lock = this.lock;
+      lock.lock();
+      try {
+        cancelled = true;
+        if (activeFuture != null) {
+          activeFuture.cancel(true);
+        }
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    @Override
+    public boolean set(@Nullable ResponseT value) {
+      final Lock lock = this.lock;
+      lock.lock();
+      try {
+        activeFuture = null;
+        return super.set(value);
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    @Override
+    public boolean setException(Throwable throwable) {
+      final Lock lock = this.lock;
+      lock.lock();
+      try {
+        activeFuture = null;
+        if (throwable instanceof CancellationException) {
+          if (cancelled) {
+            // this is just circling back - ignore.
+          } else {
+            // somehow someone else got ahold of the call-issuing future and
+            // cancelled it.
+            super.cancel(false);
+          }
+          return true;
+        } else {
+          return super.setException(throwable);
+        }
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    private void scheduleNext(
+        UnaryApiCallable.Scheduler executor, Runnable retryer, long delay, TimeUnit unit) {
+      final Lock lock = this.lock;
+      lock.lock();
+      try {
+        if (isCancelledImpl()) {
+          return;
+        } else {
+          activeFuture = executor.schedule(retryer, delay, TimeUnit.MILLISECONDS);
+        }
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    public void issueCall(
+        RequestT request,
+        CallContext deadlineContext,
+        RetryingCallable<RequestT, ResponseT>.Retryer retryer) {
+      final Lock lock = this.lock;
+      lock.lock();
+      try {
+        if (isCancelledImpl()) {
+          return;
+        } else {
+          ListenableFuture<ResponseT> callFuture = callable.futureCall(request, deadlineContext);
+          Futures.addCallback(callFuture, retryer);
+          activeFuture = callFuture;
+        }
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    private boolean isCancelledImpl() {
+      return cancelled || (activeFuture != null && activeFuture.isCancelled());
     }
   }
 

--- a/src/main/java/com/google/api/gax/grpc/UnaryApiCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/UnaryApiCallable.java
@@ -43,6 +43,8 @@ import io.grpc.Channel;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+
+import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -97,6 +99,8 @@ public final class UnaryApiCallable<RequestT, ResponseT> {
 
   interface Scheduler {
     ScheduledFuture<?> schedule(Runnable runnable, long delay, TimeUnit unit);
+
+    List<Runnable> shutdownNow();
   }
 
   static class DelegatingScheduler implements Scheduler {
@@ -109,6 +113,11 @@ public final class UnaryApiCallable<RequestT, ResponseT> {
     @Override
     public ScheduledFuture<?> schedule(Runnable runnable, long delay, TimeUnit unit) {
       return executor.schedule(runnable, delay, unit);
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      return executor.shutdownNow();
     }
   }
 

--- a/src/test/java/com/google/api/gax/grpc/CancellationTest.java
+++ b/src/test/java/com/google/api/gax/grpc/CancellationTest.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2016, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.grpc;
+
+import com.google.api.gax.core.RetrySettings;
+import com.google.api.gax.grpc.UnaryApiCallable.Scheduler;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.truth.Truth;
+import com.google.common.util.concurrent.AbstractFuture;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+import io.grpc.Status;
+
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.joda.time.Duration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+import autovalue.shaded.com.google.common.common.collect.Lists;
+
+@RunWith(JUnit4.class)
+public class CancellationTest {
+  @SuppressWarnings("unchecked")
+  private FutureCallable<Integer, Integer> callInt = Mockito.mock(FutureCallable.class);
+
+  private static final RetrySettings FAST_RETRY_SETTINGS =
+      RetrySettings.newBuilder()
+          .setInitialRetryDelay(Duration.millis(2L))
+          .setRetryDelayMultiplier(1)
+          .setMaxRetryDelay(Duration.millis(2L))
+          .setInitialRpcTimeout(Duration.millis(2L))
+          .setRpcTimeoutMultiplier(1)
+          .setMaxRpcTimeout(Duration.millis(2L))
+          .setTotalTimeout(Duration.millis(10L))
+          .build();
+
+  private static final RetrySettings SLOW_RETRY_SETTINGS =
+      RetrySettings.newBuilder()
+          .setInitialRetryDelay(Duration.millis(3000L))
+          .setRetryDelayMultiplier(1)
+          .setMaxRetryDelay(Duration.millis(3000L))
+          .setInitialRpcTimeout(Duration.millis(3000L))
+          .setRpcTimeoutMultiplier(1)
+          .setMaxRpcTimeout(Duration.millis(3000L))
+          .setTotalTimeout(Duration.millis(3000L))
+          .build();
+
+  private FakeNanoClock fakeClock;
+  private RecordingScheduler executor;
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void resetClock() {
+    fakeClock = new FakeNanoClock(System.nanoTime());
+    executor = new RecordingScheduler(fakeClock);
+  }
+
+  @After
+  public void teardown() {
+    executor.shutdownNow();
+  }
+
+  @Test
+  public void cancellationBeforeGetOnRetryingCallable() throws Exception {
+    thrown.expect(CancellationException.class);
+    Mockito.when(callInt.futureCall((Integer) Mockito.any(), (CallContext) Mockito.any()))
+        .thenReturn(SettableFuture.<Integer>create());
+
+    ImmutableSet<Status.Code> retryable = ImmutableSet.<Status.Code>of(Status.Code.UNAVAILABLE);
+    UnaryApiCallable<Integer, Integer> callable =
+        UnaryApiCallable.<Integer, Integer>create(callInt)
+            .retryableOn(retryable)
+            .retrying(FAST_RETRY_SETTINGS, executor, fakeClock);
+
+    ListenableFuture<Integer> resultFuture = callable.futureCall(0);
+    resultFuture.cancel(true);
+    resultFuture.get();
+  }
+
+  private static class LatchCountDownScheduler implements UnaryApiCallable.Scheduler {
+    private final ScheduledExecutorService executor;
+    private final CountDownLatch latch;
+
+    LatchCountDownScheduler(CountDownLatch latch) {
+      this.executor = new ScheduledThreadPoolExecutor(1);
+      this.latch = latch;
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable runnable, long delay, TimeUnit unit) {
+      latch.countDown();
+      return executor.schedule(runnable, delay, unit);
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      return executor.shutdownNow();
+    }
+  }
+
+  private void cancelAfterLatchCountDown(
+      final ListenableFuture<Integer> resultFuture, final CountDownLatch latch) {
+    Thread t =
+        new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                try {
+                  latch.await();
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                }
+                resultFuture.cancel(true);
+              }
+            });
+    t.start();
+  }
+
+  private static class CancellationTrackingFuture<RespT> extends AbstractFuture<RespT> {
+    private volatile boolean cancelled = false;
+
+    public static <RespT> CancellationTrackingFuture<RespT> create() {
+      return new CancellationTrackingFuture<>();
+    }
+
+    private CancellationTrackingFuture() {}
+
+    @Override
+    protected void interruptTask() {
+      cancelled = true;
+    }
+
+    public boolean isCancelled() {
+      return cancelled;
+    }
+  }
+
+  private static class LatchCountDownFutureCallable<RequestT, ResponseT>
+      implements FutureCallable<RequestT, ResponseT> {
+    private CountDownLatch callLatch;
+    private List<ListenableFuture<ResponseT>> injectedFutures;
+
+    @SuppressWarnings("unchecked")
+    public LatchCountDownFutureCallable(
+        CountDownLatch callLatch, ListenableFuture<ResponseT> injectedFuture) {
+      this(callLatch, Lists.newArrayList(injectedFuture));
+    }
+
+    public LatchCountDownFutureCallable(
+        CountDownLatch callLatch, List<ListenableFuture<ResponseT>> injectedFutures) {
+      this.callLatch = callLatch;
+      this.injectedFutures = Lists.newArrayList(injectedFutures);
+    }
+
+    @Override
+    public ListenableFuture<ResponseT> futureCall(RequestT request, CallContext context) {
+      callLatch.countDown();
+      if (injectedFutures.size() == 1) {
+        return injectedFutures.get(0);
+      } else {
+        return injectedFutures.remove(0);
+      }
+    }
+  }
+
+  @Test
+  public void cancellationDuringFirstCall() throws Exception {
+    CancellationTrackingFuture<Integer> innerFuture = CancellationTrackingFuture.<Integer>create();
+    CountDownLatch callIssuedLatch = new CountDownLatch(1);
+    FutureCallable<Integer, Integer> innerCallable =
+        new LatchCountDownFutureCallable<Integer, Integer>(callIssuedLatch, innerFuture);
+
+    ImmutableSet<Status.Code> retryable = ImmutableSet.<Status.Code>of(Status.Code.UNAVAILABLE);
+    UnaryApiCallable<Integer, Integer> callable =
+        UnaryApiCallable.<Integer, Integer>create(innerCallable)
+            .retryableOn(retryable)
+            .retrying(
+                FAST_RETRY_SETTINGS,
+                new UnaryApiCallable.DelegatingScheduler(new ScheduledThreadPoolExecutor(1)),
+                fakeClock);
+
+    ListenableFuture<Integer> resultFuture = callable.futureCall(0);
+    cancelAfterLatchCountDown(resultFuture, callIssuedLatch);
+    CancellationException gotException = null;
+    try {
+      resultFuture.get();
+    } catch (CancellationException e) {
+      gotException = e;
+    }
+    Truth.assertThat(gotException).isNotNull();
+    Truth.assertThat(innerFuture.isCancelled()).isTrue();
+  }
+
+  @Test
+  public void cancellationDuringRetryDelay() throws Exception {
+    Throwable throwable = Status.UNAVAILABLE.asException();
+    CancellationTrackingFuture<Integer> innerFuture = CancellationTrackingFuture.<Integer>create();
+    Mockito.when(callInt.futureCall((Integer) Mockito.any(), (CallContext) Mockito.any()))
+        .thenReturn(Futures.<Integer>immediateFailedFuture(throwable))
+        .thenReturn(innerFuture);
+
+    CountDownLatch retryScheduledLatch = new CountDownLatch(1);
+    Scheduler scheduler = new LatchCountDownScheduler(retryScheduledLatch);
+    ImmutableSet<Status.Code> retryable = ImmutableSet.<Status.Code>of(Status.Code.UNAVAILABLE);
+    UnaryApiCallable<Integer, Integer> callable =
+        UnaryApiCallable.<Integer, Integer>create(callInt)
+            .retryableOn(retryable)
+            .retrying(SLOW_RETRY_SETTINGS, scheduler, fakeClock);
+
+    ListenableFuture<Integer> resultFuture = callable.futureCall(0);
+    cancelAfterLatchCountDown(resultFuture, retryScheduledLatch);
+    CancellationException gotException = null;
+    try {
+      resultFuture.get();
+    } catch (CancellationException e) {
+      gotException = e;
+    }
+    Truth.assertThat(gotException).isNotNull();
+    Truth.assertThat(innerFuture.isCancelled()).isFalse();
+  }
+
+  @Test
+  public void cancellationDuringSecondCall() throws Exception {
+    Throwable throwable = Status.UNAVAILABLE.asException();
+    ListenableFuture<Integer> failingFuture = Futures.immediateFailedFuture(throwable);
+    CancellationTrackingFuture<Integer> innerFuture = CancellationTrackingFuture.<Integer>create();
+    CountDownLatch callIssuedLatch = new CountDownLatch(2);
+    @SuppressWarnings("unchecked")
+    FutureCallable<Integer, Integer> innerCallable =
+        new LatchCountDownFutureCallable<Integer, Integer>(
+            callIssuedLatch,
+            Lists.<ListenableFuture<Integer>>newArrayList(failingFuture, innerFuture));
+
+    ImmutableSet<Status.Code> retryable = ImmutableSet.<Status.Code>of(Status.Code.UNAVAILABLE);
+    UnaryApiCallable<Integer, Integer> callable =
+        UnaryApiCallable.<Integer, Integer>create(innerCallable)
+            .retryableOn(retryable)
+            .retrying(
+                FAST_RETRY_SETTINGS,
+                new UnaryApiCallable.DelegatingScheduler(new ScheduledThreadPoolExecutor(1)),
+                fakeClock);
+
+    ListenableFuture<Integer> resultFuture = callable.futureCall(0);
+    cancelAfterLatchCountDown(resultFuture, callIssuedLatch);
+    CancellationException gotException = null;
+    try {
+      resultFuture.get();
+    } catch (CancellationException e) {
+      gotException = e;
+    }
+    Truth.assertThat(gotException).isNotNull();
+    Truth.assertThat(innerFuture.isCancelled()).isTrue();
+  }
+}

--- a/src/test/java/com/google/api/gax/grpc/CancellationTest.java
+++ b/src/test/java/com/google/api/gax/grpc/CancellationTest.java
@@ -33,6 +33,7 @@ package com.google.api.gax.grpc;
 import com.google.api.gax.core.RetrySettings;
 import com.google.api.gax.grpc.UnaryApiCallable.Scheduler;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.truth.Truth;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.Futures;
@@ -58,8 +59,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
-
-import autovalue.shaded.com.google.common.common.collect.Lists;
 
 @RunWith(JUnit4.class)
 public class CancellationTest {
@@ -199,11 +198,7 @@ public class CancellationTest {
     @Override
     public ListenableFuture<ResponseT> futureCall(RequestT request, CallContext context) {
       callLatch.countDown();
-      if (injectedFutures.size() == 1) {
-        return injectedFutures.get(0);
-      } else {
-        return injectedFutures.remove(0);
-      }
+      return injectedFutures.remove(0);
     }
   }
 

--- a/src/test/java/com/google/api/gax/grpc/FakeNanoClock.java
+++ b/src/test/java/com/google/api/gax/grpc/FakeNanoClock.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.grpc;
+
+class FakeNanoClock implements NanoClock {
+
+  private volatile long currentNanoTime;
+
+  public FakeNanoClock(long initialNanoTime) {
+    currentNanoTime = initialNanoTime;
+  }
+
+  @Override
+  public long nanoTime() {
+    return currentNanoTime;
+  }
+
+  public void setCurrentNanoTime(long nanoTime) {
+    currentNanoTime = nanoTime;
+  }
+}

--- a/src/test/java/com/google/api/gax/grpc/RecordingScheduler.java
+++ b/src/test/java/com/google/api/gax/grpc/RecordingScheduler.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.grpc;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.joda.time.Duration;
+
+class RecordingScheduler implements UnaryApiCallable.Scheduler {
+  private final ScheduledExecutorService executor;
+  private final List<Duration> sleepDurations = new ArrayList<>();
+  private final FakeNanoClock clock;
+
+  public RecordingScheduler(FakeNanoClock clock) {
+    this.executor = new ScheduledThreadPoolExecutor(1);
+    this.clock = clock;
+  }
+
+  @Override
+  public ScheduledFuture<?> schedule(Runnable runnable, long delay, TimeUnit unit) {
+    sleepDurations.add(new Duration(TimeUnit.MILLISECONDS.convert(delay, unit)));
+    clock.setCurrentNanoTime(clock.nanoTime() + TimeUnit.NANOSECONDS.convert(delay, unit));
+    return executor.schedule(runnable, 0, TimeUnit.NANOSECONDS);
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    return executor.shutdownNow();
+  }
+
+  public List<Duration> getSleepDurations() {
+    return sleepDurations;
+  }
+
+  public FakeNanoClock getClock() {
+    return clock;
+  }
+}


### PR DESCRIPTION
The key complication is forwarding the cancellation from
RetryingCallable to the inner FutureCallable, since the inner
FutureCallable will change as each call attempt is made.