### PR TITLE
fix release doc

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,12 +33,14 @@ Add deploy credential settings
 ------------------------
 * Create a settings file at ```$HOME/.gradle/gradle.properties``` with your key information and your sonatype username/password
 
+```
 signing.keyId=<YOUR-KEY-ID-HERE>
 signing.password=<YOUR-PASSWORD-HERE>
 signing.secretKeyRingFile=/usr/local/google/home/<YOUR-USER-NAME>/.gnupg/secring.gpg
 
 ossrhUsername=<YOUR-NEXUS-USERNAME>
 ossrhPassword=<YOUR-NEXUS-PASSWORD>
+```
 
 Deploy to Sonatype
 ------------------


### PR DESCRIPTION
The "deploy credential settings" paragraph was not quoted.
Consequently, the placeholder like `<YOUR-KEY-ID-HERE>`
was invisible in MD.

This commit properly quotes the relevant sections.