### PR TITLE
Bump to 0.0.21 for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ If you are using Maven, add this to your pom.xml file
 <dependency>
   <groupId>com.google.api</groupId>
   <artifactId>gax</artifactId>
-  <version>0.0.20</version>
+  <version>0.0.21</version>
 </dependency>
 ```
 If you are using Gradle, add this to your dependencies
 ```Groovy
-compile 'com.google.api:gax:0.0.20'
+compile 'com.google.api:gax:0.0.21'
 ```
 If you are using SBT, add this to your dependencies
 ```Scala
-libraryDependencies += "com.google.api" % "gax" % "0.0.20"
+libraryDependencies += "com.google.api" % "gax" % "0.0.21"
 ```
 
 Java Versions

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ apply plugin: "net.ltgt.apt"
 
 group = "com.google.api"
 archivesBaseName = "gax"
-version = "0.0.21-SNAPSHOT"
+version = "0.0.21"
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax</artifactId>
-      <version>0.0.20</version>
+      <version>0.0.21</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>


### PR DESCRIPTION
Required to support rename of UnaryApiCallable -> UnaryCallable