### PR TITLE
Rename callable classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ client and server, based on [GRPC](http://grpc.io) and Google API conventions.
 
 Application code will rarely need to use most of the classes within this
 library directly, but code generated automatically from the API definition
-files can use services such as page streaming and request bundling to provide
+files can use services such as paged response and request bundling to provide
 a more convenient and idiomatic API surface to callers.
 
 Quickstart
@@ -87,7 +87,7 @@ Non-generated code:
   conditions on protocol buffers), path templates (to compose and decompose
   resource names), type (to represent field types in protocol buffers), etc.
 - `com.google.api.gax.grpc` - Contains classes that provide functionality on top
-  of gRPC calls, such as retry, page streaming, and request bundling.
+  of gRPC calls, such as retry, paged response, and request bundling.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ client and server, based on [GRPC](http://grpc.io) and Google API conventions.
 
 Application code will rarely need to use most of the classes within this
 library directly, but code generated automatically from the API definition
-files can use services such as paged response and request bundling to provide
+files can use services such as paged list iteration and request bundling to provide
 a more convenient and idiomatic API surface to callers.
 
 Quickstart
@@ -87,7 +87,7 @@ Non-generated code:
   conditions on protocol buffers), path templates (to compose and decompose
   resource names), type (to represent field types in protocol buffers), etc.
 - `com.google.api.gax.grpc` - Contains classes that provide functionality on top
-  of gRPC calls, such as retry, paged response, and request bundling.
+  of gRPC calls, such as retry, paged list iteration, and request bundling.
 
 License
 -------

--- a/src/main/java/com/google/api/gax/grpc/ApiException.java
+++ b/src/main/java/com/google/api/gax/grpc/ApiException.java
@@ -39,8 +39,8 @@ import io.grpc.Status;
  * Represents an exception thrown during an RPC call.
  *
  * <p>
- * It stores information useful for functionalities in {@link UnaryApiCallable} and
- * {@link StreamingApiCallable}. For more information about the status codes returned by the
+ * It stores information useful for functionalities in {@link UnaryCallable} and
+ * {@link StreamingCallable}. For more information about the status codes returned by the
  * underlying grpc exception see
  * https://github.com/grpc/grpc-java/blob/master/core/src/main/java/io/grpc/Status.java
  */

--- a/src/main/java/com/google/api/gax/grpc/BundleExecutor.java
+++ b/src/main/java/com/google/api/gax/grpc/BundleExecutor.java
@@ -78,7 +78,7 @@ class BundleExecutor<RequestT, ResponseT>
       requests.add(message.getRequest());
     }
     RequestT bundleRequest = bundlingDescriptor.mergeRequests(requests);
-    UnaryApiCallable<RequestT, ResponseT> callable = bundle.get(0).getCallable();
+    UnaryCallable<RequestT, ResponseT> callable = bundle.get(0).getCallable();
 
     try {
       ResponseT bundleResponse = callable.call(bundleRequest);

--- a/src/main/java/com/google/api/gax/grpc/BundlingCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/BundlingCallSettings.java
@@ -43,21 +43,21 @@ import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
- * A settings class to configure a UnaryApiCallable for calls to an API method that supports
+ * A settings class to configure a UnaryCallable for calls to an API method that supports
  * bundling. The settings are provided using an instance of {@link BundlingSettings}.
  */
 public final class BundlingCallSettings<RequestT, ResponseT>
-    extends UnaryApiCallSettingsTyped<RequestT, ResponseT> {
+    extends UnaryCallSettingsTyped<RequestT, ResponseT> {
   private final BundlingDescriptor<RequestT, ResponseT> bundlingDescriptor;
   private final BundlingSettings bundlingSettings;
   private BundlerFactory<RequestT, ResponseT> bundlerFactory;
 
   /**
-   * Package-private, for use by UnaryApiCallable.
+   * Package-private, for use by UnaryCallable.
    */
-  UnaryApiCallable<RequestT, ResponseT> create(
+  UnaryCallable<RequestT, ResponseT> create(
       ManagedChannel channel, ScheduledExecutorService executor) {
-    UnaryApiCallable<RequestT, ResponseT> baseCallable = createBaseCallable(channel, executor);
+    UnaryCallable<RequestT, ResponseT> baseCallable = createBaseCallable(channel, executor);
     bundlerFactory = new BundlerFactory<>(bundlingDescriptor, bundlingSettings);
     return baseCallable.bundling(bundlingDescriptor, bundlerFactory);
   }
@@ -89,7 +89,7 @@ public final class BundlingCallSettings<RequestT, ResponseT>
   }
 
   public static class Builder<RequestT, ResponseT>
-      extends UnaryApiCallSettingsTyped.Builder<RequestT, ResponseT> {
+      extends UnaryCallSettingsTyped.Builder<RequestT, ResponseT> {
 
     private BundlingDescriptor<RequestT, ResponseT> bundlingDescriptor;
     private BundlingSettings.Builder bundlingSettingsBuilder;

--- a/src/main/java/com/google/api/gax/grpc/BundlingCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/BundlingCallable.java
@@ -63,8 +63,8 @@ class BundlingCallable<RequestT, ResponseT> implements FutureCallable<RequestT, 
   public ListenableFuture<ResponseT> futureCall(RequestT request, CallContext context) {
     if (bundlerFactory.getBundlingSettings().getIsEnabled()) {
       BundlingFuture<ResponseT> result = BundlingFuture.<ResponseT>create();
-      UnaryApiCallable<RequestT, ResponseT> apiCallable =
-          UnaryApiCallable.<RequestT, ResponseT>create(callable).bind(context.getChannel());
+      UnaryCallable<RequestT, ResponseT> apiCallable =
+          UnaryCallable.<RequestT, ResponseT>create(callable).bind(context.getChannel());
       BundlingContext<RequestT, ResponseT> bundlableMessage =
           new BundlingContext<RequestT, ResponseT>(request, context, apiCallable, result);
       String partitionKey = bundlingDescriptor.getBundlePartitionKey(request);

--- a/src/main/java/com/google/api/gax/grpc/BundlingCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/BundlingCallable.java
@@ -63,10 +63,10 @@ class BundlingCallable<RequestT, ResponseT> implements FutureCallable<RequestT, 
   public ListenableFuture<ResponseT> futureCall(RequestT request, CallContext context) {
     if (bundlerFactory.getBundlingSettings().getIsEnabled()) {
       BundlingFuture<ResponseT> result = BundlingFuture.<ResponseT>create();
-      UnaryCallable<RequestT, ResponseT> apiCallable =
+      UnaryCallable<RequestT, ResponseT> unaryCallable =
           UnaryCallable.<RequestT, ResponseT>create(callable).bind(context.getChannel());
       BundlingContext<RequestT, ResponseT> bundlableMessage =
-          new BundlingContext<RequestT, ResponseT>(request, context, apiCallable, result);
+          new BundlingContext<RequestT, ResponseT>(request, context, unaryCallable, result);
       String partitionKey = bundlingDescriptor.getBundlePartitionKey(request);
       ThresholdBundlingForwarder<BundlingContext<RequestT, ResponseT>> forwarder =
           bundlerFactory.getForwarder(partitionKey);

--- a/src/main/java/com/google/api/gax/grpc/BundlingContext.java
+++ b/src/main/java/com/google/api/gax/grpc/BundlingContext.java
@@ -36,7 +36,7 @@ import com.google.common.base.Preconditions;
 /**
  * Holds the complete context to issue a call and notify the call's
  * listener. This includes a CallContext object, which contains the call
- * objects, the channel, and the request; a UnaryApiCallable object to issue
+ * objects, the channel, and the request; a UnaryCallable object to issue
  * the request; and a SettableFuture object, to notify the response
  * listener.
  *
@@ -46,7 +46,7 @@ public final class BundlingContext<RequestT, ResponseT>
     implements RequestIssuer<RequestT, ResponseT> {
   private final RequestT request;
   private final CallContext context;
-  private final UnaryApiCallable<RequestT, ResponseT> callable;
+  private final UnaryCallable<RequestT, ResponseT> callable;
   private final BundlingFuture<ResponseT> bundlingFuture;
   private ResponseT responseToSend;
   private Throwable throwableToSend;
@@ -54,7 +54,7 @@ public final class BundlingContext<RequestT, ResponseT>
   public BundlingContext(
       RequestT request,
       CallContext context,
-      UnaryApiCallable<RequestT, ResponseT> callable,
+      UnaryCallable<RequestT, ResponseT> callable,
       BundlingFuture<ResponseT> bundlingFuture) {
     this.request = request;
     this.context = context;
@@ -68,7 +68,7 @@ public final class BundlingContext<RequestT, ResponseT>
     return context;
   }
 
-  public UnaryApiCallable<RequestT, ResponseT> getCallable() {
+  public UnaryCallable<RequestT, ResponseT> getCallable() {
     return callable;
   }
 

--- a/src/main/java/com/google/api/gax/grpc/ClientCallFactory.java
+++ b/src/main/java/com/google/api/gax/grpc/ClientCallFactory.java
@@ -37,7 +37,7 @@ import io.grpc.ClientCall;
 /**
  * {@code ClientCallFactory} creates {@link io.grpc.ClientCall}s.
  *
- * <p>It is designed to be used by {@link com.google.api.gax.grpc.UnaryApiCallable},
+ * <p>It is designed to be used by {@link com.google.api.gax.grpc.UnaryCallable},
  * {@link com.google.api.gax.grpc.DirectStreamingCallable} and their supporting classes to create
  * new RPC calls.
  *

--- a/src/main/java/com/google/api/gax/grpc/DirectCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/DirectCallable.java
@@ -40,7 +40,7 @@ import io.grpc.stub.ClientCalls;
  * {@code DirectCallable} uses the given {@link ClientCallFactory} to create gRPC calls.
  *
  * <p>It is used to bridge the abstractions provided by gRPC and those provided in
- * {@link UnaryApiCallable}.
+ * {@link UnaryCallable}.
  *
  * <p>Package-private for internal use.
  */

--- a/src/main/java/com/google/api/gax/grpc/FutureCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/FutureCallable.java
@@ -38,7 +38,7 @@ import com.google.common.util.concurrent.ListenableFuture;
  * <p>The preferred way to modify the behavior of a {@code FutureCallable} is to use the decorator
  * pattern: Creating a {@code FutureCallable} that wraps another one. In this way, other
  * abstractions remain available after the modification. Common abstractions are provided in {@link
- * UnaryApiCallable}.
+ * UnaryCallable}.
  *
  * <p>Package-private for internal use.
  */

--- a/src/main/java/com/google/api/gax/grpc/PageImpl.java
+++ b/src/main/java/com/google/api/gax/grpc/PageImpl.java
@@ -44,14 +44,14 @@ import java.util.concurrent.Future;
 
 class PageImpl<RequestT, ResponseT, ResourceT> implements Page<RequestT, ResponseT, ResourceT> {
 
-  private final UnaryApiCallable<RequestT, ResponseT> callable;
+  private final UnaryCallable<RequestT, ResponseT> callable;
   private final PageStreamingDescriptor<RequestT, ResponseT, ResourceT> pageDescriptor;
   private final RequestT request;
   private final CallContext context;
   private ResponseT response;
 
   public PageImpl(
-      UnaryApiCallable<RequestT, ResponseT> callable,
+      UnaryCallable<RequestT, ResponseT> callable,
       PageStreamingDescriptor<RequestT, ResponseT, ResourceT> pageDescriptor,
       RequestT request,
       CallContext context) {

--- a/src/main/java/com/google/api/gax/grpc/PageImpl.java
+++ b/src/main/java/com/google/api/gax/grpc/PageImpl.java
@@ -45,14 +45,14 @@ import java.util.concurrent.Future;
 class PageImpl<RequestT, ResponseT, ResourceT> implements Page<RequestT, ResponseT, ResourceT> {
 
   private final UnaryCallable<RequestT, ResponseT> callable;
-  private final PageStreamingDescriptor<RequestT, ResponseT, ResourceT> pageDescriptor;
+  private final PagedListDescriptor<RequestT, ResponseT, ResourceT> pageDescriptor;
   private final RequestT request;
   private final CallContext context;
   private ResponseT response;
 
   public PageImpl(
       UnaryCallable<RequestT, ResponseT> callable,
-      PageStreamingDescriptor<RequestT, ResponseT, ResourceT> pageDescriptor,
+      PagedListDescriptor<RequestT, ResponseT, ResourceT> pageDescriptor,
       RequestT request,
       CallContext context) {
     this.callable = callable;

--- a/src/main/java/com/google/api/gax/grpc/PageStreamingCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/PageStreamingCallSettings.java
@@ -40,26 +40,26 @@ import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
- * A settings class to configure a UnaryApiCallable for calls to an API method that supports page
+ * A settings class to configure a UnaryCallable for calls to an API method that supports page
  * streaming.
  */
 public final class PageStreamingCallSettings<RequestT, ResponseT, PagedListResponseT>
-    extends UnaryApiCallSettingsTyped<RequestT, ResponseT> {
+    extends UnaryCallSettingsTyped<RequestT, ResponseT> {
   private final PagedListResponseFactory<RequestT, ResponseT, PagedListResponseT>
       pagedListResponseFactory;
 
   /**
-   * Package-private, for use by UnaryApiCallable.
+   * Package-private, for use by UnaryCallable.
    */
-  UnaryApiCallable<RequestT, ResponseT> create(
+  UnaryCallable<RequestT, ResponseT> create(
       ManagedChannel channel, ScheduledExecutorService executor) {
     return createBaseCallable(channel, executor);
   }
 
-  /** Package-private, for use by UnaryApiCallable. */
-  UnaryApiCallable<RequestT, PagedListResponseT> createPagedVariant(
+  /** Package-private, for use by UnaryCallable. */
+  UnaryCallable<RequestT, PagedListResponseT> createPagedVariant(
       ManagedChannel channel, ScheduledExecutorService executor) {
-    UnaryApiCallable<RequestT, ResponseT> baseCallable = createBaseCallable(channel, executor);
+    UnaryCallable<RequestT, ResponseT> baseCallable = createBaseCallable(channel, executor);
     return baseCallable.pageStreaming(pagedListResponseFactory);
   }
 
@@ -86,7 +86,7 @@ public final class PageStreamingCallSettings<RequestT, ResponseT, PagedListRespo
   }
 
   public static class Builder<RequestT, ResponseT, PagedListResponseT>
-      extends UnaryApiCallSettingsTyped.Builder<RequestT, ResponseT> {
+      extends UnaryCallSettingsTyped.Builder<RequestT, ResponseT> {
     private PagedListResponseFactory<RequestT, ResponseT, PagedListResponseT>
         pagedListResponseFactory;
 

--- a/src/main/java/com/google/api/gax/grpc/PageStreamingCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/PageStreamingCallable.java
@@ -36,7 +36,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
 /**
- * Implements the page streaming functionality used in {@link UnaryApiCallable}.
+ * Implements the page streaming functionality used in {@link UnaryCallable}.
  *
  * <p>Package-private for internal use.
  */
@@ -62,7 +62,7 @@ class PageStreamingCallable<RequestT, ResponseT, PagedListResponseT>
   public ListenableFuture<PagedListResponseT> futureCall(RequestT request, CallContext context) {
     PagedListResponseT pagedListResponse =
         pagedListResponseFactory.createPagedListResponse(
-            UnaryApiCallable.create(callable), request, context);
+            UnaryCallable.create(callable), request, context);
     return Futures.immediateFuture(pagedListResponse);
   }
 }

--- a/src/main/java/com/google/api/gax/grpc/PagedCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/PagedCallSettings.java
@@ -60,7 +60,7 @@ public final class PagedCallSettings<RequestT, ResponseT, PagedListResponseT>
   UnaryCallable<RequestT, PagedListResponseT> createPagedVariant(
       ManagedChannel channel, ScheduledExecutorService executor) {
     UnaryCallable<RequestT, ResponseT> baseCallable = createBaseCallable(channel, executor);
-    return baseCallable.pageStreaming(pagedListResponseFactory);
+    return baseCallable.paged(pagedListResponseFactory);
   }
 
   public static <RequestT, ResponseT, PagedListResponseT>

--- a/src/main/java/com/google/api/gax/grpc/PagedCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/PagedCallSettings.java
@@ -43,7 +43,7 @@ import java.util.concurrent.ScheduledExecutorService;
  * A settings class to configure a UnaryCallable for calls to an API method that supports page
  * streaming.
  */
-public final class PageStreamingCallSettings<RequestT, ResponseT, PagedListResponseT>
+public final class PagedCallSettings<RequestT, ResponseT, PagedListResponseT>
     extends UnaryCallSettingsTyped<RequestT, ResponseT> {
   private final PagedListResponseFactory<RequestT, ResponseT, PagedListResponseT>
       pagedListResponseFactory;
@@ -76,7 +76,7 @@ public final class PageStreamingCallSettings<RequestT, ResponseT, PagedListRespo
     return new Builder<>(this);
   }
 
-  private PageStreamingCallSettings(
+  private PagedCallSettings(
       ImmutableSet<Status.Code> retryableCodes,
       RetrySettings retrySettings,
       MethodDescriptor<RequestT, ResponseT> methodDescriptor,
@@ -98,7 +98,7 @@ public final class PageStreamingCallSettings<RequestT, ResponseT, PagedListRespo
       this.pagedListResponseFactory = pagedListResponseFactory;
     }
 
-    public Builder(PageStreamingCallSettings<RequestT, ResponseT, PagedListResponseT> settings) {
+    public Builder(PagedCallSettings<RequestT, ResponseT, PagedListResponseT> settings) {
       super(settings);
       this.pagedListResponseFactory = settings.pagedListResponseFactory;
     }
@@ -125,8 +125,8 @@ public final class PageStreamingCallSettings<RequestT, ResponseT, PagedListRespo
     }
 
     @Override
-    public PageStreamingCallSettings<RequestT, ResponseT, PagedListResponseT> build() {
-      return new PageStreamingCallSettings<>(
+    public PagedCallSettings<RequestT, ResponseT, PagedListResponseT> build() {
+      return new PagedCallSettings<>(
           ImmutableSet.<Status.Code>copyOf(getRetryableCodes()),
           getRetrySettingsBuilder().build(),
           getMethodDescriptor(),

--- a/src/main/java/com/google/api/gax/grpc/PagedCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/PagedCallable.java
@@ -36,7 +36,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
 /**
- * Implements the page streaming functionality used in {@link UnaryCallable}.
+ * Implements the paged functionality used in {@link UnaryCallable}.
  *
  * <p>Package-private for internal use.
  */
@@ -55,7 +55,7 @@ class PagedCallable<RequestT, ResponseT, PagedListResponseT>
 
   @Override
   public String toString() {
-    return String.format("pageStreaming(%s)", callable);
+    return String.format("paged(%s)", callable);
   }
 
   @Override

--- a/src/main/java/com/google/api/gax/grpc/PagedCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/PagedCallable.java
@@ -31,40 +31,38 @@
 
 package com.google.api.gax.grpc;
 
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
 /**
- * An interface which describes the paging pattern.
+ * Implements the page streaming functionality used in {@link UnaryCallable}.
  *
- * <p>This is public only for technical reasons, for advanced usage.
+ * <p>Package-private for internal use.
  */
-public interface PageStreamingDescriptor<RequestT, ResponseT, ResourceT> {
+class PagedCallable<RequestT, ResponseT, PagedListResponseT>
+    implements FutureCallable<RequestT, PagedListResponseT> {
+  private final FutureCallable<RequestT, ResponseT> callable;
+  private final PagedListResponseFactory<RequestT, ResponseT, PagedListResponseT>
+      pagedListResponseFactory;
 
-  /**
-   * Delivers the empty page token.
-   */
-  Object emptyToken();
+  PagedCallable(
+      FutureCallable<RequestT, ResponseT> callable,
+      PagedListResponseFactory<RequestT, ResponseT, PagedListResponseT> pagedListResponseFactory) {
+    this.callable = Preconditions.checkNotNull(callable);
+    this.pagedListResponseFactory = pagedListResponseFactory;
+  }
 
-  /**
-   * Injects a page token into the request.
-   */
-  RequestT injectToken(RequestT payload, Object token);
+  @Override
+  public String toString() {
+    return String.format("pageStreaming(%s)", callable);
+  }
 
-  /**
-   * Injects page size setting into the request.
-   */
-  RequestT injectPageSize(RequestT payload, int pageSize);
-
-  /*
-   * Extracts the page size setting from the request.
-   */
-  Integer extractPageSize(RequestT payload);
-
-  /**
-   * Extracts the next token from the response. Returns the empty token if there are no more pages.
-   */
-  Object extractNextToken(ResponseT payload);
-
-  /**
-   * Extracts an iterable of resources from the response.
-   */
-  Iterable<ResourceT> extractResources(ResponseT payload);
+  @Override
+  public ListenableFuture<PagedListResponseT> futureCall(RequestT request, CallContext context) {
+    PagedListResponseT pagedListResponse =
+        pagedListResponseFactory.createPagedListResponse(
+            UnaryCallable.create(callable), request, context);
+    return Futures.immediateFuture(pagedListResponse);
+  }
 }

--- a/src/main/java/com/google/api/gax/grpc/PagedListDescriptor.java
+++ b/src/main/java/com/google/api/gax/grpc/PagedListDescriptor.java
@@ -31,38 +31,40 @@
 
 package com.google.api.gax.grpc;
 
-import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-
 /**
- * Implements the page streaming functionality used in {@link UnaryCallable}.
+ * An interface which describes the paging pattern.
  *
- * <p>Package-private for internal use.
+ * <p>This is public only for technical reasons, for advanced usage.
  */
-class PageStreamingCallable<RequestT, ResponseT, PagedListResponseT>
-    implements FutureCallable<RequestT, PagedListResponseT> {
-  private final FutureCallable<RequestT, ResponseT> callable;
-  private final PagedListResponseFactory<RequestT, ResponseT, PagedListResponseT>
-      pagedListResponseFactory;
+public interface PagedListDescriptor<RequestT, ResponseT, ResourceT> {
 
-  PageStreamingCallable(
-      FutureCallable<RequestT, ResponseT> callable,
-      PagedListResponseFactory<RequestT, ResponseT, PagedListResponseT> pagedListResponseFactory) {
-    this.callable = Preconditions.checkNotNull(callable);
-    this.pagedListResponseFactory = pagedListResponseFactory;
-  }
+  /**
+   * Delivers the empty page token.
+   */
+  Object emptyToken();
 
-  @Override
-  public String toString() {
-    return String.format("pageStreaming(%s)", callable);
-  }
+  /**
+   * Injects a page token into the request.
+   */
+  RequestT injectToken(RequestT payload, Object token);
 
-  @Override
-  public ListenableFuture<PagedListResponseT> futureCall(RequestT request, CallContext context) {
-    PagedListResponseT pagedListResponse =
-        pagedListResponseFactory.createPagedListResponse(
-            UnaryCallable.create(callable), request, context);
-    return Futures.immediateFuture(pagedListResponse);
-  }
+  /**
+   * Injects page size setting into the request.
+   */
+  RequestT injectPageSize(RequestT payload, int pageSize);
+
+  /*
+   * Extracts the page size setting from the request.
+   */
+  Integer extractPageSize(RequestT payload);
+
+  /**
+   * Extracts the next token from the response. Returns the empty token if there are no more pages.
+   */
+  Object extractNextToken(ResponseT payload);
+
+  /**
+   * Extracts an iterable of resources from the response.
+   */
+  Iterable<ResourceT> extractResources(ResponseT payload);
 }

--- a/src/main/java/com/google/api/gax/grpc/PagedListResponseFactory.java
+++ b/src/main/java/com/google/api/gax/grpc/PagedListResponseFactory.java
@@ -32,12 +32,12 @@
 package com.google.api.gax.grpc;
 
 /**
- * Interface for constructing PagedListResponse objects, used by {@link UnaryApiCallable}.
+ * Interface for constructing PagedListResponse objects, used by {@link UnaryCallable}.
  *
  * <p>This is public only for technical reasons, for advanced usage.
  */
 public interface PagedListResponseFactory<RequestT, ResponseT, PagedListResponseT> {
 
   PagedListResponseT createPagedListResponse(
-      UnaryApiCallable<RequestT, ResponseT> callable, RequestT request, CallContext context);
+      UnaryCallable<RequestT, ResponseT> callable, RequestT request, CallContext context);
 }

--- a/src/main/java/com/google/api/gax/grpc/PagedListResponseImpl.java
+++ b/src/main/java/com/google/api/gax/grpc/PagedListResponseImpl.java
@@ -51,7 +51,7 @@ public class PagedListResponseImpl<RequestT, ResponseT, ResourceT>
   private Page<RequestT, ResponseT, ResourceT> currentPage;
 
   public PagedListResponseImpl(
-      UnaryApiCallable<RequestT, ResponseT> callable,
+      UnaryCallable<RequestT, ResponseT> callable,
       PageStreamingDescriptor<RequestT, ResponseT, ResourceT> pageDescriptor,
       RequestT request,
       CallContext context) {

--- a/src/main/java/com/google/api/gax/grpc/PagedListResponseImpl.java
+++ b/src/main/java/com/google/api/gax/grpc/PagedListResponseImpl.java
@@ -47,12 +47,12 @@ public class PagedListResponseImpl<RequestT, ResponseT, ResourceT>
     implements PagedListResponse<RequestT, ResponseT, ResourceT> {
 
   private RequestT request;
-  private PageStreamingDescriptor<RequestT, ResponseT, ResourceT> pageDescriptor;
+  private PagedListDescriptor<RequestT, ResponseT, ResourceT> pageDescriptor;
   private Page<RequestT, ResponseT, ResourceT> currentPage;
 
   public PagedListResponseImpl(
       UnaryCallable<RequestT, ResponseT> callable,
-      PageStreamingDescriptor<RequestT, ResponseT, ResourceT> pageDescriptor,
+      PagedListDescriptor<RequestT, ResponseT, ResourceT> pageDescriptor,
       RequestT request,
       CallContext context) {
     this.pageDescriptor = pageDescriptor;

--- a/src/main/java/com/google/api/gax/grpc/RetryingCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/RetryingCallable.java
@@ -51,7 +51,7 @@ import javax.annotation.Nullable;
 import org.joda.time.Duration;
 
 /**
- * Implements the retry and timeout functionality used in {@link UnaryApiCallable}. The behavior is
+ * Implements the retry and timeout functionality used in {@link UnaryCallable}. The behavior is
  * controlled by the given {@link RetrySettings}.
  */
 class RetryingCallable<RequestT, ResponseT> implements FutureCallable<RequestT, ResponseT> {
@@ -61,13 +61,13 @@ class RetryingCallable<RequestT, ResponseT> implements FutureCallable<RequestT, 
 
   private final FutureCallable<RequestT, ResponseT> callable;
   private final RetrySettings retryParams;
-  private final UnaryApiCallable.Scheduler executor;
+  private final UnaryCallable.Scheduler executor;
   private final NanoClock clock;
 
   RetryingCallable(
       FutureCallable<RequestT, ResponseT> callable,
       RetrySettings retrySettings,
-      UnaryApiCallable.Scheduler executor,
+      UnaryCallable.Scheduler executor,
       NanoClock clock) {
     this.callable = Preconditions.checkNotNull(callable);
     this.retryParams = Preconditions.checkNotNull(retrySettings);
@@ -205,7 +205,7 @@ class RetryingCallable<RequestT, ResponseT> implements FutureCallable<RequestT, 
     }
 
     private void scheduleNext(
-        UnaryApiCallable.Scheduler executor, Runnable retryer, long delay, TimeUnit unit) {
+        UnaryCallable.Scheduler executor, Runnable retryer, long delay, TimeUnit unit) {
       synchronized (syncObject) {
         if (!isCancelled()) {
           activeFuture = executor.schedule(retryer, delay, TimeUnit.MILLISECONDS);

--- a/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
@@ -315,12 +315,12 @@ public abstract class ServiceApiSettings {
      *  Performs a merge, using only non-null fields
      */
     protected Builder applyToAllApiMethods(
-        Iterable<UnaryApiCallSettings.Builder> methodSettingsBuilders,
-        UnaryApiCallSettings.Builder newSettingsBuilder)
+        Iterable<UnaryCallSettings.Builder> methodSettingsBuilders,
+        UnaryCallSettings.Builder newSettingsBuilder)
         throws Exception {
       Set<Status.Code> newRetryableCodes = newSettingsBuilder.getRetryableCodes();
       RetrySettings.Builder newRetrySettingsBuilder = newSettingsBuilder.getRetrySettingsBuilder();
-      for (UnaryApiCallSettings.Builder settingsBuilder : methodSettingsBuilders) {
+      for (UnaryCallSettings.Builder settingsBuilder : methodSettingsBuilders) {
         if (newRetryableCodes != null) {
           settingsBuilder.setRetryableCodes(newRetryableCodes);
         }

--- a/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/ServiceApiSettings.java
@@ -327,7 +327,7 @@ public abstract class ServiceApiSettings {
         if (newRetrySettingsBuilder != null) {
           settingsBuilder.getRetrySettingsBuilder().merge(newRetrySettingsBuilder);
         }
-        // TODO(shinfan): Investigate on bundling and page-streaming settings.
+        // TODO(shinfan): Investigate on bundling and paged settings.
       }
       return this;
     }

--- a/src/main/java/com/google/api/gax/grpc/SimpleCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/SimpleCallSettings.java
@@ -42,16 +42,16 @@ import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
- * A settings class to configure a UnaryApiCallable for calls to a simple API method (i.e. that
+ * A settings class to configure a UnaryCallable for calls to a simple API method (i.e. that
  * doesn't support things like page streaming or bundling.)
  */
 public final class SimpleCallSettings<RequestT, ResponseT>
-    extends UnaryApiCallSettingsTyped<RequestT, ResponseT> {
+    extends UnaryCallSettingsTyped<RequestT, ResponseT> {
 
   /**
-   * Package-private, for use by UnaryApiCallable.
+   * Package-private, for use by UnaryCallable.
    */
-  UnaryApiCallable<RequestT, ResponseT> create(
+  UnaryCallable<RequestT, ResponseT> create(
       ManagedChannel channel, ScheduledExecutorService executor) {
     return createBaseCallable(channel, executor);
   }
@@ -74,7 +74,7 @@ public final class SimpleCallSettings<RequestT, ResponseT>
   }
 
   public static class Builder<RequestT, ResponseT>
-      extends UnaryApiCallSettingsTyped.Builder<RequestT, ResponseT> {
+      extends UnaryCallSettingsTyped.Builder<RequestT, ResponseT> {
 
     public Builder(MethodDescriptor<RequestT, ResponseT> grpcMethodDescriptor) {
       super(grpcMethodDescriptor);

--- a/src/main/java/com/google/api/gax/grpc/SimpleCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/SimpleCallSettings.java
@@ -43,7 +43,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * A settings class to configure a UnaryCallable for calls to a simple API method (i.e. that
- * doesn't support things like page streaming or bundling.)
+ * doesn't support paged or bundling functionalities.)
  */
 public final class SimpleCallSettings<RequestT, ResponseT>
     extends UnaryCallSettingsTyped<RequestT, ResponseT> {

--- a/src/main/java/com/google/api/gax/grpc/StreamingCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/StreamingCallSettings.java
@@ -34,9 +34,9 @@ import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
 
 /**
- * A settings class to configure an StreamingApiCallable for calls to a streaming API method.
+ * A settings class to configure an StreamingCallable for calls to a streaming API method.
  *
- * <p>Currently this class is used to create the StreamingApiCallable object based on the
+ * <p>Currently this class is used to create the StreamingCallable object based on the
  * configured MethodDescriptor from the gRPC method and the given channel.
  */
 public class StreamingCallSettings<RequestT, ResponseT> {
@@ -60,11 +60,11 @@ public class StreamingCallSettings<RequestT, ResponseT> {
   }
 
   /** Package-private */
-  StreamingApiCallable<RequestT, ResponseT> createStreamingApiCallable(ManagedChannel channel) {
+  StreamingCallable<RequestT, ResponseT> createStreamingCallable(ManagedChannel channel) {
     ClientCallFactory<RequestT, ResponseT> clientCallFactory =
         new DescriptorClientCallFactory<>(methodDescriptor);
-    StreamingApiCallable<RequestT, ResponseT> callable =
-        new StreamingApiCallable<>(new DirectStreamingCallable<>(clientCallFactory));
+    StreamingCallable<RequestT, ResponseT> callable =
+        new StreamingCallable<>(new DirectStreamingCallable<>(clientCallFactory));
     callable.bind(channel);
     return callable;
   }

--- a/src/main/java/com/google/api/gax/grpc/StreamingCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/StreamingCallable.java
@@ -37,20 +37,20 @@ import io.grpc.stub.StreamObserver;
 import java.util.Iterator;
 
 /**
- * A StreamingApiCallable is an immutable object which is capable of making RPC calls to streaming
+ * A StreamingCallable is an immutable object which is capable of making RPC calls to streaming
  * API methods.
  *
- * <p>It is considered advanced usage for a user to create a StreamingApiCallable themselves. This
+ * <p>It is considered advanced usage for a user to create a StreamingCallable themselves. This
  * class is intended to be created by a generated service API wrapper class, and configured by
  * instances of StreamingCallSettings.Builder which are exposed through the API wrapper class's
  * settings class.
  */
-public class StreamingApiCallable<RequestT, ResponseT> {
+public class StreamingCallable<RequestT, ResponseT> {
   private final DirectStreamingCallable<RequestT, ResponseT> callable;
   private ManagedChannel channel;
 
   /** Package-private */
-  StreamingApiCallable(DirectStreamingCallable<RequestT, ResponseT> callable) {
+  StreamingCallable(DirectStreamingCallable<RequestT, ResponseT> callable) {
     this.callable = callable;
   }
 
@@ -70,11 +70,11 @@ public class StreamingApiCallable<RequestT, ResponseT> {
    * @param streamingCallSettings {@link com.google.api.gax.grpc.StreamingCallSettings} to configure
    *     the method-level settings with.
    * @param channel {@link ManagedChannel} to use to connect to the service.
-   * @return {@link com.google.api.gax.grpc.StreamingApiCallable} callable object.
+   * @return {@link com.google.api.gax.grpc.StreamingCallable} callable object.
    */
-  public static <RequestT, ResponseT> StreamingApiCallable<RequestT, ResponseT> create(
+  public static <RequestT, ResponseT> StreamingCallable<RequestT, ResponseT> create(
       StreamingCallSettings<RequestT, ResponseT> streamingCallSettings, ManagedChannel channel) {
-    return streamingCallSettings.createStreamingApiCallable(channel);
+    return streamingCallSettings.createStreamingCallable(channel);
   }
 
   /**

--- a/src/main/java/com/google/api/gax/grpc/UnaryCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/UnaryCallSettings.java
@@ -45,7 +45,7 @@ import java.util.Set;
 /**
  * A base settings class to configure a UnaryCallable. An instance of ApiCallSettings
  * is not sufficient on its own to construct a UnaryCallable; a concrete derived type
- * is necessary, e.g. {@link SimpleCallSettings}, {@link PageStreamingCallSettings}, or
+ * is necessary, e.g. {@link SimpleCallSettings}, {@link PagedCallSettings}, or
  * {@link BundlingCallSettings}.
  *
  * <p>This base class includes settings that are applicable to all calls, which currently
@@ -106,7 +106,7 @@ public abstract class UnaryCallSettings {
    * instance of the abstract base class ApiCallSettings. See the class documentation of
    * {@link UnaryCallSettings} for a description of the different values that can be set, and
    * for a description of when this builder may be used. Builders for concrete derived classes such
-   * as {@link SimpleCallSettings}, {@link PageStreamingCallSettings}, or
+   * as {@link SimpleCallSettings}, {@link PagedCallSettings}, or
    * {@link BundlingCallSettings} can be used to create instances of those classes.
    */
   public static class Builder {
@@ -185,7 +185,7 @@ public abstract class UnaryCallSettings {
     /**
      * Builds an instance of the containing class. This operation is unsupported on the abstract
      * base class UnaryCallSettings, but is valid on concrete derived classes such as
-     * {@link SimpleCallSettings}, {@link PageStreamingCallSettings}, or
+     * {@link SimpleCallSettings}, {@link PagedCallSettings}, or
      * {@link BundlingCallSettings}.
      */
     public UnaryCallSettings build() {

--- a/src/main/java/com/google/api/gax/grpc/UnaryCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/UnaryCallSettings.java
@@ -43,7 +43,7 @@ import io.grpc.Status;
 import java.util.Set;
 
 /**
- * A base settings class to configure a UnaryCallable. An instance of ApiCallSettings
+ * A base settings class to configure a UnaryCallable. An instance of UnaryCallSettings
  * is not sufficient on its own to construct a UnaryCallable; a concrete derived type
  * is necessary, e.g. {@link SimpleCallSettings}, {@link PagedCallSettings}, or
  * {@link BundlingCallSettings}.
@@ -57,7 +57,7 @@ import java.util.Set;
  * To turn off retries, set the retryable codes needs to be set to the empty set.
  *
  * UnaryCallSettings contains a concrete builder class, {@link Builder}. This builder class
- * cannot be used to create an instance of ApiCallSettings, because ApiCallSettings is an
+ * cannot be used to create an instance of UnaryCallSettings, because UnaryCallSettings is an
  * abstract class. The {@link Builder} class may be used when a builder is required for a
  * purpose other than the creation of an instance type, such as by applyToAllApiMethods
  * in {@link ServiceApiSettings}.
@@ -103,7 +103,7 @@ public abstract class UnaryCallSettings {
 
   /**
    * A base builder class for {@link UnaryCallSettings}. This class cannot be used to create an
-   * instance of the abstract base class ApiCallSettings. See the class documentation of
+   * instance of the abstract base class UnaryCallSettings. See the class documentation of
    * {@link UnaryCallSettings} for a description of the different values that can be set, and
    * for a description of when this builder may be used. Builders for concrete derived classes such
    * as {@link SimpleCallSettings}, {@link PagedCallSettings}, or
@@ -119,9 +119,9 @@ public abstract class UnaryCallSettings {
       retrySettingsBuilder = RetrySettings.newBuilder();
     }
 
-    protected Builder(UnaryCallSettings apiCallSettings) {
-      setRetryableCodes(apiCallSettings.retryableCodes);
-      setRetrySettingsBuilder(apiCallSettings.getRetrySettings().toBuilder());
+    protected Builder(UnaryCallSettings unaryCallSettings) {
+      setRetryableCodes(unaryCallSettings.retryableCodes);
+      setRetrySettingsBuilder(unaryCallSettings.getRetrySettings().toBuilder());
     }
 
     /**
@@ -190,7 +190,7 @@ public abstract class UnaryCallSettings {
      */
     public UnaryCallSettings build() {
       throw new UnsupportedOperationException(
-          "Cannot build an instance of abstract class ApiCallSettings.");
+          "Cannot build an instance of abstract class UnaryCallSettings.");
     }
   }
 }

--- a/src/main/java/com/google/api/gax/grpc/UnaryCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/UnaryCallSettings.java
@@ -43,8 +43,8 @@ import io.grpc.Status;
 import java.util.Set;
 
 /**
- * A base settings class to configure a UnaryApiCallable. An instance of ApiCallSettings
- * is not sufficient on its own to construct a UnaryApiCallable; a concrete derived type
+ * A base settings class to configure a UnaryCallable. An instance of ApiCallSettings
+ * is not sufficient on its own to construct a UnaryCallable; a concrete derived type
  * is necessary, e.g. {@link SimpleCallSettings}, {@link PageStreamingCallSettings}, or
  * {@link BundlingCallSettings}.
  *
@@ -56,19 +56,19 @@ import java.util.Set;
  * the retry settings configure the retry logic when the retry needs to happen.
  * To turn off retries, set the retryable codes needs to be set to the empty set.
  *
- * UnaryApiCallSettings contains a concrete builder class, {@link Builder}. This builder class
+ * UnaryCallSettings contains a concrete builder class, {@link Builder}. This builder class
  * cannot be used to create an instance of ApiCallSettings, because ApiCallSettings is an
  * abstract class. The {@link Builder} class may be used when a builder is required for a
  * purpose other than the creation of an instance type, such as by applyToAllApiMethods
  * in {@link ServiceApiSettings}.
  */
-public abstract class UnaryApiCallSettings {
+public abstract class UnaryCallSettings {
 
   private final ImmutableSet<Status.Code> retryableCodes;
   private final RetrySettings retrySettings;
 
   /**
-   * See the class documentation of {@link UnaryApiCallSettings} for a description
+   * See the class documentation of {@link UnaryCallSettings} for a description
    * of what retryable codes do.
    */
   public final ImmutableSet<Status.Code> getRetryableCodes() {
@@ -76,7 +76,7 @@ public abstract class UnaryApiCallSettings {
   }
 
   /**
-   * See the class documentation of {@link UnaryApiCallSettings} for a description
+   * See the class documentation of {@link UnaryCallSettings} for a description
    * of what retry settings do.
    */
   public final RetrySettings getRetrySettings() {
@@ -84,9 +84,9 @@ public abstract class UnaryApiCallSettings {
   }
 
   /**
-   * Create a new UnaryApiCallSettings.Builder object. This builder cannot be used
-   * to build an instance of UnaryApiCallSettings, because UnaryApiCallSettings is an
-   * abstract class. See the class documentation of {@link UnaryApiCallSettings}
+   * Create a new UnaryCallSettings.Builder object. This builder cannot be used
+   * to build an instance of UnaryCallSettings, because UnaryCallSettings is an
+   * abstract class. See the class documentation of {@link UnaryCallSettings}
    * for a description of when this builder may be used.
    */
   public static Builder newBuilder() {
@@ -95,16 +95,16 @@ public abstract class UnaryApiCallSettings {
 
   public abstract Builder toBuilder();
 
-  protected UnaryApiCallSettings(
+  protected UnaryCallSettings(
       ImmutableSet<Status.Code> retryableCodes, RetrySettings retrySettings) {
     this.retryableCodes = ImmutableSet.<Status.Code>copyOf(retryableCodes);
     this.retrySettings = retrySettings;
   }
 
   /**
-   * A base builder class for {@link UnaryApiCallSettings}. This class cannot be used to create an
+   * A base builder class for {@link UnaryCallSettings}. This class cannot be used to create an
    * instance of the abstract base class ApiCallSettings. See the class documentation of
-   * {@link UnaryApiCallSettings} for a description of the different values that can be set, and
+   * {@link UnaryCallSettings} for a description of the different values that can be set, and
    * for a description of when this builder may be used. Builders for concrete derived classes such
    * as {@link SimpleCallSettings}, {@link PageStreamingCallSettings}, or
    * {@link BundlingCallSettings} can be used to create instances of those classes.
@@ -119,13 +119,13 @@ public abstract class UnaryApiCallSettings {
       retrySettingsBuilder = RetrySettings.newBuilder();
     }
 
-    protected Builder(UnaryApiCallSettings apiCallSettings) {
+    protected Builder(UnaryCallSettings apiCallSettings) {
       setRetryableCodes(apiCallSettings.retryableCodes);
       setRetrySettingsBuilder(apiCallSettings.getRetrySettings().toBuilder());
     }
 
     /**
-     * See the class documentation of {@link UnaryApiCallSettings} for a description
+     * See the class documentation of {@link UnaryCallSettings} for a description
      * of what retryable codes do.
      */
     public Builder setRetryableCodes(Set<Status.Code> retryableCodes) {
@@ -134,7 +134,7 @@ public abstract class UnaryApiCallSettings {
     }
 
     /**
-     * See the class documentation of {@link UnaryApiCallSettings} for a description
+     * See the class documentation of {@link UnaryCallSettings} for a description
      * of what retryable codes do.
      */
     public Builder setRetryableCodes(Status.Code... codes) {
@@ -143,7 +143,7 @@ public abstract class UnaryApiCallSettings {
     }
 
     /**
-     * See the class documentation of {@link UnaryApiCallSettings} for a description
+     * See the class documentation of {@link UnaryCallSettings} for a description
      * of what retry settings do.
      */
     public Builder setRetrySettingsBuilder(RetrySettings.Builder retrySettingsBuilder) {
@@ -167,7 +167,7 @@ public abstract class UnaryApiCallSettings {
     }
 
     /**
-     * See the class documentation of {@link UnaryApiCallSettings} for a description
+     * See the class documentation of {@link UnaryCallSettings} for a description
      * of what retryable codes do.
      */
     public Set<Status.Code> getRetryableCodes() {
@@ -175,7 +175,7 @@ public abstract class UnaryApiCallSettings {
     }
 
     /**
-     * See the class documentation of {@link UnaryApiCallSettings} for a description
+     * See the class documentation of {@link UnaryCallSettings} for a description
      * of what retry settings do.
      */
     public RetrySettings.Builder getRetrySettingsBuilder() {
@@ -184,11 +184,11 @@ public abstract class UnaryApiCallSettings {
 
     /**
      * Builds an instance of the containing class. This operation is unsupported on the abstract
-     * base class UnaryApiCallSettings, but is valid on concrete derived classes such as
+     * base class UnaryCallSettings, but is valid on concrete derived classes such as
      * {@link SimpleCallSettings}, {@link PageStreamingCallSettings}, or
      * {@link BundlingCallSettings}.
      */
-    public UnaryApiCallSettings build() {
+    public UnaryCallSettings build() {
       throw new UnsupportedOperationException(
           "Cannot build an instance of abstract class ApiCallSettings.");
     }

--- a/src/main/java/com/google/api/gax/grpc/UnaryCallSettingsTyped.java
+++ b/src/main/java/com/google/api/gax/grpc/UnaryCallSettingsTyped.java
@@ -44,7 +44,7 @@ import java.util.concurrent.ScheduledExecutorService;
  * A settings class with generic typing configure a UnaryCallable.
  *
  * <p>This class can be used as the base class that other concrete call settings classes inherit
- * from. We need this intermediate class to add generic typing, because ApiCallSettings is
+ * from. We need this intermediate class to add generic typing, because UnaryCallSettings is
  * not parameterized for its request and response types.
  *
  * <p>This class is package-private; use the concrete settings classes instead of this class from

--- a/src/main/java/com/google/api/gax/grpc/UnaryCallSettingsTyped.java
+++ b/src/main/java/com/google/api/gax/grpc/UnaryCallSettingsTyped.java
@@ -41,7 +41,7 @@ import io.grpc.Status;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
- * A settings class with generic typing configure a UnaryApiCallable.
+ * A settings class with generic typing configure a UnaryCallable.
  *
  * <p>This class can be used as the base class that other concrete call settings classes inherit
  * from. We need this intermediate class to add generic typing, because ApiCallSettings is
@@ -50,7 +50,7 @@ import java.util.concurrent.ScheduledExecutorService;
  * <p>This class is package-private; use the concrete settings classes instead of this class from
  * outside of the package.
  */
-abstract class UnaryApiCallSettingsTyped<RequestT, ResponseT> extends UnaryApiCallSettings {
+abstract class UnaryCallSettingsTyped<RequestT, ResponseT> extends UnaryCallSettings {
 
   private final MethodDescriptor<RequestT, ResponseT> methodDescriptor;
 
@@ -61,7 +61,7 @@ abstract class UnaryApiCallSettingsTyped<RequestT, ResponseT> extends UnaryApiCa
   @Override
   public abstract Builder<RequestT, ResponseT> toBuilder();
 
-  protected UnaryApiCallSettingsTyped(
+  protected UnaryCallSettingsTyped(
       ImmutableSet<Status.Code> retryableCodes,
       RetrySettings retrySettings,
       MethodDescriptor<RequestT, ResponseT> methodDescriptor) {
@@ -69,12 +69,12 @@ abstract class UnaryApiCallSettingsTyped<RequestT, ResponseT> extends UnaryApiCa
     this.methodDescriptor = methodDescriptor;
   }
 
-  protected UnaryApiCallable<RequestT, ResponseT> createBaseCallable(
+  protected UnaryCallable<RequestT, ResponseT> createBaseCallable(
       ManagedChannel channel, ScheduledExecutorService executor) {
     ClientCallFactory<RequestT, ResponseT> clientCallFactory =
         new DescriptorClientCallFactory<>(methodDescriptor);
-    UnaryApiCallable<RequestT, ResponseT> callable =
-        new UnaryApiCallable<>(new DirectCallable<>(clientCallFactory), channel, this);
+    UnaryCallable<RequestT, ResponseT> callable =
+        new UnaryCallable<>(new DirectCallable<>(clientCallFactory), channel, this);
     if (getRetryableCodes() != null) {
       callable = callable.retryableOn(ImmutableSet.copyOf(getRetryableCodes()));
     }
@@ -84,14 +84,14 @@ abstract class UnaryApiCallSettingsTyped<RequestT, ResponseT> extends UnaryApiCa
     return callable;
   }
 
-  public abstract static class Builder<RequestT, ResponseT> extends UnaryApiCallSettings.Builder {
+  public abstract static class Builder<RequestT, ResponseT> extends UnaryCallSettings.Builder {
     private MethodDescriptor<RequestT, ResponseT> grpcMethodDescriptor;
 
     protected Builder(MethodDescriptor<RequestT, ResponseT> grpcMethodDescriptor) {
       this.grpcMethodDescriptor = grpcMethodDescriptor;
     }
 
-    protected Builder(UnaryApiCallSettingsTyped<RequestT, ResponseT> settings) {
+    protected Builder(UnaryCallSettingsTyped<RequestT, ResponseT> settings) {
       super(settings);
       this.grpcMethodDescriptor = settings.getMethodDescriptor();
     }
@@ -101,6 +101,6 @@ abstract class UnaryApiCallSettingsTyped<RequestT, ResponseT> extends UnaryApiCa
     }
 
     @Override
-    public abstract UnaryApiCallSettingsTyped<RequestT, ResponseT> build();
+    public abstract UnaryCallSettingsTyped<RequestT, ResponseT> build();
   }
 }

--- a/src/main/java/com/google/api/gax/grpc/UnaryCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/UnaryCallable.java
@@ -146,36 +146,35 @@ public final class UnaryCallable<RequestT, ResponseT> {
    * Create a paged callable object that represents a page-streaming API method. Public only for
    * technical reasons - for advanced usage
    *
-   * @param pageStreamingCallSettings {@link com.google.api.gax.grpc.PageStreamingCallSettings} to
-   *     configure the page-streaming related settings with.
+   * @param PagedCallSettings {@link com.google.api.gax.grpc.PagedCallSettings} to configure the
+   *     page-streaming related settings with.
    * @param channel {@link ManagedChannel} to use to connect to the service.
    * @param executor {@link ScheduledExecutorService} to use to when connecting to the service.
    * @return {@link com.google.api.gax.grpc.UnaryCallable} callable object.
    */
   public static <RequestT, ResponseT, PagedListResponseT>
       UnaryCallable<RequestT, PagedListResponseT> createPagedVariant(
-          PageStreamingCallSettings<RequestT, ResponseT, PagedListResponseT>
-              pageStreamingCallSettings,
+          PagedCallSettings<RequestT, ResponseT, PagedListResponseT> PagedCallSettings,
           ManagedChannel channel,
           ScheduledExecutorService executor) {
-    return pageStreamingCallSettings.createPagedVariant(channel, executor);
+    return PagedCallSettings.createPagedVariant(channel, executor);
   }
 
   /**
    * Create a base callable object that represents a page-streaming API method. Public only for
    * technical reasons - for advanced usage
    *
-   * @param pageStreamingCallSettings {@link com.google.api.gax.grpc.PageStreamingCallSettings} to
-   *     configure the page-streaming related settings with.
+   * @param PagedCallSettings {@link com.google.api.gax.grpc.PagedCallSettings} to configure the
+   *     page-streaming related settings with.
    * @param channel {@link ManagedChannel} to use to connect to the service.
    * @param executor {@link ScheduledExecutorService} to use to when connecting to the service.
    * @return {@link com.google.api.gax.grpc.UnaryCallable} callable object.
    */
   public static <RequestT, ResponseT, PagedListResponseT> UnaryCallable<RequestT, ResponseT> create(
-      PageStreamingCallSettings<RequestT, ResponseT, PagedListResponseT> pageStreamingCallSettings,
+      PagedCallSettings<RequestT, ResponseT, PagedListResponseT> PagedCallSettings,
       ManagedChannel channel,
       ScheduledExecutorService executor) {
-    return pageStreamingCallSettings.create(channel, executor);
+    return PagedCallSettings.create(channel, executor);
   }
 
   /**
@@ -361,7 +360,7 @@ public final class UnaryCallable<RequestT, ResponseT> {
   <PagedListResponseT> UnaryCallable<RequestT, PagedListResponseT> pageStreaming(
       PagedListResponseFactory<RequestT, ResponseT, PagedListResponseT> pagedListResponseFactory) {
     return new UnaryCallable<>(
-        new PageStreamingCallable<>(callable, pagedListResponseFactory), channel, settings);
+        new PagedCallable<>(callable, pagedListResponseFactory), channel, settings);
   }
 
   /**

--- a/src/main/java/com/google/api/gax/grpc/UnaryCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/UnaryCallable.java
@@ -43,7 +43,6 @@ import io.grpc.Channel;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -51,36 +50,36 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
- * A UnaryApiCallable is an immutable object which is capable of making RPC calls to non-streaming
- * API methods.
+ * A UnaryCallable is an immutable object which is capable of making RPC calls to non-streaming API
+ * methods.
  *
  * <p>Whereas java.util.concurrent.Callable encapsulates all of the data necessary for a call,
- * UnaryApiCallable allows incremental addition of inputs, configuration, and behavior through
+ * UnaryCallable allows incremental addition of inputs, configuration, and behavior through
  * decoration. In typical usage, the request to send to the remote service will not be bound to the
- * UnaryApiCallable, but instead is provided at call time, which allows for a UnaryApiCallable to be
- * saved and used indefinitely.
+ * UnaryCallable, but instead is provided at call time, which allows for a UnaryCallable to be saved
+ * and used indefinitely.
  *
  * <p>The order of decoration matters. For example, if retrying is added before page streaming, then
  * RPC failures will only cause a retry of the failed RPC; if retrying is added after page
  * streaming, then a failure will cause the whole page stream to be retried.
  *
- * <p>As an alternative to creating a UnaryApiCallable through decoration, all of the decorative
- * behavior of a UnaryApiCallable can be specified by using ApiCallSettings. This allows for the
- * inputs and configuration to be provided in any order, and the final UnaryApiCallable is built
- * through decoration in a predefined order.
+ * <p>As an alternative to creating a UnaryCallable through decoration, all of the decorative
+ * behavior of a UnaryCallable can be specified by using ApiCallSettings. This allows for the inputs
+ * and configuration to be provided in any order, and the final UnaryCallable is built through
+ * decoration in a predefined order.
  *
- * <p>It is considered advanced usage for a user to create a UnaryApiCallable themselves. This class
- * is intended to be created by a generated service API wrapper class, and configured by instances
- * of ApiCallSettings.Builder which are exposed through the API wrapper class's settings class.
+ * <p>It is considered advanced usage for a user to create a UnaryCallable themselves. This class is
+ * intended to be created by a generated service API wrapper class, and configured by instances of
+ * ApiCallSettings.Builder which are exposed through the API wrapper class's settings class.
  *
- * <p>There are two styles of calls that can be made through a UnaryApiCallable: synchronous and
+ * <p>There are two styles of calls that can be made through a UnaryCallable: synchronous and
  * asynchronous.
  *
  * <p>Synchronous example:
  *
  * <pre>{@code
  * RequestType request = RequestType.newBuilder().build();
- * UnaryApiCallable<RequestType, ResponseType> apiCallable = api.doSomethingCallable();
+ * UnaryCallable<RequestType, ResponseType> apiCallable = api.doSomethingCallable();
  * ResponseType response = apiCallable.call();
  * }</pre>
  *
@@ -88,14 +87,14 @@ import javax.annotation.Nullable;
  *
  * <pre>{@code
  * RequestType request = RequestType.newBuilder().build();
- * UnaryApiCallable<RequestType, ResponseType> apiCallable = api.doSomethingCallable();
+ * UnaryCallable<RequestType, ResponseType> apiCallable = api.doSomethingCallable();
  * ListenableFuture<ResponseType> resultFuture = apiCallable.futureCall();
  * // do other work
  * // ...
  * ResponseType response = resultFuture.get();
  * }</pre>
  */
-public final class UnaryApiCallable<RequestT, ResponseT> {
+public final class UnaryCallable<RequestT, ResponseT> {
 
   interface Scheduler {
     ScheduledFuture<?> schedule(Runnable runnable, long delay, TimeUnit unit);
@@ -124,7 +123,7 @@ public final class UnaryApiCallable<RequestT, ResponseT> {
   private final FutureCallable<RequestT, ResponseT> callable;
   private final Channel channel;
 
-  @Nullable private final UnaryApiCallSettings settings;
+  @Nullable private final UnaryCallSettings settings;
 
   /**
    * Create a callable object that represents a simple API method. Public only for technical reasons
@@ -134,9 +133,9 @@ public final class UnaryApiCallable<RequestT, ResponseT> {
    *     method-level settings with.
    * @param channel {@link ManagedChannel} to use to connect to the service.
    * @param executor {@link ScheduledExecutorService} to use when connecting to the service.
-   * @return {@link com.google.api.gax.grpc.UnaryApiCallable} callable object.
+   * @return {@link com.google.api.gax.grpc.UnaryCallable} callable object.
    */
-  public static <RequestT, ResponseT> UnaryApiCallable<RequestT, ResponseT> create(
+  public static <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> create(
       SimpleCallSettings<RequestT, ResponseT> simpleCallSettings,
       ManagedChannel channel,
       ScheduledExecutorService executor) {
@@ -151,10 +150,10 @@ public final class UnaryApiCallable<RequestT, ResponseT> {
    *     configure the page-streaming related settings with.
    * @param channel {@link ManagedChannel} to use to connect to the service.
    * @param executor {@link ScheduledExecutorService} to use to when connecting to the service.
-   * @return {@link com.google.api.gax.grpc.UnaryApiCallable} callable object.
+   * @return {@link com.google.api.gax.grpc.UnaryCallable} callable object.
    */
   public static <RequestT, ResponseT, PagedListResponseT>
-      UnaryApiCallable<RequestT, PagedListResponseT> createPagedVariant(
+      UnaryCallable<RequestT, PagedListResponseT> createPagedVariant(
           PageStreamingCallSettings<RequestT, ResponseT, PagedListResponseT>
               pageStreamingCallSettings,
           ManagedChannel channel,
@@ -170,14 +169,12 @@ public final class UnaryApiCallable<RequestT, ResponseT> {
    *     configure the page-streaming related settings with.
    * @param channel {@link ManagedChannel} to use to connect to the service.
    * @param executor {@link ScheduledExecutorService} to use to when connecting to the service.
-   * @return {@link com.google.api.gax.grpc.UnaryApiCallable} callable object.
+   * @return {@link com.google.api.gax.grpc.UnaryCallable} callable object.
    */
-  public static <RequestT, ResponseT, PagedListResponseT>
-      UnaryApiCallable<RequestT, ResponseT> create(
-          PageStreamingCallSettings<RequestT, ResponseT, PagedListResponseT>
-              pageStreamingCallSettings,
-          ManagedChannel channel,
-          ScheduledExecutorService executor) {
+  public static <RequestT, ResponseT, PagedListResponseT> UnaryCallable<RequestT, ResponseT> create(
+      PageStreamingCallSettings<RequestT, ResponseT, PagedListResponseT> pageStreamingCallSettings,
+      ManagedChannel channel,
+      ScheduledExecutorService executor) {
     return pageStreamingCallSettings.create(channel, executor);
   }
 
@@ -189,9 +186,9 @@ public final class UnaryApiCallable<RequestT, ResponseT> {
    *     bundling related settings with.
    * @param channel {@link ManagedChannel} to use to connect to the service.
    * @param executor {@link ScheduledExecutorService} to use to when connecting to the service.
-   * @return {@link com.google.api.gax.grpc.UnaryApiCallable} callable object.
+   * @return {@link com.google.api.gax.grpc.UnaryCallable} callable object.
    */
-  public static <RequestT, ResponseT> UnaryApiCallable<RequestT, ResponseT> create(
+  public static <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> create(
       BundlingCallSettings<RequestT, ResponseT> bundlingCallSettings,
       ManagedChannel channel,
       ScheduledExecutorService executor) {
@@ -202,34 +199,32 @@ public final class UnaryApiCallable<RequestT, ResponseT> {
    * Creates a callable object which uses the given {@link FutureCallable}.
    *
    * @param futureCallable {@link FutureCallable} to wrap the bundling related settings with.
-   * @return {@link com.google.api.gax.grpc.UnaryApiCallable} callable object.
+   * @return {@link com.google.api.gax.grpc.UnaryCallable} callable object.
    *     <p>Package-private for internal usage.
    */
-  static <ReqT, RespT> UnaryApiCallable<ReqT, RespT> create(
+  static <ReqT, RespT> UnaryCallable<ReqT, RespT> create(
       FutureCallable<ReqT, RespT> futureCallable) {
-    return new UnaryApiCallable<>(futureCallable);
+    return new UnaryCallable<>(futureCallable);
   }
 
   /**
-   * Returns the {@link UnaryApiCallSettings} that contains the configuration settings of this
-   * UnaryApiCallable.
+   * Returns the {@link UnaryCallSettings} that contains the configuration settings of this
+   * UnaryCallable.
    */
-  public UnaryApiCallSettings getSettings() {
+  public UnaryCallSettings getSettings() {
     return settings;
   }
 
   /** Package-private for internal use. */
-  UnaryApiCallable(
-      FutureCallable<RequestT, ResponseT> callable,
-      Channel channel,
-      UnaryApiCallSettings settings) {
+  UnaryCallable(
+      FutureCallable<RequestT, ResponseT> callable, Channel channel, UnaryCallSettings settings) {
     this.callable = Preconditions.checkNotNull(callable);
     this.channel = channel;
     this.settings = settings;
   }
 
   /** Package-private for internal use. */
-  UnaryApiCallable(FutureCallable<RequestT, ResponseT> callable) {
+  UnaryCallable(FutureCallable<RequestT, ResponseT> callable) {
     this(callable, null, null);
   }
 
@@ -310,8 +305,8 @@ public final class UnaryApiCallable<RequestT, ResponseT> {
    *
    * <p>Package-private for internal use.
    */
-  UnaryApiCallable<RequestT, ResponseT> bind(Channel boundChannel) {
-    return new UnaryApiCallable<>(callable, boundChannel, settings);
+  UnaryCallable<RequestT, ResponseT> bind(Channel boundChannel) {
+    return new UnaryCallable<>(callable, boundChannel, settings);
   }
 
   /**
@@ -319,13 +314,13 @@ public final class UnaryApiCallable<RequestT, ResponseT> {
    * io.grpc.StatusRuntimeException}. The {@link ApiException} will consider failures with any of
    * the given status codes retryable.
    *
-   * <p>This decoration must be added to a UnaryApiCallable before the "retrying" decoration which
-   * will retry these codes.
+   * <p>This decoration must be added to a UnaryCallable before the "retrying" decoration which will
+   * retry these codes.
    *
    * <p>Package-private for internal use.
    */
-  UnaryApiCallable<RequestT, ResponseT> retryableOn(ImmutableSet<Status.Code> retryableCodes) {
-    return new UnaryApiCallable<>(
+  UnaryCallable<RequestT, ResponseT> retryableOn(ImmutableSet<Status.Code> retryableCodes) {
+    return new UnaryCallable<>(
         new ExceptionTransformingCallable<>(callable, retryableCodes), channel, settings);
   }
 
@@ -333,12 +328,12 @@ public final class UnaryApiCallable<RequestT, ResponseT> {
    * Creates a callable which retries using exponential back-off. Back-off parameters are defined by
    * the given {@code retrySettings}.
    *
-   * <p>This decoration will only retry if the UnaryApiCallable has already been decorated with
+   * <p>This decoration will only retry if the UnaryCallable has already been decorated with
    * "retryableOn" so that it throws an ApiException for the right codes.
    *
    * <p>Package-private for internal use.
    */
-  UnaryApiCallable<RequestT, ResponseT> retrying(
+  UnaryCallable<RequestT, ResponseT> retrying(
       RetrySettings retrySettings, ScheduledExecutorService executor) {
     return retrying(retrySettings, new DelegatingScheduler(executor), DefaultNanoClock.create());
   }
@@ -351,9 +346,9 @@ public final class UnaryApiCallable<RequestT, ResponseT> {
    * <p>Package-private for internal use.
    */
   @VisibleForTesting
-  UnaryApiCallable<RequestT, ResponseT> retrying(
+  UnaryCallable<RequestT, ResponseT> retrying(
       RetrySettings retrySettings, Scheduler executor, NanoClock clock) {
-    return new UnaryApiCallable<>(
+    return new UnaryCallable<>(
         new RetryingCallable<>(callable, retrySettings, executor, clock), channel, settings);
   }
 
@@ -363,9 +358,9 @@ public final class UnaryApiCallable<RequestT, ResponseT> {
    *
    * <p>Package-private for internal use.
    */
-  <PagedListResponseT> UnaryApiCallable<RequestT, PagedListResponseT> pageStreaming(
+  <PagedListResponseT> UnaryCallable<RequestT, PagedListResponseT> pageStreaming(
       PagedListResponseFactory<RequestT, ResponseT, PagedListResponseT> pagedListResponseFactory) {
-    return new UnaryApiCallable<>(
+    return new UnaryCallable<>(
         new PageStreamingCallable<>(callable, pagedListResponseFactory), channel, settings);
   }
 
@@ -375,10 +370,10 @@ public final class UnaryApiCallable<RequestT, ResponseT> {
    *
    * <p>Package-private for internal use.
    */
-  UnaryApiCallable<RequestT, ResponseT> bundling(
+  UnaryCallable<RequestT, ResponseT> bundling(
       BundlingDescriptor<RequestT, ResponseT> bundlingDescriptor,
       BundlerFactory<RequestT, ResponseT> bundlerFactory) {
-    return new UnaryApiCallable<>(
+    return new UnaryCallable<>(
         new BundlingCallable<>(callable, bundlingDescriptor, bundlerFactory), channel, settings);
   }
 }

--- a/src/main/java/com/google/api/gax/grpc/UnaryCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/UnaryCallable.java
@@ -59,18 +59,18 @@ import javax.annotation.Nullable;
  * UnaryCallable, but instead is provided at call time, which allows for a UnaryCallable to be saved
  * and used indefinitely.
  *
- * <p>The order of decoration matters. For example, if retrying is added before page streaming, then
- * RPC failures will only cause a retry of the failed RPC; if retrying is added after page
- * streaming, then a failure will cause the whole page stream to be retried.
+ * <p>The order of decoration matters. For example, if RetryingCallable is added before
+ * PagedCallable, then RPC failures will only cause a retry of the failed RPC; if RetryingCallable
+ * is added after PagedCallable, then a failure will cause the whole page stream to be retried.
  *
  * <p>As an alternative to creating a UnaryCallable through decoration, all of the decorative
- * behavior of a UnaryCallable can be specified by using ApiCallSettings. This allows for the inputs
- * and configuration to be provided in any order, and the final UnaryCallable is built through
- * decoration in a predefined order.
+ * behavior of a UnaryCallable can be specified by using UnaryCallSettings. This allows for the
+ * inputs and configuration to be provided in any order, and the final UnaryCallable is built
+ * through decoration in a predefined order.
  *
  * <p>It is considered advanced usage for a user to create a UnaryCallable themselves. This class is
  * intended to be created by a generated service API wrapper class, and configured by instances of
- * ApiCallSettings.Builder which are exposed through the API wrapper class's settings class.
+ * UnaryCallSettings.Builder which are exposed through the API wrapper class's settings class.
  *
  * <p>There are two styles of calls that can be made through a UnaryCallable: synchronous and
  * asynchronous.
@@ -79,16 +79,16 @@ import javax.annotation.Nullable;
  *
  * <pre>{@code
  * RequestType request = RequestType.newBuilder().build();
- * UnaryCallable<RequestType, ResponseType> apiCallable = api.doSomethingCallable();
- * ResponseType response = apiCallable.call();
+ * UnaryCallable<RequestType, ResponseType> unaryCallable = api.doSomethingCallable();
+ * ResponseType response = unaryCallable.call();
  * }</pre>
  *
  * <p>Asynchronous example:
  *
  * <pre>{@code
  * RequestType request = RequestType.newBuilder().build();
- * UnaryCallable<RequestType, ResponseType> apiCallable = api.doSomethingCallable();
- * ListenableFuture<ResponseType> resultFuture = apiCallable.futureCall();
+ * UnaryCallable<RequestType, ResponseType> unaryCallable = api.doSomethingCallable();
+ * ListenableFuture<ResponseType> resultFuture = unaryCallable.futureCall();
  * // do other work
  * // ...
  * ResponseType response = resultFuture.get();
@@ -143,11 +143,11 @@ public final class UnaryCallable<RequestT, ResponseT> {
   }
 
   /**
-   * Create a paged callable object that represents a page-streaming API method. Public only for
+   * Create a paged callable object that represents a paged API method. Public only for
    * technical reasons - for advanced usage
    *
    * @param PagedCallSettings {@link com.google.api.gax.grpc.PagedCallSettings} to configure the
-   *     page-streaming related settings with.
+   *     paged settings with.
    * @param channel {@link ManagedChannel} to use to connect to the service.
    * @param executor {@link ScheduledExecutorService} to use to when connecting to the service.
    * @return {@link com.google.api.gax.grpc.UnaryCallable} callable object.
@@ -161,11 +161,11 @@ public final class UnaryCallable<RequestT, ResponseT> {
   }
 
   /**
-   * Create a base callable object that represents a page-streaming API method. Public only for
+   * Create a base callable object that represents a paged API method. Public only for
    * technical reasons - for advanced usage
    *
    * @param PagedCallSettings {@link com.google.api.gax.grpc.PagedCallSettings} to configure the
-   *     page-streaming related settings with.
+   *     paged settings with.
    * @param channel {@link ManagedChannel} to use to connect to the service.
    * @param executor {@link ScheduledExecutorService} to use to when connecting to the service.
    * @return {@link com.google.api.gax.grpc.UnaryCallable} callable object.
@@ -353,11 +353,11 @@ public final class UnaryCallable<RequestT, ResponseT> {
 
   /**
    * Returns a callable which streams the resources obtained from a series of calls to a method
-   * implementing the page streaming pattern.
+   * implementing the paged pattern.
    *
    * <p>Package-private for internal use.
    */
-  <PagedListResponseT> UnaryCallable<RequestT, PagedListResponseT> pageStreaming(
+  <PagedListResponseT> UnaryCallable<RequestT, PagedListResponseT> paged(
       PagedListResponseFactory<RequestT, ResponseT, PagedListResponseT> pagedListResponseFactory) {
     return new UnaryCallable<>(
         new PagedCallable<>(callable, pagedListResponseFactory), channel, settings);

--- a/src/test/java/com/google/api/gax/grpc/CancellationTest.java
+++ b/src/test/java/com/google/api/gax/grpc/CancellationTest.java
@@ -31,7 +31,7 @@
 package com.google.api.gax.grpc;
 
 import com.google.api.gax.core.RetrySettings;
-import com.google.api.gax.grpc.UnaryApiCallable.Scheduler;
+import com.google.api.gax.grpc.UnaryCallable.Scheduler;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.truth.Truth;
@@ -110,8 +110,8 @@ public class CancellationTest {
         .thenReturn(SettableFuture.<Integer>create());
 
     ImmutableSet<Status.Code> retryable = ImmutableSet.<Status.Code>of(Status.Code.UNAVAILABLE);
-    UnaryApiCallable<Integer, Integer> callable =
-        UnaryApiCallable.<Integer, Integer>create(callInt)
+    UnaryCallable<Integer, Integer> callable =
+        UnaryCallable.<Integer, Integer>create(callInt)
             .retryableOn(retryable)
             .retrying(FAST_RETRY_SETTINGS, executor, fakeClock);
 
@@ -120,7 +120,7 @@ public class CancellationTest {
     resultFuture.get();
   }
 
-  private static class LatchCountDownScheduler implements UnaryApiCallable.Scheduler {
+  private static class LatchCountDownScheduler implements UnaryCallable.Scheduler {
     private final ScheduledExecutorService executor;
     private final CountDownLatch latch;
 
@@ -210,12 +210,12 @@ public class CancellationTest {
         new LatchCountDownFutureCallable<Integer, Integer>(callIssuedLatch, innerFuture);
 
     ImmutableSet<Status.Code> retryable = ImmutableSet.<Status.Code>of(Status.Code.UNAVAILABLE);
-    UnaryApiCallable<Integer, Integer> callable =
-        UnaryApiCallable.<Integer, Integer>create(innerCallable)
+    UnaryCallable<Integer, Integer> callable =
+        UnaryCallable.<Integer, Integer>create(innerCallable)
             .retryableOn(retryable)
             .retrying(
                 FAST_RETRY_SETTINGS,
-                new UnaryApiCallable.DelegatingScheduler(new ScheduledThreadPoolExecutor(1)),
+                new UnaryCallable.DelegatingScheduler(new ScheduledThreadPoolExecutor(1)),
                 fakeClock);
 
     ListenableFuture<Integer> resultFuture = callable.futureCall(0);
@@ -241,8 +241,8 @@ public class CancellationTest {
     CountDownLatch retryScheduledLatch = new CountDownLatch(1);
     Scheduler scheduler = new LatchCountDownScheduler(retryScheduledLatch);
     ImmutableSet<Status.Code> retryable = ImmutableSet.<Status.Code>of(Status.Code.UNAVAILABLE);
-    UnaryApiCallable<Integer, Integer> callable =
-        UnaryApiCallable.<Integer, Integer>create(callInt)
+    UnaryCallable<Integer, Integer> callable =
+        UnaryCallable.<Integer, Integer>create(callInt)
             .retryableOn(retryable)
             .retrying(SLOW_RETRY_SETTINGS, scheduler, fakeClock);
 
@@ -271,12 +271,12 @@ public class CancellationTest {
             Lists.<ListenableFuture<Integer>>newArrayList(failingFuture, innerFuture));
 
     ImmutableSet<Status.Code> retryable = ImmutableSet.<Status.Code>of(Status.Code.UNAVAILABLE);
-    UnaryApiCallable<Integer, Integer> callable =
-        UnaryApiCallable.<Integer, Integer>create(innerCallable)
+    UnaryCallable<Integer, Integer> callable =
+        UnaryCallable.<Integer, Integer>create(innerCallable)
             .retryableOn(retryable)
             .retrying(
                 FAST_RETRY_SETTINGS,
-                new UnaryApiCallable.DelegatingScheduler(new ScheduledThreadPoolExecutor(1)),
+                new UnaryCallable.DelegatingScheduler(new ScheduledThreadPoolExecutor(1)),
                 fakeClock);
 
     ListenableFuture<Integer> resultFuture = callable.futureCall(0);

--- a/src/test/java/com/google/api/gax/grpc/RecordingScheduler.java
+++ b/src/test/java/com/google/api/gax/grpc/RecordingScheduler.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.joda.time.Duration;
 
-class RecordingScheduler implements UnaryApiCallable.Scheduler {
+class RecordingScheduler implements UnaryCallable.Scheduler {
   private final ScheduledExecutorService executor;
   private final List<Duration> sleepDurations = new ArrayList<>();
   private final FakeNanoClock clock;

--- a/src/test/java/com/google/api/gax/grpc/SettingsTest.java
+++ b/src/test/java/com/google/api/gax/grpc/SettingsTest.java
@@ -56,9 +56,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
-/**
- * Tests for {@link ServiceApiSettings}.
- */
+/** Tests for {@link ServiceApiSettings}. */
 @RunWith(JUnit4.class)
 public class SettingsTest {
 
@@ -126,7 +124,7 @@ public class SettingsTest {
     }
 
     private final SimpleCallSettings<Integer, Integer> fakeMethodSimple;
-    private final PageStreamingCallSettings<Integer, Integer, FakePagedListResponse>
+    private final PagedCallSettings<Integer, Integer, FakePagedListResponse>
         fakeMethodPageStreaming;
     private final BundlingCallSettings<Integer, Integer> fakeMethodBundling;
 
@@ -134,8 +132,7 @@ public class SettingsTest {
       return fakeMethodSimple;
     }
 
-    public PageStreamingCallSettings<Integer, Integer, FakePagedListResponse>
-        fakeMethodPageStreaming() {
+    public PagedCallSettings<Integer, Integer, FakePagedListResponse> fakeMethodPageStreaming() {
       return fakeMethodPageStreaming;
     }
 
@@ -168,7 +165,7 @@ public class SettingsTest {
     private static class Builder extends ServiceApiSettings.Builder {
 
       private SimpleCallSettings.Builder<Integer, Integer> fakeMethodSimple;
-      private PageStreamingCallSettings.Builder<Integer, Integer, FakePagedListResponse>
+      private PagedCallSettings.Builder<Integer, Integer, FakePagedListResponse>
           fakeMethodPageStreaming;
       private BundlingCallSettings.Builder<Integer, Integer> fakeMethodBundling;
 
@@ -177,8 +174,7 @@ public class SettingsTest {
 
         fakeMethodSimple = SimpleCallSettings.newBuilder(fakeMethodMethodDescriptor);
         fakeMethodPageStreaming =
-            PageStreamingCallSettings.newBuilder(
-                fakeMethodMethodDescriptor, fakePagedListResponseFactory);
+            PagedCallSettings.newBuilder(fakeMethodMethodDescriptor, fakePagedListResponseFactory);
         fakeMethodBundling =
             BundlingCallSettings.newBuilder(fakeMethodMethodDescriptor, fakeBundlingDescriptor)
                 .setBundlingSettingsBuilder(BundlingSettings.newBuilder());
@@ -266,7 +262,7 @@ public class SettingsTest {
         return fakeMethodSimple;
       }
 
-      public PageStreamingCallSettings.Builder<Integer, Integer, FakePagedListResponse>
+      public PagedCallSettings.Builder<Integer, Integer, FakePagedListResponse>
           fakeMethodPageStreaming() {
         return fakeMethodPageStreaming;
       }

--- a/src/test/java/com/google/api/gax/grpc/SettingsTest.java
+++ b/src/test/java/com/google/api/gax/grpc/SettingsTest.java
@@ -529,7 +529,7 @@ public class SettingsTest {
   }
 
   private static void assertIsReflectionEqual(
-      UnaryApiCallSettings.Builder builderA, UnaryApiCallSettings.Builder builderB) {
+      UnaryCallSettings.Builder builderA, UnaryCallSettings.Builder builderB) {
     assertIsReflectionEqual(builderA, builderB, new String[] {"retrySettingsBuilder"});
     assertIsReflectionEqual(builderA.getRetrySettingsBuilder(), builderB.getRetrySettingsBuilder());
   }

--- a/src/test/java/com/google/api/gax/grpc/SettingsTest.java
+++ b/src/test/java/com/google/api/gax/grpc/SettingsTest.java
@@ -124,16 +124,15 @@ public class SettingsTest {
     }
 
     private final SimpleCallSettings<Integer, Integer> fakeMethodSimple;
-    private final PagedCallSettings<Integer, Integer, FakePagedListResponse>
-        fakeMethodPageStreaming;
+    private final PagedCallSettings<Integer, Integer, FakePagedListResponse> fakePagedMethod;
     private final BundlingCallSettings<Integer, Integer> fakeMethodBundling;
 
     public SimpleCallSettings<Integer, Integer> fakeMethodSimple() {
       return fakeMethodSimple;
     }
 
-    public PagedCallSettings<Integer, Integer, FakePagedListResponse> fakeMethodPageStreaming() {
-      return fakeMethodPageStreaming;
+    public PagedCallSettings<Integer, Integer, FakePagedListResponse> fakePagedMethod() {
+      return fakePagedMethod;
     }
 
     public BundlingCallSettings<Integer, Integer> fakeMethodBundling() {
@@ -158,22 +157,21 @@ public class SettingsTest {
           settingsBuilder.getClientLibVersion());
 
       this.fakeMethodSimple = settingsBuilder.fakeMethodSimple().build();
-      this.fakeMethodPageStreaming = settingsBuilder.fakeMethodPageStreaming().build();
+      this.fakePagedMethod = settingsBuilder.fakePagedMethod().build();
       this.fakeMethodBundling = settingsBuilder.fakeMethodBundling().build();
     }
 
     private static class Builder extends ServiceApiSettings.Builder {
 
       private SimpleCallSettings.Builder<Integer, Integer> fakeMethodSimple;
-      private PagedCallSettings.Builder<Integer, Integer, FakePagedListResponse>
-          fakeMethodPageStreaming;
+      private PagedCallSettings.Builder<Integer, Integer, FakePagedListResponse> fakePagedMethod;
       private BundlingCallSettings.Builder<Integer, Integer> fakeMethodBundling;
 
       private Builder() {
         super(DEFAULT_CONNECTION_SETTINGS);
 
         fakeMethodSimple = SimpleCallSettings.newBuilder(fakeMethodMethodDescriptor);
-        fakeMethodPageStreaming =
+        fakePagedMethod =
             PagedCallSettings.newBuilder(fakeMethodMethodDescriptor, fakePagedListResponseFactory);
         fakeMethodBundling =
             BundlingCallSettings.newBuilder(fakeMethodMethodDescriptor, fakeBundlingDescriptor)
@@ -188,7 +186,7 @@ public class SettingsTest {
             .setRetrySettingsBuilder(RETRY_PARAM_DEFINITIONS.get("default"));
 
         builder
-            .fakeMethodPageStreaming()
+            .fakePagedMethod()
             .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
             .setRetrySettingsBuilder(RETRY_PARAM_DEFINITIONS.get("default"));
 
@@ -213,7 +211,7 @@ public class SettingsTest {
         super(settings);
 
         fakeMethodSimple = settings.fakeMethodSimple().toBuilder();
-        fakeMethodPageStreaming = settings.fakeMethodPageStreaming().toBuilder();
+        fakePagedMethod = settings.fakePagedMethod().toBuilder();
         fakeMethodBundling = settings.fakeMethodBundling().toBuilder();
       }
 
@@ -262,9 +260,8 @@ public class SettingsTest {
         return fakeMethodSimple;
       }
 
-      public PagedCallSettings.Builder<Integer, Integer, FakePagedListResponse>
-          fakeMethodPageStreaming() {
-        return fakeMethodPageStreaming;
+      public PagedCallSettings.Builder<Integer, Integer, FakePagedListResponse> fakePagedMethod() {
+        return fakePagedMethod;
       }
 
       public BundlingCallSettings.Builder<Integer, Integer> fakeMethodBundling() {
@@ -392,7 +389,7 @@ public class SettingsTest {
     Truth.assertThat(executorA).isEqualTo(executorB);
   }
 
-  //ApiCallSettings
+  // CallSettings
   // ====
 
   @Test
@@ -493,13 +490,13 @@ public class SettingsTest {
         settingsB,
         new String[] {
           "fakeMethodSimple",
-          "fakeMethodPageStreaming",
+          "fakePagedMethod",
           "fakeMethodBundling",
           "channelProvider",
           "executorProvider"
         });
     assertIsReflectionEqual(settingsA.fakeMethodSimple, settingsB.fakeMethodSimple);
-    assertIsReflectionEqual(settingsA.fakeMethodPageStreaming, settingsB.fakeMethodPageStreaming);
+    assertIsReflectionEqual(settingsA.fakePagedMethod, settingsB.fakePagedMethod);
     assertIsReflectionEqual(settingsA.fakeMethodBundling, settingsB.fakeMethodBundling);
     assertIsReflectionEqual(settingsA.getChannelProvider(), settingsB.getChannelProvider());
     assertIsReflectionEqual(settingsA.getExecutorProvider(), settingsB.getExecutorProvider());
@@ -512,13 +509,13 @@ public class SettingsTest {
         builderB,
         new String[] {
           "fakeMethodSimple",
-          "fakeMethodPageStreaming",
+          "fakePagedMethod",
           "fakeMethodBundling",
           "channelProvider",
           "executorProvider"
         });
     assertIsReflectionEqual(builderA.fakeMethodSimple, builderB.fakeMethodSimple);
-    assertIsReflectionEqual(builderA.fakeMethodPageStreaming, builderB.fakeMethodPageStreaming);
+    assertIsReflectionEqual(builderA.fakePagedMethod, builderB.fakePagedMethod);
     assertIsReflectionEqual(builderA.fakeMethodBundling, builderB.fakeMethodBundling);
     assertIsReflectionEqual(builderA.getChannelProvider(), builderB.getChannelProvider());
     assertIsReflectionEqual(builderA.getExecutorProvider(), builderB.getExecutorProvider());

--- a/src/test/java/com/google/api/gax/grpc/StreamingCallableTest.java
+++ b/src/test/java/com/google/api/gax/grpc/StreamingCallableTest.java
@@ -31,28 +31,25 @@
 package com.google.api.gax.grpc;
 
 import com.google.common.truth.Truth;
-
+import io.grpc.CallOptions;
+import io.grpc.ManagedChannel;
+import io.grpc.MethodDescriptor;
+import io.grpc.stub.StreamObserver;
+import java.util.Iterator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
-import io.grpc.CallOptions;
-import io.grpc.ManagedChannel;
-import io.grpc.MethodDescriptor;
-import io.grpc.stub.StreamObserver;
-
-import java.util.Iterator;
-
 @RunWith(JUnit4.class)
-public class StreamingApiCallableTest {
+public class StreamingCallableTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testChannelBinding() {
     ManagedChannel channel = Mockito.mock(ManagedChannel.class);
     ClientCallFactory<Integer, Integer> factory = Mockito.mock(ClientCallFactory.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(factory);
-    StreamingApiCallable<Integer, Integer> apiCallable = new StreamingApiCallable<>(stash);
+    StreamingCallable<Integer, Integer> apiCallable = new StreamingCallable<>(stash);
     apiCallable.bind(channel);
     StreamObserver<Integer> observer = Mockito.mock(StreamObserver.class);
     apiCallable.bidiStreamingCall(observer);
@@ -66,8 +63,7 @@ public class StreamingApiCallableTest {
     ManagedChannel channel = Mockito.mock(ManagedChannel.class);
     StreamingCallSettings<Integer, Integer> settings =
         StreamingCallSettings.newBuilder(methodDescriptor).build();
-    StreamingApiCallable<Integer, Integer> apiCallable =
-        settings.createStreamingApiCallable(channel);
+    StreamingCallable<Integer, Integer> apiCallable = settings.createStreamingCallable(channel);
     Truth.assertThat(apiCallable.getChannel()).isSameAs(channel);
   }
 
@@ -77,7 +73,7 @@ public class StreamingApiCallableTest {
     ManagedChannel channel = Mockito.mock(ManagedChannel.class);
     ClientCallFactory<Integer, Integer> factory = Mockito.mock(ClientCallFactory.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(factory);
-    StreamingApiCallable<Integer, Integer> apiCallable = new StreamingApiCallable<>(stash);
+    StreamingCallable<Integer, Integer> apiCallable = new StreamingCallable<>(stash);
     apiCallable.bind(channel);
     StreamObserver<Integer> observer = Mockito.mock(StreamObserver.class);
     apiCallable.bidiStreamingCall(observer);
@@ -91,7 +87,7 @@ public class StreamingApiCallableTest {
     CallContext context = CallContext.of(channel, CallOptions.DEFAULT);
     ClientCallFactory<Integer, Integer> factory = Mockito.mock(ClientCallFactory.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(factory);
-    StreamingApiCallable<Integer, Integer> apiCallable = new StreamingApiCallable<>(stash);
+    StreamingCallable<Integer, Integer> apiCallable = new StreamingCallable<>(stash);
     StreamObserver<Integer> observer = Mockito.mock(StreamObserver.class);
     apiCallable.bidiStreamingCall(observer, context);
     Truth.assertThat(stash.actualObserver).isSameAs(observer);
@@ -104,7 +100,7 @@ public class StreamingApiCallableTest {
     ManagedChannel channel = Mockito.mock(ManagedChannel.class);
     ClientCallFactory<Integer, Integer> factory = Mockito.mock(ClientCallFactory.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(factory);
-    StreamingApiCallable<Integer, Integer> apiCallable = new StreamingApiCallable<>(stash);
+    StreamingCallable<Integer, Integer> apiCallable = new StreamingCallable<>(stash);
     apiCallable.bind(channel);
     StreamObserver<Integer> observer = Mockito.mock(StreamObserver.class);
     apiCallable.clientStreamingCall(observer);
@@ -118,7 +114,7 @@ public class StreamingApiCallableTest {
     CallContext context = CallContext.of(channel, CallOptions.DEFAULT);
     ClientCallFactory<Integer, Integer> factory = Mockito.mock(ClientCallFactory.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(factory);
-    StreamingApiCallable<Integer, Integer> apiCallable = new StreamingApiCallable<>(stash);
+    StreamingCallable<Integer, Integer> apiCallable = new StreamingCallable<>(stash);
     StreamObserver<Integer> observer = Mockito.mock(StreamObserver.class);
     apiCallable.clientStreamingCall(observer, context);
     Truth.assertThat(stash.actualObserver).isSameAs(observer);
@@ -131,7 +127,7 @@ public class StreamingApiCallableTest {
     ManagedChannel channel = Mockito.mock(ManagedChannel.class);
     ClientCallFactory<Integer, Integer> factory = Mockito.mock(ClientCallFactory.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(factory);
-    StreamingApiCallable<Integer, Integer> apiCallable = new StreamingApiCallable<>(stash);
+    StreamingCallable<Integer, Integer> apiCallable = new StreamingCallable<>(stash);
     apiCallable.bind(channel);
     StreamObserver<Integer> observer = Mockito.mock(StreamObserver.class);
     Integer request = 1;
@@ -147,7 +143,7 @@ public class StreamingApiCallableTest {
     CallContext context = CallContext.of(channel, CallOptions.DEFAULT);
     ClientCallFactory<Integer, Integer> factory = Mockito.mock(ClientCallFactory.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(factory);
-    StreamingApiCallable<Integer, Integer> apiCallable = new StreamingApiCallable<>(stash);
+    StreamingCallable<Integer, Integer> apiCallable = new StreamingCallable<>(stash);
     StreamObserver<Integer> observer = Mockito.mock(StreamObserver.class);
     Integer request = 1;
     apiCallable.serverStreamingCall(request, observer, context);
@@ -162,7 +158,7 @@ public class StreamingApiCallableTest {
     ManagedChannel channel = Mockito.mock(ManagedChannel.class);
     ClientCallFactory<Integer, Integer> factory = Mockito.mock(ClientCallFactory.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(factory);
-    StreamingApiCallable<Integer, Integer> apiCallable = new StreamingApiCallable<>(stash);
+    StreamingCallable<Integer, Integer> apiCallable = new StreamingCallable<>(stash);
     apiCallable.bind(channel);
     Integer request = 1;
     apiCallable.serverStreamingCall(request);
@@ -176,7 +172,7 @@ public class StreamingApiCallableTest {
     CallContext context = CallContext.of(channel, CallOptions.DEFAULT);
     ClientCallFactory<Integer, Integer> factory = Mockito.mock(ClientCallFactory.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(factory);
-    StreamingApiCallable<Integer, Integer> apiCallable = new StreamingApiCallable<>(stash);
+    StreamingCallable<Integer, Integer> apiCallable = new StreamingCallable<>(stash);
     Integer request = 1;
     apiCallable.serverStreamingCall(request, context);
     Truth.assertThat(stash.actualRequest).isSameAs(request);

--- a/src/test/java/com/google/api/gax/grpc/UnaryCallableTest.java
+++ b/src/test/java/com/google/api/gax/grpc/UnaryCallableTest.java
@@ -63,9 +63,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
-/** Tests for {@link UnaryApiCallable}. */
+/** Tests for {@link UnaryCallable}. */
 @RunWith(JUnit4.class)
-public class UnaryApiCallableTest {
+public class UnaryCallableTest {
   @SuppressWarnings("unchecked")
   private FutureCallable<Integer, Integer> callInt = Mockito.mock(FutureCallable.class);
 
@@ -118,7 +118,7 @@ public class UnaryApiCallableTest {
   public void bind() {
     Channel channel = Mockito.mock(Channel.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(0);
-    UnaryApiCallable.<Integer, Integer>create(stash).bind(channel).futureCall(0);
+    UnaryCallable.<Integer, Integer>create(stash).bind(channel).futureCall(0);
     Truth.assertThat(stash.context.getChannel()).isSameAs(channel);
   }
 
@@ -128,8 +128,8 @@ public class UnaryApiCallableTest {
     StashCallable<Integer, Integer> stash = new StashCallable<>(0);
 
     ImmutableSet<Status.Code> retryable = ImmutableSet.<Status.Code>of(Status.Code.UNAVAILABLE);
-    UnaryApiCallable<Integer, Integer> callable =
-        UnaryApiCallable.<Integer, Integer>create(stash)
+    UnaryCallable<Integer, Integer> callable =
+        UnaryCallable.<Integer, Integer>create(stash)
             .bind(channel)
             .retryableOn(retryable)
             .retrying(FAST_RETRY_SETTINGS, executor, fakeClock);
@@ -143,7 +143,7 @@ public class UnaryApiCallableTest {
     StashCallable<Integer, List<Integer>> stash =
         new StashCallable<Integer, List<Integer>>(new ArrayList<Integer>());
 
-    UnaryApiCallable.<Integer, List<Integer>>create(stash)
+    UnaryCallable.<Integer, List<Integer>>create(stash)
         .bind(channel)
         .pageStreaming(new StreamingFactory())
         .call(0);
@@ -203,8 +203,8 @@ public class UnaryApiCallableTest {
       Channel channel = Mockito.mock(Channel.class);
       StashCallable<Integer, List<Integer>> stash =
           new StashCallable<Integer, List<Integer>>(new ArrayList<Integer>());
-      UnaryApiCallable<Integer, List<Integer>> callable =
-          UnaryApiCallable.<Integer, List<Integer>>create(stash)
+      UnaryCallable<Integer, List<Integer>> callable =
+          UnaryCallable.<Integer, List<Integer>>create(stash)
               .bind(channel)
               .bundling(STASH_BUNDLING_DESC, bundlerFactory);
       ListenableFuture<List<Integer>> future = callable.futureCall(0);
@@ -227,8 +227,8 @@ public class UnaryApiCallableTest {
         .thenReturn(Futures.<Integer>immediateFailedFuture(throwable))
         .thenReturn(Futures.<Integer>immediateFailedFuture(throwable))
         .thenReturn(Futures.<Integer>immediateFuture(2));
-    UnaryApiCallable<Integer, Integer> callable =
-        UnaryApiCallable.<Integer, Integer>create(callInt)
+    UnaryCallable<Integer, Integer> callable =
+        UnaryCallable.<Integer, Integer>create(callInt)
             .retryableOn(retryable)
             .retrying(FAST_RETRY_SETTINGS, executor, fakeClock);
     Truth.assertThat(callable.call(1)).isEqualTo(2);
@@ -243,8 +243,8 @@ public class UnaryApiCallableTest {
         .thenReturn(Futures.<Integer>immediateFailedFuture(throwable))
         .thenReturn(Futures.<Integer>immediateFailedFuture(throwable))
         .thenReturn(Futures.<Integer>immediateFuture(2));
-    UnaryApiCallable<Integer, Integer> callable =
-        UnaryApiCallable.<Integer, Integer>create(callInt)
+    UnaryCallable<Integer, Integer> callable =
+        UnaryCallable.<Integer, Integer>create(callInt)
             .retryableOn(retryable)
             .retrying(FAST_RETRY_SETTINGS, executor, fakeClock);
     Truth.assertThat(callable.call(1)).isEqualTo(2);
@@ -258,8 +258,8 @@ public class UnaryApiCallableTest {
     Throwable throwable = new RuntimeException("foobar");
     Mockito.when(callInt.futureCall((Integer) Mockito.any(), (CallContext) Mockito.any()))
         .thenReturn(Futures.<Integer>immediateFailedFuture(throwable));
-    UnaryApiCallable<Integer, Integer> callable =
-        UnaryApiCallable.<Integer, Integer>create(callInt)
+    UnaryCallable<Integer, Integer> callable =
+        UnaryCallable.<Integer, Integer>create(callInt)
             .retryableOn(retryable)
             .retrying(FAST_RETRY_SETTINGS, executor, fakeClock);
     callable.call(1);
@@ -275,8 +275,8 @@ public class UnaryApiCallableTest {
             Futures.<Integer>immediateFailedFuture(
                 Status.FAILED_PRECONDITION.withDescription("foobar").asException()))
         .thenReturn(Futures.immediateFuture(2));
-    UnaryApiCallable<Integer, Integer> callable =
-        UnaryApiCallable.<Integer, Integer>create(callInt)
+    UnaryCallable<Integer, Integer> callable =
+        UnaryCallable.<Integer, Integer>create(callInt)
             .retryableOn(retryable)
             .retrying(FAST_RETRY_SETTINGS, executor, fakeClock);
     callable.call(1);
@@ -291,8 +291,8 @@ public class UnaryApiCallableTest {
         .thenReturn(
             Futures.<Integer>immediateFailedFuture(
                 Status.UNAVAILABLE.withDescription("foobar").asException()));
-    UnaryApiCallable<Integer, Integer> callable =
-        UnaryApiCallable.<Integer, Integer>create(callInt)
+    UnaryCallable<Integer, Integer> callable =
+        UnaryCallable.<Integer, Integer>create(callInt)
             .retryableOn(retryable)
             .retrying(FAST_RETRY_SETTINGS, executor, fakeClock);
     // Need to advance time inside the call.
@@ -310,8 +310,8 @@ public class UnaryApiCallableTest {
                 Status.DEADLINE_EXCEEDED.withDescription("DEADLINE_EXCEEDED").asException()))
         .thenReturn(Futures.<Integer>immediateFuture(2));
 
-    UnaryApiCallable<Integer, Integer> callable =
-        UnaryApiCallable.<Integer, Integer>create(callInt)
+    UnaryCallable<Integer, Integer> callable =
+        UnaryCallable.<Integer, Integer>create(callInt)
             .retryableOn(retryable)
             .retrying(FAST_RETRY_SETTINGS, executor, fakeClock);
     callable.call(1);
@@ -362,7 +362,7 @@ public class UnaryApiCallableTest {
   private class StreamingListResponse
       extends PagedListResponseImpl<Integer, List<Integer>, Integer> {
     public StreamingListResponse(
-        UnaryApiCallable<Integer, List<Integer>> callable,
+        UnaryCallable<Integer, List<Integer>> callable,
         PageStreamingDescriptor<Integer, List<Integer>, Integer> pageDescriptor,
         Integer request,
         CallContext context) {
@@ -377,7 +377,7 @@ public class UnaryApiCallableTest {
 
     @Override
     public StreamingListResponse createPagedListResponse(
-        UnaryApiCallable<Integer, List<Integer>> callable, Integer request, CallContext context) {
+        UnaryCallable<Integer, List<Integer>> callable, Integer request, CallContext context) {
       return new StreamingListResponse(callable, streamingDescriptor, request, context);
     }
   }
@@ -389,7 +389,7 @@ public class UnaryApiCallableTest {
         .thenReturn(Futures.<List<Integer>>immediateFuture(Lists.newArrayList(3, 4)))
         .thenReturn(Futures.immediateFuture(Collections.<Integer>emptyList()));
     Truth.assertThat(
-            UnaryApiCallable.<Integer, List<Integer>>create(callIntList)
+            UnaryCallable.<Integer, List<Integer>>create(callIntList)
                 .pageStreaming(new StreamingFactory())
                 .call(0)
                 .iterateAllElements())
@@ -404,7 +404,7 @@ public class UnaryApiCallableTest {
         .thenReturn(Futures.<List<Integer>>immediateFuture(Lists.newArrayList(3, 4)))
         .thenReturn(Futures.immediateFuture(Collections.<Integer>emptyList()));
     Page<Integer, List<Integer>, Integer> page =
-        UnaryApiCallable.<Integer, List<Integer>>create(callIntList)
+        UnaryCallable.<Integer, List<Integer>>create(callIntList)
             .pageStreaming(new StreamingFactory())
             .call(0)
             .getPage();
@@ -421,7 +421,7 @@ public class UnaryApiCallableTest {
         .thenReturn(Futures.<List<Integer>>immediateFuture(Lists.newArrayList(5, 6, 7)))
         .thenReturn(Futures.immediateFuture(Collections.<Integer>emptyList()));
     FixedSizeCollection<Integer> fixedSizeCollection =
-        UnaryApiCallable.<Integer, List<Integer>>create(callIntList)
+        UnaryCallable.<Integer, List<Integer>>create(callIntList)
             .pageStreaming(new StreamingFactory())
             .call(0)
             .expandToFixedSizeCollection(5);
@@ -437,7 +437,7 @@ public class UnaryApiCallableTest {
         .thenReturn(Futures.<List<Integer>>immediateFuture(Lists.newArrayList(3, 4)))
         .thenReturn(Futures.immediateFuture(Collections.<Integer>emptyList()));
 
-    UnaryApiCallable.<Integer, List<Integer>>create(callIntList)
+    UnaryCallable.<Integer, List<Integer>>create(callIntList)
         .pageStreaming(new StreamingFactory())
         .call(0)
         .expandToFixedSizeCollection(4);
@@ -449,7 +449,7 @@ public class UnaryApiCallableTest {
         .thenReturn(Futures.<List<Integer>>immediateFuture(Lists.newArrayList(0, 1)))
         .thenReturn(Futures.immediateFuture(Collections.<Integer>emptyList()));
 
-    UnaryApiCallable.<Integer, List<Integer>>create(callIntList)
+    UnaryCallable.<Integer, List<Integer>>create(callIntList)
         .pageStreaming(new StreamingFactory())
         .call(0)
         .expandToFixedSizeCollection(2);
@@ -552,8 +552,8 @@ public class UnaryApiCallableTest {
     BundlerFactory<LabeledIntList, List<Integer>> bundlerFactory =
         new BundlerFactory<>(SQUARER_BUNDLING_DESC, bundlingSettings);
     try {
-      UnaryApiCallable<LabeledIntList, List<Integer>> callable =
-          UnaryApiCallable.<LabeledIntList, List<Integer>>create(callLabeledIntSquarer)
+      UnaryCallable<LabeledIntList, List<Integer>> callable =
+          UnaryCallable.<LabeledIntList, List<Integer>>create(callLabeledIntSquarer)
               .bundling(SQUARER_BUNDLING_DESC, bundlerFactory);
       ListenableFuture<List<Integer>> f1 = callable.futureCall(new LabeledIntList("one", 1, 2));
       ListenableFuture<List<Integer>> f2 = callable.futureCall(new LabeledIntList("one", 3, 4));
@@ -612,8 +612,8 @@ public class UnaryApiCallableTest {
     BundlerFactory<LabeledIntList, List<Integer>> bundlerFactory =
         new BundlerFactory<>(DISABLED_BUNDLING_DESC, bundlingSettings);
     try {
-      UnaryApiCallable<LabeledIntList, List<Integer>> callable =
-          UnaryApiCallable.<LabeledIntList, List<Integer>>create(callLabeledIntSquarer)
+      UnaryCallable<LabeledIntList, List<Integer>> callable =
+          UnaryCallable.<LabeledIntList, List<Integer>>create(callLabeledIntSquarer)
               .bundling(DISABLED_BUNDLING_DESC, bundlerFactory);
       ListenableFuture<List<Integer>> f1 = callable.futureCall(new LabeledIntList("one", 1, 2));
       ListenableFuture<List<Integer>> f2 = callable.futureCall(new LabeledIntList("one", 3, 4));
@@ -634,8 +634,8 @@ public class UnaryApiCallableTest {
     BundlerFactory<LabeledIntList, List<Integer>> bundlerFactory =
         new BundlerFactory<>(SQUARER_BUNDLING_DESC, bundlingSettings);
     try {
-      UnaryApiCallable<LabeledIntList, List<Integer>> callable =
-          UnaryApiCallable.<LabeledIntList, List<Integer>>create(callLabeledIntSquarer)
+      UnaryCallable<LabeledIntList, List<Integer>> callable =
+          UnaryCallable.<LabeledIntList, List<Integer>>create(callLabeledIntSquarer)
               .bundling(SQUARER_BUNDLING_DESC, bundlerFactory);
       ListenableFuture<List<Integer>> f1 = callable.futureCall(new LabeledIntList("one", 1));
       ListenableFuture<List<Integer>> f2 = callable.futureCall(new LabeledIntList("one", 3));
@@ -666,8 +666,8 @@ public class UnaryApiCallableTest {
     BundlerFactory<LabeledIntList, List<Integer>> bundlerFactory =
         new BundlerFactory<>(SQUARER_BUNDLING_DESC, bundlingSettings);
     try {
-      UnaryApiCallable<LabeledIntList, List<Integer>> callable =
-          UnaryApiCallable.<LabeledIntList, List<Integer>>create(callLabeledIntExceptionThrower)
+      UnaryCallable<LabeledIntList, List<Integer>> callable =
+          UnaryCallable.<LabeledIntList, List<Integer>>create(callLabeledIntExceptionThrower)
               .bundling(SQUARER_BUNDLING_DESC, bundlerFactory);
       ListenableFuture<List<Integer>> f1 = callable.futureCall(new LabeledIntList("one", 1, 2));
       ListenableFuture<List<Integer>> f2 = callable.futureCall(new LabeledIntList("one", 3, 4));
@@ -698,8 +698,8 @@ public class UnaryApiCallableTest {
         .thenReturn(
             Futures.<Integer>immediateFailedFuture(
                 Status.FAILED_PRECONDITION.withDescription("known").asException()));
-    UnaryApiCallable<Integer, Integer> callable =
-        UnaryApiCallable.<Integer, Integer>create(callInt).retryableOn(retryable);
+    UnaryCallable<Integer, Integer> callable =
+        UnaryCallable.<Integer, Integer>create(callInt).retryableOn(retryable);
     try {
       callable.call(1);
     } catch (ApiException exception) {
@@ -714,8 +714,8 @@ public class UnaryApiCallableTest {
     ImmutableSet<Status.Code> retryable = ImmutableSet.<Status.Code>of();
     Mockito.when(callInt.futureCall((Integer) Mockito.any(), (CallContext) Mockito.any()))
         .thenReturn(Futures.<Integer>immediateFailedFuture(new RuntimeException("unknown")));
-    UnaryApiCallable<Integer, Integer> callable =
-        UnaryApiCallable.<Integer, Integer>create(callInt).retryableOn(retryable);
+    UnaryCallable<Integer, Integer> callable =
+        UnaryCallable.<Integer, Integer>create(callInt).retryableOn(retryable);
     try {
       callable.call(1);
     } catch (ApiException exception) {

--- a/src/test/java/com/google/api/gax/grpc/UnaryCallableTest.java
+++ b/src/test/java/com/google/api/gax/grpc/UnaryCallableTest.java
@@ -326,7 +326,7 @@ public class UnaryCallableTest {
   FutureCallable<Integer, List<Integer>> callIntList = Mockito.mock(FutureCallable.class);
 
   private class StreamingDescriptor
-      implements PageStreamingDescriptor<Integer, List<Integer>, Integer> {
+      implements PagedListDescriptor<Integer, List<Integer>, Integer> {
     @Override
     public Object emptyToken() {
       return 0;
@@ -363,7 +363,7 @@ public class UnaryCallableTest {
       extends PagedListResponseImpl<Integer, List<Integer>, Integer> {
     public StreamingListResponse(
         UnaryCallable<Integer, List<Integer>> callable,
-        PageStreamingDescriptor<Integer, List<Integer>, Integer> pageDescriptor,
+        PagedListDescriptor<Integer, List<Integer>, Integer> pageDescriptor,
         Integer request,
         CallContext context) {
       super(callable, pageDescriptor, request, context);


### PR DESCRIPTION
UnaryApiCallable -> UnaryCallable
UnaryApiCallSettings -> UnaryCallSettings
UnaryApiCallSettingsTyped -> UnaryCallSettingsTyped
StreamingApiCallable -> StreamingCallable
PageStreamingCallable -> PagedCallable
PageStreamingCallSettings -> PagedCallSettings
PageStreamingDescriptor -> PagedListDescriptor

* Also removed "page-streaming" or equivalent terms.