### PR TITLE
ServiceApiSettings: Require builder from subclasses

### DIFF
--- a/src/main/java/com/google/api/gax/grpc/ApiException.java
+++ b/src/main/java/com/google/api/gax/grpc/ApiException.java
@@ -45,11 +45,19 @@ import io.grpc.Status;
  * https://github.com/grpc/grpc-java/blob/master/core/src/main/java/io/grpc/Status.java
  */
 public class ApiException extends RuntimeException {
+  private static final long serialVersionUID = -725668425459379694L;
+
   private final Status.Code statusCode;
   private final boolean retryable;
 
   ApiException(Throwable cause, Status.Code statusCode, boolean retryable) {
     super(cause);
+    this.statusCode = Preconditions.checkNotNull(statusCode);
+    this.retryable = retryable;
+  }
+
+  ApiException(String message, Throwable cause, Status.Code statusCode, boolean retryable) {
+    super(message, cause);
     this.statusCode = Preconditions.checkNotNull(statusCode);
     this.retryable = retryable;
   }

--- a/src/main/java/com/google/api/gax/grpc/RetryingCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/RetryingCallable.java
@@ -45,8 +45,6 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 import javax.annotation.Nullable;
 

--- a/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
@@ -159,7 +159,7 @@ public abstract class ServiceApiSettings {
       this.serviceGeneratorVersion = settings.generatorVersion;
     }
 
-    private Builder() {
+    protected Builder() {
       clientLibName = DEFAULT_CLIENT_LIB_NAME;
       clientLibVersion = DEFAULT_VERSION;
       serviceGeneratorName = DEFAULT_GENERATOR_NAME;
@@ -242,7 +242,7 @@ public abstract class ServiceApiSettings {
       return this;
     }
 
-    protected abstract ConnectionSettings getDefaultConnectionSettings();
+    protected abstract ConnectionSettings.Builder getDefaultConnectionSettingsBuilder();
 
     /**
      * Provides the credentials necessary to create a channel. Other settings required to create the
@@ -251,7 +251,7 @@ public abstract class ServiceApiSettings {
      */
     public Builder provideChannelWith(final Credentials credentials) {
       provideChannelWith(
-          getDefaultConnectionSettings().toBuilder().provideCredentialsWith(credentials).build());
+          getDefaultConnectionSettingsBuilder().provideCredentialsWith(credentials).build());
       return this;
     }
 
@@ -265,7 +265,7 @@ public abstract class ServiceApiSettings {
      */
     public Builder provideChannelWith(List<String> scopes) {
       provideChannelWith(
-          getDefaultConnectionSettings().toBuilder().provideCredentialsWith(scopes).build());
+          getDefaultConnectionSettingsBuilder().provideCredentialsWith(scopes).build());
       return this;
     }
 

--- a/src/test/java/com/google/api/gax/grpc/SettingsTest.java
+++ b/src/test/java/com/google/api/gax/grpc/SettingsTest.java
@@ -68,15 +68,15 @@ public class SettingsTest {
 
     private interface FakePagedListResponse extends PagedListResponse<Integer, Integer, Integer> {}
 
+    @SuppressWarnings("unchecked")
     private static final MethodDescriptor<Integer, Integer> fakeMethodMethodDescriptor =
         Mockito.mock(MethodDescriptor.class);
 
-    private static final PageStreamingDescriptor<Integer, Integer, Integer>
-        fakePageStreamingDescriptor = Mockito.mock(PageStreamingDescriptor.class);
-
+    @SuppressWarnings("unchecked")
     private static final PagedListResponseFactory<Integer, Integer, FakePagedListResponse>
         fakePagedListResponseFactory = Mockito.mock(PagedListResponseFactory.class);
 
+    @SuppressWarnings("unchecked")
     private static final BundlingDescriptor<Integer, Integer> fakeBundlingDescriptor =
         Mockito.mock(BundlingDescriptor.class);
 
@@ -227,8 +227,8 @@ public class SettingsTest {
       }
 
       @Override
-      protected ConnectionSettings getDefaultConnectionSettings() {
-        return DEFAULT_CONNECTION_SETTINGS;
+      protected ConnectionSettings.Builder getDefaultConnectionSettingsBuilder() {
+        return DEFAULT_CONNECTION_SETTINGS.toBuilder();
       }
 
       @Override
@@ -273,21 +273,6 @@ public class SettingsTest {
 
       public BundlingCallSettings.Builder<Integer, Integer> fakeMethodBundling() {
         return fakeMethodBundling;
-      }
-
-      public void setFakeMethodSimple(SimpleCallSettings.Builder<Integer, Integer> fakeMethod) {
-        this.fakeMethodSimple = fakeMethod;
-      }
-
-      public void setFakeMethodPageStreaming(
-          PageStreamingCallSettings.Builder<Integer, Integer, FakePagedListResponse>
-              fakeMethodPageStreaming) {
-        this.fakeMethodPageStreaming = fakeMethodPageStreaming;
-      }
-
-      public void setFakeMethodBundling(
-          BundlingCallSettings.Builder<Integer, Integer> fakeMethodBundling) {
-        this.fakeMethodBundling = fakeMethodBundling;
       }
     }
   }
@@ -364,8 +349,8 @@ public class SettingsTest {
     FakeSettings settings = FakeSettings.defaultBuilder().provideChannelWith(channel, true).build();
     ChannelProvider channelProvider = settings.getChannelProvider();
     ScheduledExecutorService executor = settings.getExecutorProvider().getOrBuildExecutor();
-    ManagedChannel channelA = channelProvider.getOrBuildChannel(executor);
-    ManagedChannel channelB = channelProvider.getOrBuildChannel(executor);
+    channelProvider.getOrBuildChannel(executor);
+    channelProvider.getOrBuildChannel(executor);
   }
 
   @Test
@@ -396,8 +381,8 @@ public class SettingsTest {
     FakeSettings settings =
         FakeSettings.defaultBuilder().provideExecutorWith(executor, true).build();
     ExecutorProvider executorProvider = settings.getExecutorProvider();
-    ScheduledExecutorService executorA = executorProvider.getOrBuildExecutor();
-    ScheduledExecutorService executorB = executorProvider.getOrBuildExecutor();
+    executorProvider.getOrBuildExecutor();
+    executorProvider.getOrBuildExecutor();
   }
 
   @Test


### PR DESCRIPTION
This allows cases like OperationsApi to not have to provide a complete
instance of ConnectionSettings, since it does not have an inherent
service address.