### PR TITLE
Fixed error-handling issue in MockStreamObserver.

### DIFF
--- a/src/main/java/com/google/api/gax/testing/MockGrpcService.java
+++ b/src/main/java/com/google/api/gax/testing/MockGrpcService.java
@@ -44,8 +44,11 @@ public interface MockGrpcService {
   /** Returns all the requests received. */
   public List<GeneratedMessageV3> getRequests();
 
-  /** Sets the responses. */
-  public void setResponses(List<GeneratedMessageV3> responses);
+  /** Adds the response to the response queue. */
+  public void addResponse(GeneratedMessageV3 response);
+
+  /** Adds the exception to the response queue. */
+  public void addException(Exception exception);
 
   /** Returns gRPC service definition used for binding. */
   public ServerServiceDefinition getServiceDefinition();

--- a/src/main/java/com/google/api/gax/testing/MockGrpcService.java
+++ b/src/main/java/com/google/api/gax/testing/MockGrpcService.java
@@ -47,6 +47,10 @@ public interface MockGrpcService {
   /** Adds the response to the response queue. */
   public void addResponse(GeneratedMessageV3 response);
 
+  /** Sets the responses. */
+  @Deprecated
+  public void setResponses(List<GeneratedMessageV3> responses);
+
   /** Adds the exception to the response queue. */
   public void addException(Exception exception);
 

--- a/src/main/java/com/google/api/gax/testing/MockStreamObserver.java
+++ b/src/main/java/com/google/api/gax/testing/MockStreamObserver.java
@@ -43,7 +43,6 @@ import java.util.List;
 public class MockStreamObserver<T> implements StreamObserver<T> {
 
   private final SettableFuture<List<T>> future = SettableFuture.create();
-  private final List<Throwable> errors = new ArrayList<>();
   private final List<T> actualMessages = new ArrayList<>();
 
   @Override
@@ -53,20 +52,13 @@ public class MockStreamObserver<T> implements StreamObserver<T> {
 
   @Override
   public void onError(Throwable t) {
-    errors.add(t);
-    future.set(actualMessages);
+    future.setException(t);
   }
 
   @Override
   public void onCompleted() {
     future.set(actualMessages);
   }
-
-  // Returns the list of errors encountered.
-  public List<Throwable> errors() {
-    return errors;
-  }
-
   // Returns the SettableFuture object which can be used to retrieve received messages.
   public SettableFuture<List<T>> future() {
     return future;

--- a/src/main/java/com/google/api/gax/testing/MockStreamObserver.java
+++ b/src/main/java/com/google/api/gax/testing/MockStreamObserver.java
@@ -54,6 +54,7 @@ public class MockStreamObserver<T> implements StreamObserver<T> {
   @Override
   public void onError(Throwable t) {
     errors.add(t);
+    future.set(actualMessages);
   }
 
   @Override


### PR DESCRIPTION
The future should be set whenever an error occurs. Therefore in the streaming test use case, the following code would execute appropriately:
```
StreamingCallable<StreamingRequest, StreamingResponse> callable =
    api.streamingCallable();
StreamObserver<StreamingRequest> requestObserver =
    callable.bidiStreamingCall(responseObserver);

requestObserver.onNext(request);
List<StreamingResponse> actualResponses = responseObserver.future().get();
Assert.assertEquals(1, responseObserver.errors().size());
Assert.assertTrue(responseObserver.errors().get(0) instanceof StatusRuntimeException);
```

Also roll-forward the MockGrpcService change.