### PR TITLE
Renaming Api to Client

### DIFF
--- a/src/main/java/com/google/api/gax/grpc/ClientSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/ClientSettings.java
@@ -30,11 +30,9 @@
 package com.google.api.gax.grpc;
 
 import com.google.api.gax.core.RetrySettings;
-import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import java.io.IOException;
 import java.util.Set;
-import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * A base settings class to configure a service API class.
@@ -60,15 +58,15 @@ import java.util.concurrent.ScheduledExecutorService;
  *   ProviderManager once all of the service API objects are no longer in use.
  * </ol>
  */
-public abstract class ServiceApiSettings {
+public abstract class ClientSettings {
 
   private final ExecutorProvider executorProvider;
   private final ChannelProvider channelProvider;
 
   /**
-   * Constructs an instance of ServiceApiSettings.
+   * Constructs an instance of ClientSettings.
    */
-  protected ServiceApiSettings(ExecutorProvider executorProvider, ChannelProvider channelProvider) {
+  protected ClientSettings(ExecutorProvider executorProvider, ChannelProvider channelProvider) {
     this.executorProvider = executorProvider;
     this.channelProvider = channelProvider;
   }
@@ -94,9 +92,9 @@ public abstract class ServiceApiSettings {
     private ChannelProvider channelProvider;
 
     /**
-     * Create a builder from a ServiceApiSettings object.
+     * Create a builder from a ClientSettings object.
      */
-    protected Builder(ServiceApiSettings settings) {
+    protected Builder(ClientSettings settings) {
       this.executorProvider = settings.executorProvider;
       this.channelProvider = settings.channelProvider;
     }
@@ -142,7 +140,7 @@ public abstract class ServiceApiSettings {
     /**
      *  Performs a merge, using only non-null fields
      */
-    protected Builder applyToAllApiMethods(
+    protected Builder applyToAllUnaryMethods(
         Iterable<UnaryCallSettings.Builder> methodSettingsBuilders,
         UnaryCallSettings.Builder newSettingsBuilder)
         throws Exception {
@@ -160,6 +158,6 @@ public abstract class ServiceApiSettings {
       return this;
     }
 
-    public abstract ServiceApiSettings build() throws IOException;
+    public abstract ClientSettings build() throws IOException;
   }
 }

--- a/src/main/java/com/google/api/gax/grpc/InstantiatingChannelProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/InstantiatingChannelProvider.java
@@ -217,7 +217,7 @@ public final class InstantiatingChannelProvider implements ChannelProvider {
      *
      * This is optional; if it is not provided, needsExecutor() will return true, meaning that
      * an Executor must be provided when getChannel
-     * is called on the constructed ChannelProvider instance. Note: ServiceApiSettings will
+     * is called on the constructed ChannelProvider instance. Note: ClientSettings will
      * automatically provide its own Executor in this circumstance when it calls getChannel.
      */
     public Builder setExecutorProvider(ExecutorProvider executorProvider) {

--- a/src/main/java/com/google/api/gax/grpc/OperationCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/OperationCallSettings.java
@@ -30,7 +30,7 @@
 package com.google.api.gax.grpc;
 
 import com.google.longrunning.Operation;
-import com.google.longrunning.OperationsApi;
+import com.google.longrunning.OperationsClient;
 import com.google.protobuf.Message;
 import io.grpc.Channel;
 import io.grpc.MethodDescriptor;
@@ -51,12 +51,12 @@ public final class OperationCallSettings<RequestT, ResponseT extends Message> {
 
   // package-private for internal use.
   OperationCallable<RequestT, ResponseT> createOperationCallable(
-      Channel channel, ScheduledExecutorService executor, OperationsApi operationsApi) {
+      Channel channel, ScheduledExecutorService executor, OperationsClient operationsClient) {
     UnaryCallable<RequestT, Operation> initialCallable =
         initialCallSettings.create(channel, executor);
     OperationCallable<RequestT, ResponseT> operationCallable =
         new OperationCallable<>(
-            initialCallable, channel, executor, operationsApi, responseClass, this);
+            initialCallable, channel, executor, operationsClient, responseClass, this);
     return operationCallable;
   }
 

--- a/src/main/java/com/google/api/gax/grpc/UnaryCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/UnaryCallSettings.java
@@ -57,8 +57,8 @@ import java.util.Set;
  * UnaryCallSettings contains a concrete builder class, {@link Builder}. This builder class
  * cannot be used to create an instance of UnaryCallSettings, because UnaryCallSettings is an
  * abstract class. The {@link Builder} class may be used when a builder is required for a
- * purpose other than the creation of an instance type, such as by applyToAllApiMethods
- * in {@link ServiceApiSettings}.
+ * purpose other than the creation of an instance type, such as by applyToAllUnaryMethods
+ * in {@link ClientSettings}.
  */
 public abstract class UnaryCallSettings {
 

--- a/src/main/java/com/google/longrunning/OperationsClient.java
+++ b/src/main/java/com/google/longrunning/OperationsClient.java
@@ -35,12 +35,14 @@ import com.google.api.gax.grpc.ChannelAndExecutor;
 import com.google.api.gax.grpc.UnaryCallable;
 import com.google.api.gax.protobuf.PathTemplate;
 import com.google.protobuf.Empty;
+import com.google.protobuf.ExperimentalApi;
 import io.grpc.ManagedChannel;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
+import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND SERVICE
 /**
@@ -58,14 +60,14 @@ import java.util.concurrent.ScheduledExecutorService;
  *
  * <pre>
  * <code>
- * try (OperationsApi operationsApi = OperationsApi.create()) {
- *   String formattedName = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
- *   Operation response = operationsApi.getOperation(formattedName);
+ * try (OperationsClient operationsClient = OperationsClient.create()) {
+ *   String formattedName = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
+ *   Operation response = operationsClient.getOperation(formattedName);
  * }
  * </code>
  * </pre>
  *
- * <p>Note: close() needs to be called on the operationsApi object to clean up resources such as
+ * <p>Note: close() needs to be called on the operationsClient object to clean up resources such as
  * threads. In the example above, try-with-resources is used, which automatically calls close().
  *
  * <p>The surface of this class includes several types of Java methods for each of the API's
@@ -99,13 +101,14 @@ import java.util.concurrent.ScheduledExecutorService;
  *         .build();
  * OperationsSettings operationsSettings =
  *     OperationsSettings.defaultBuilder().setChannelProvider(channelProvider).build();
- * OperationsApi operationsApi =
- *     OperationsApi.create(operationsSettings);
+ * OperationsClient operationsClient =
+ *     OperationsClient.create(operationsSettings);
  * </code>
  * </pre>
  */
-@javax.annotation.Generated("by GAPIC")
-public class OperationsApi implements AutoCloseable {
+@Generated("by GAPIC")
+@ExperimentalApi
+public class OperationsClient implements AutoCloseable {
   private final OperationsSettings settings;
   private final ScheduledExecutorService executor;
   private final ManagedChannel channel;
@@ -137,18 +140,18 @@ public class OperationsApi implements AutoCloseable {
   }
 
   /**
-   * Constructs an instance of OperationsApi, using the given settings. The channels are created
+   * Constructs an instance of OperationsClient, using the given settings. The channels are created
    * based on the settings passed in, or defaults for any settings that are not set.
    */
-  public static final OperationsApi create(OperationsSettings settings) throws IOException {
-    return new OperationsApi(settings);
+  public static final OperationsClient create(OperationsSettings settings) throws IOException {
+    return new OperationsClient(settings);
   }
 
   /**
-   * Constructs an instance of OperationsApi, using the given settings. This is protected so that it
-   * easy to make a subclass, but otherwise, the static factory methods should be preferred.
+   * Constructs an instance of OperationsClient, using the given settings. This is protected so that
+   * it easy to make a subclass, but otherwise, the static factory methods should be preferred.
    */
-  protected OperationsApi(OperationsSettings settings) throws IOException {
+  protected OperationsClient(OperationsSettings settings) throws IOException {
     this.settings = settings;
     ChannelAndExecutor channelAndExecutor = settings.getChannelAndExecutor();
     this.executor = channelAndExecutor.getExecutor();
@@ -198,9 +201,9 @@ public class OperationsApi implements AutoCloseable {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (OperationsApi operationsApi = OperationsApi.create()) {
-   *   String formattedName = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
-   *   Operation response = operationsApi.getOperation(formattedName);
+   * try (OperationsClient operationsClient = OperationsClient.create()) {
+   *   String formattedName = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
+   *   Operation response = operationsClient.getOperation(formattedName);
    * }
    * </code></pre>
    *
@@ -221,12 +224,12 @@ public class OperationsApi implements AutoCloseable {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (OperationsApi operationsApi = OperationsApi.create()) {
-   *   String formattedName = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
+   * try (OperationsClient operationsClient = OperationsClient.create()) {
+   *   String formattedName = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
    *   GetOperationRequest request = GetOperationRequest.newBuilder()
    *     .setName(formattedName)
    *     .build();
-   *   Operation response = operationsApi.getOperation(request);
+   *   Operation response = operationsClient.getOperation(request);
    * }
    * </code></pre>
    *
@@ -245,12 +248,12 @@ public class OperationsApi implements AutoCloseable {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (OperationsApi operationsApi = OperationsApi.create()) {
-   *   String formattedName = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
+   * try (OperationsClient operationsClient = OperationsClient.create()) {
+   *   String formattedName = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
    *   GetOperationRequest request = GetOperationRequest.newBuilder()
    *     .setName(formattedName)
    *     .build();
-   *   ListenableFuture&lt;Operation&gt; future = operationsApi.getOperationCallable().futureCall(request);
+   *   ListenableFuture&lt;Operation&gt; future = operationsClient.getOperationCallable().futureCall(request);
    *   // Do something
    *   Operation response = future.get();
    * }
@@ -271,10 +274,10 @@ public class OperationsApi implements AutoCloseable {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (OperationsApi operationsApi = OperationsApi.create()) {
+   * try (OperationsClient operationsClient = OperationsClient.create()) {
    *   String name = "";
    *   String filter = "";
-   *   for (Operation element : operationsApi.listOperations(name, filter).iterateAllElements()) {
+   *   for (Operation element : operationsClient.listOperations(name, filter).iterateAllElements()) {
    *     // doThingsWith(element);
    *   }
    * }
@@ -301,14 +304,14 @@ public class OperationsApi implements AutoCloseable {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (OperationsApi operationsApi = OperationsApi.create()) {
+   * try (OperationsClient operationsClient = OperationsClient.create()) {
    *   String name = "";
    *   String filter = "";
    *   ListOperationsRequest request = ListOperationsRequest.newBuilder()
    *     .setName(name)
    *     .setFilter(filter)
    *     .build();
-   *   for (Operation element : operationsApi.listOperations(request).iterateAllElements()) {
+   *   for (Operation element : operationsClient.listOperations(request).iterateAllElements()) {
    *     // doThingsWith(element);
    *   }
    * }
@@ -332,14 +335,14 @@ public class OperationsApi implements AutoCloseable {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (OperationsApi operationsApi = OperationsApi.create()) {
+   * try (OperationsClient operationsClient = OperationsClient.create()) {
    *   String name = "";
    *   String filter = "";
    *   ListOperationsRequest request = ListOperationsRequest.newBuilder()
    *     .setName(name)
    *     .setFilter(filter)
    *     .build();
-   *   ListenableFuture&lt;ListOperationsPagedResponse&gt; future = operationsApi.listOperationsPagedCallable().futureCall(request);
+   *   ListenableFuture&lt;ListOperationsPagedResponse&gt; future = operationsClient.listOperationsPagedCallable().futureCall(request);
    *   // Do something
    *   for (Operation element : future.get().iterateAllElements()) {
    *     // doThingsWith(element);
@@ -363,7 +366,7 @@ public class OperationsApi implements AutoCloseable {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (OperationsApi operationsApi = OperationsApi.create()) {
+   * try (OperationsClient operationsClient = OperationsClient.create()) {
    *   String name = "";
    *   String filter = "";
    *   ListOperationsRequest request = ListOperationsRequest.newBuilder()
@@ -371,7 +374,7 @@ public class OperationsApi implements AutoCloseable {
    *     .setFilter(filter)
    *     .build();
    *   while (true) {
-   *     ListOperationsResponse response = operationsApi.listOperationsCallable().call(request);
+   *     ListOperationsResponse response = operationsClient.listOperationsCallable().call(request);
    *     for (Operation element : response.getOperationsList()) {
    *       // doThingsWith(element);
    *     }
@@ -404,9 +407,9 @@ public class OperationsApi implements AutoCloseable {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (OperationsApi operationsApi = OperationsApi.create()) {
-   *   String formattedName = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
-   *   operationsApi.cancelOperation(formattedName);
+   * try (OperationsClient operationsClient = OperationsClient.create()) {
+   *   String formattedName = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
+   *   operationsClient.cancelOperation(formattedName);
    * }
    * </code></pre>
    *
@@ -433,12 +436,12 @@ public class OperationsApi implements AutoCloseable {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (OperationsApi operationsApi = OperationsApi.create()) {
-   *   String formattedName = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
+   * try (OperationsClient operationsClient = OperationsClient.create()) {
+   *   String formattedName = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
    *   CancelOperationRequest request = CancelOperationRequest.newBuilder()
    *     .setName(formattedName)
    *     .build();
-   *   operationsApi.cancelOperation(request);
+   *   operationsClient.cancelOperation(request);
    * }
    * </code></pre>
    *
@@ -463,12 +466,12 @@ public class OperationsApi implements AutoCloseable {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (OperationsApi operationsApi = OperationsApi.create()) {
-   *   String formattedName = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
+   * try (OperationsClient operationsClient = OperationsClient.create()) {
+   *   String formattedName = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
    *   CancelOperationRequest request = CancelOperationRequest.newBuilder()
    *     .setName(formattedName)
    *     .build();
-   *   ListenableFuture&lt;Void&gt; future = operationsApi.cancelOperationCallable().futureCall(request);
+   *   ListenableFuture&lt;Void&gt; future = operationsClient.cancelOperationCallable().futureCall(request);
    *   // Do something
    *   future.get();
    * }
@@ -487,9 +490,9 @@ public class OperationsApi implements AutoCloseable {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (OperationsApi operationsApi = OperationsApi.create()) {
-   *   String formattedName = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
-   *   operationsApi.deleteOperation(formattedName);
+   * try (OperationsClient operationsClient = OperationsClient.create()) {
+   *   String formattedName = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
+   *   operationsClient.deleteOperation(formattedName);
    * }
    * </code></pre>
    *
@@ -511,12 +514,12 @@ public class OperationsApi implements AutoCloseable {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (OperationsApi operationsApi = OperationsApi.create()) {
-   *   String formattedName = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
+   * try (OperationsClient operationsClient = OperationsClient.create()) {
+   *   String formattedName = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
    *   DeleteOperationRequest request = DeleteOperationRequest.newBuilder()
    *     .setName(formattedName)
    *     .build();
-   *   operationsApi.deleteOperation(request);
+   *   operationsClient.deleteOperation(request);
    * }
    * </code></pre>
    *
@@ -536,12 +539,12 @@ public class OperationsApi implements AutoCloseable {
    * <p>Sample code:
    *
    * <pre><code>
-   * try (OperationsApi operationsApi = OperationsApi.create()) {
-   *   String formattedName = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
+   * try (OperationsClient operationsClient = OperationsClient.create()) {
+   *   String formattedName = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
    *   DeleteOperationRequest request = DeleteOperationRequest.newBuilder()
    *     .setName(formattedName)
    *     .build();
-   *   ListenableFuture&lt;Void&gt; future = operationsApi.deleteOperationCallable().futureCall(request);
+   *   ListenableFuture&lt;Void&gt; future = operationsClient.deleteOperationCallable().futureCall(request);
    *   // Do something
    *   future.get();
    * }

--- a/src/main/java/com/google/longrunning/OperationsSettings.java
+++ b/src/main/java/com/google/longrunning/OperationsSettings.java
@@ -35,13 +35,13 @@ import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.RetrySettings;
 import com.google.api.gax.grpc.CallContext;
 import com.google.api.gax.grpc.ChannelProvider;
+import com.google.api.gax.grpc.ClientSettings;
 import com.google.api.gax.grpc.ExecutorProvider;
 import com.google.api.gax.grpc.InstantiatingChannelProvider;
 import com.google.api.gax.grpc.InstantiatingExecutorProvider;
 import com.google.api.gax.grpc.PagedCallSettings;
 import com.google.api.gax.grpc.PagedListDescriptor;
 import com.google.api.gax.grpc.PagedListResponseFactory;
-import com.google.api.gax.grpc.ServiceApiSettings;
 import com.google.api.gax.grpc.SimpleCallSettings;
 import com.google.api.gax.grpc.UnaryCallSettings;
 import com.google.api.gax.grpc.UnaryCallable;
@@ -51,14 +51,17 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.protobuf.Empty;
+import com.google.protobuf.ExperimentalApi;
 import io.grpc.Status;
 import java.io.IOException;
+import javax.annotation.Generated;
 import org.joda.time.Duration;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
-/** Settings class to configure an instance of {@link OperationsApi}. */
-@javax.annotation.Generated("by GAPIC")
-public class OperationsSettings extends ServiceApiSettings {
+/** Settings class to configure an instance of {@link OperationsClient}. */
+@Generated("by GAPIC")
+@ExperimentalApi
+public class OperationsSettings extends ClientSettings {
 
   /** The default port of the service. */
   private static final int DEFAULT_SERVICE_PORT = 443;
@@ -189,7 +192,7 @@ public class OperationsSettings extends ServiceApiSettings {
           };
 
   /** Builder for OperationsSettings. */
-  public static class Builder extends ServiceApiSettings.Builder {
+  public static class Builder extends ClientSettings.Builder {
     private final ImmutableList<UnaryCallSettings.Builder> unaryMethodSettingsBuilders;
 
     private final SimpleCallSettings.Builder<GetOperationRequest, Operation> getOperationSettings;
@@ -313,9 +316,9 @@ public class OperationsSettings extends ServiceApiSettings {
      *
      * <p>Note: This method does not support applying settings to streaming methods.
      */
-    public Builder applyToAllApiMethods(UnaryCallSettings.Builder apiCallSettings)
+    public Builder applyToAllUnaryMethods(UnaryCallSettings.Builder unaryCallSettings)
         throws Exception {
-      super.applyToAllApiMethods(unaryMethodSettingsBuilders, apiCallSettings);
+      super.applyToAllUnaryMethods(unaryMethodSettingsBuilders, unaryCallSettings);
       return this;
     }
 

--- a/src/main/java/com/google/longrunning/PagedResponseWrappers.java
+++ b/src/main/java/com/google/longrunning/PagedResponseWrappers.java
@@ -33,6 +33,8 @@ import com.google.api.gax.grpc.CallContext;
 import com.google.api.gax.grpc.PagedListDescriptor;
 import com.google.api.gax.grpc.PagedListResponseImpl;
 import com.google.api.gax.grpc.UnaryCallable;
+import com.google.protobuf.ExperimentalApi;
+import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
@@ -40,7 +42,8 @@ import com.google.api.gax.grpc.UnaryCallable;
  * inside this wrapper class is used as the return type of one of an API method that implements the
  * page streaming pattern.
  */
-@javax.annotation.Generated("by GAPIC")
+@Generated("by GAPIC")
+@ExperimentalApi
 public class PagedResponseWrappers {
 
   public static class ListOperationsPagedResponse

--- a/src/main/java/com/google/longrunning/package-info.java
+++ b/src/main/java/com/google/longrunning/package-info.java
@@ -33,7 +33,7 @@
  *
  * <p>The interfaces provided are listed below, along with usage samples.
  *
- * <p>============= OperationsApi =============
+ * <p>================ OperationsClient ================
  *
  * <p>Service Description: Manages long-running operations with an API service.
  *

--- a/src/test/java/com/google/api/gax/grpc/OperationCallableTest.java
+++ b/src/test/java/com/google/api/gax/grpc/OperationCallableTest.java
@@ -35,7 +35,7 @@ import com.google.common.truth.Truth;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.longrunning.Operation;
-import com.google.longrunning.OperationsApi;
+import com.google.longrunning.OperationsClient;
 import com.google.longrunning.OperationsSettings;
 import com.google.protobuf.Any;
 import com.google.type.Color;
@@ -56,7 +56,7 @@ import org.mockito.Mockito;
 public class OperationCallableTest {
   private MockOperationsEx mockOperations;
   private MockServiceHelper serviceHelper;
-  private OperationsApi operationsApi;
+  private OperationsClient operationsClient;
   private ScheduledExecutorService executor;
 
   @Before
@@ -69,20 +69,20 @@ public class OperationCallableTest {
         OperationsSettings.defaultBuilder()
             .setChannelProvider(serviceHelper.createChannelProvider())
             .build();
-    operationsApi = OperationsApi.create(settings);
+    operationsClient = OperationsClient.create(settings);
     executor = new ScheduledThreadPoolExecutor(1);
   }
 
   @After
   public void tearDown() throws Exception {
-    operationsApi.close();
+    operationsClient.close();
     executor.shutdown();
     serviceHelper.stop();
   }
 
   @Test
   public void testCall() {
-    String opName = OperationsApi.formatOperationPathName("testCall");
+    String opName = OperationsClient.formatOperationPathName("testCall");
     Color injectedResponse = Color.newBuilder().setBlue(1.0f).build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -95,7 +95,7 @@ public class OperationCallableTest {
 
     OperationCallable<Integer, Color> callable =
         new OperationCallable<Integer, Color>(
-            stashUnaryCallable, null, executor, operationsApi, Color.class, null);
+            stashUnaryCallable, null, executor, operationsClient, Color.class, null);
     Color response = callable.call(2, CallContext.createDefault());
     Truth.assertThat(response).isEqualTo(injectedResponse);
     Truth.assertThat(stash.context.getChannel()).isNull();
@@ -104,7 +104,7 @@ public class OperationCallableTest {
 
   @Test
   public void testBind() {
-    String opName = OperationsApi.formatOperationPathName("testBind");
+    String opName = OperationsClient.formatOperationPathName("testBind");
     Color injectedResponse = Color.newBuilder().setBlue(1.0f).build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -118,7 +118,7 @@ public class OperationCallableTest {
     Channel channel = Mockito.mock(Channel.class);
     OperationCallable<Integer, Color> callable =
         new OperationCallable<Integer, Color>(
-            stashUnaryCallable, null, executor, operationsApi, Color.class, null);
+            stashUnaryCallable, null, executor, operationsClient, Color.class, null);
     callable = callable.bind(channel);
     Color response = callable.call(2);
     Truth.assertThat(response).isEqualTo(injectedResponse);
@@ -127,7 +127,7 @@ public class OperationCallableTest {
 
   @Test
   public void testResumeFutureCall() throws Exception {
-    String opName = OperationsApi.formatOperationPathName("testCall");
+    String opName = OperationsClient.formatOperationPathName("testCall");
     Color injectedResponse = Color.newBuilder().setBlue(1.0f).build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -142,7 +142,7 @@ public class OperationCallableTest {
 
     OperationCallable<Integer, Color> callable =
         new OperationCallable<Integer, Color>(
-            stashUnaryCallable, null, executor, operationsApi, Color.class, null);
+            stashUnaryCallable, null, executor, operationsClient, Color.class, null);
     OperationFuture<Color> operationFuture = callable.futureCall(2);
 
     Color response = callable.resumeFutureCall(operationFuture.getOperationName()).get();

--- a/src/test/java/com/google/api/gax/grpc/SettingsTest.java
+++ b/src/test/java/com/google/api/gax/grpc/SettingsTest.java
@@ -53,13 +53,13 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
-/** Tests for {@link ServiceApiSettings}. */
+/** Tests for {@link ClientSettings}. */
 @RunWith(JUnit4.class)
 public class SettingsTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
-  private static class FakeSettings extends ServiceApiSettings {
+  private static class FakeSettings extends ClientSettings {
 
     private interface FakePagedListResponse extends PagedListResponse<Integer, Integer, Integer> {}
 
@@ -161,7 +161,7 @@ public class SettingsTest {
       this.fakeMethodBundling = settingsBuilder.fakeMethodBundling().build();
     }
 
-    private static class Builder extends ServiceApiSettings.Builder {
+    private static class Builder extends ClientSettings.Builder {
 
       private SimpleCallSettings.Builder<Integer, Integer> fakeMethodSimple;
       private PagedCallSettings.Builder<Integer, Integer, FakePagedListResponse> fakePagedMethod;
@@ -279,7 +279,7 @@ public class SettingsTest {
     Truth.assertThat(settingsA.getMaxRetryDelay()).isEqualTo(settingsB.getMaxRetryDelay());
   }
 
-  //ServiceApiSettings
+  //ClientSettings
   // ====
 
   @Test

--- a/src/test/java/com/google/longrunning/MockOperations.java
+++ b/src/test/java/com/google/longrunning/MockOperations.java
@@ -57,7 +57,6 @@ public class MockOperations implements MockGrpcService {
     serviceImpl.addException(exception);
   }
 
-  @Override
   public void setResponses(List<GeneratedMessageV3> responses) {
     serviceImpl.setResponses(responses);
   }

--- a/src/test/java/com/google/longrunning/OperationsTest.java
+++ b/src/test/java/com/google/longrunning/OperationsTest.java
@@ -53,7 +53,7 @@ import org.junit.Test;
 public class OperationsTest {
   private static MockOperations mockOperations;
   private static MockServiceHelper serviceHelper;
-  private OperationsApi api;
+  private OperationsClient client;
 
   @BeforeClass
   public static void startStaticServer() {
@@ -75,26 +75,26 @@ public class OperationsTest {
         OperationsSettings.defaultBuilder()
             .setChannelProvider(serviceHelper.createChannelProvider())
             .build();
-    api = OperationsApi.create(settings);
+    client = OperationsClient.create(settings);
   }
 
   @After
   public void tearDown() throws Exception {
-    api.close();
+    client.close();
   }
 
   @Test
   @SuppressWarnings("all")
   public void getOperationTest() {
-    String formattedName2 = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
+    String formattedName2 = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
     boolean done = true;
     Operation expectedResponse =
         Operation.newBuilder().setName(formattedName2).setDone(done).build();
     mockOperations.addResponse(expectedResponse);
 
-    String formattedName = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
+    String formattedName = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
 
-    Operation actualResponse = api.getOperation(formattedName);
+    Operation actualResponse = client.getOperation(formattedName);
     Assert.assertEquals(expectedResponse, actualResponse);
 
     List<GeneratedMessageV3> actualRequests = mockOperations.getRequests();
@@ -111,9 +111,9 @@ public class OperationsTest {
     mockOperations.addException(exception);
 
     try {
-      String formattedName = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
+      String formattedName = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
 
-      api.getOperation(formattedName);
+      client.getOperation(formattedName);
       Assert.fail("No exception raised");
     } catch (ApiException e) {
       Assert.assertEquals(Status.INTERNAL.getCode(), e.getStatusCode());
@@ -136,7 +136,7 @@ public class OperationsTest {
     String name = "name3373707";
     String filter = "filter-1274492040";
 
-    ListOperationsPagedResponse pagedListResponse = api.listOperations(name, filter);
+    ListOperationsPagedResponse pagedListResponse = client.listOperations(name, filter);
 
     List<Operation> resources = Lists.newArrayList(pagedListResponse.iterateAllElements());
     Assert.assertEquals(1, resources.size());
@@ -160,7 +160,7 @@ public class OperationsTest {
       String name = "name3373707";
       String filter = "filter-1274492040";
 
-      api.listOperations(name, filter);
+      client.listOperations(name, filter);
       Assert.fail("No exception raised");
     } catch (ApiException e) {
       Assert.assertEquals(Status.INTERNAL.getCode(), e.getStatusCode());
@@ -173,9 +173,9 @@ public class OperationsTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockOperations.addResponse(expectedResponse);
 
-    String formattedName = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
+    String formattedName = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
 
-    api.cancelOperation(formattedName);
+    client.cancelOperation(formattedName);
 
     List<GeneratedMessageV3> actualRequests = mockOperations.getRequests();
     Assert.assertEquals(1, actualRequests.size());
@@ -191,9 +191,9 @@ public class OperationsTest {
     mockOperations.addException(exception);
 
     try {
-      String formattedName = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
+      String formattedName = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
 
-      api.cancelOperation(formattedName);
+      client.cancelOperation(formattedName);
       Assert.fail("No exception raised");
     } catch (ApiException e) {
       Assert.assertEquals(Status.INTERNAL.getCode(), e.getStatusCode());
@@ -206,9 +206,9 @@ public class OperationsTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockOperations.addResponse(expectedResponse);
 
-    String formattedName = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
+    String formattedName = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
 
-    api.deleteOperation(formattedName);
+    client.deleteOperation(formattedName);
 
     List<GeneratedMessageV3> actualRequests = mockOperations.getRequests();
     Assert.assertEquals(1, actualRequests.size());
@@ -224,9 +224,9 @@ public class OperationsTest {
     mockOperations.addException(exception);
 
     try {
-      String formattedName = OperationsApi.formatOperationPathName("[OPERATION_PATH]");
+      String formattedName = OperationsClient.formatOperationPathName("[OPERATION_PATH]");
 
-      api.deleteOperation(formattedName);
+      client.deleteOperation(formattedName);
       Assert.fail("No exception raised");
     } catch (ApiException e) {
       Assert.assertEquals(Status.INTERNAL.getCode(), e.getStatusCode());


### PR DESCRIPTION
The OperationsApi -> OperationsClient rename was performed by an updated toolkit; toolkit's changes will appear in a separate PR. 