### PR TITLE
delete deprecated fields of BundlingSettings

### DIFF
--- a/src/main/java/com/google/api/gax/bundling/BundlingThreshold.java
+++ b/src/main/java/com/google/api/gax/bundling/BundlingThreshold.java
@@ -36,11 +36,6 @@ package com.google.api.gax.bundling;
 public interface BundlingThreshold<E> {
 
   /**
-   * Returns true if adding this value would breach the limit for the value in this threshold.
-   */
-  boolean canAccept(E e);
-
-  /**
    * Presents the element to the threshold for the attribute of interest to be accumulated.
    *
    * Any calls into this function from ThresholdBundler will be under a lock.

--- a/src/main/java/com/google/api/gax/bundling/BundlingThresholds.java
+++ b/src/main/java/com/google/api/gax/bundling/BundlingThresholds.java
@@ -45,7 +45,6 @@ public final class BundlingThresholds {
     BundlingThreshold<E> bundlingThreshold =
         new NumericThreshold<E>(
             elementThreshold,
-            null,
             new ElementCounter<E>() {
               @Override
               public long count(E e) {

--- a/src/main/java/com/google/api/gax/bundling/NumericThreshold.java
+++ b/src/main/java/com/google/api/gax/bundling/NumericThreshold.java
@@ -37,7 +37,6 @@ import javax.annotation.Nullable;
  */
 public final class NumericThreshold<E> implements BundlingThreshold<E> {
   private final long threshold;
-  private final Long limit;
   private final ElementCounter<E> extractor;
   private long sum;
 
@@ -45,23 +44,12 @@ public final class NumericThreshold<E> implements BundlingThreshold<E> {
    * Constructs a NumericThreshold.
    *
    * @param threshold The value that allows an event to happen.
-   * @param limit The value that forces an event to happen. If null, then this is not enforced.
    * @param extractor Object that extracts a numeric value from the value object.
    */
-  public NumericThreshold(long threshold, @Nullable Long limit, ElementCounter<E> extractor) {
+  public NumericThreshold(long threshold, ElementCounter<E> extractor) {
     this.threshold = threshold;
-    this.limit = limit;
     this.extractor = Preconditions.checkNotNull(extractor);
     this.sum = 0;
-  }
-
-  @Override
-  public boolean canAccept(E e) {
-    if (limit == null) {
-      return true;
-    } else {
-      return sum + extractor.count(e) <= limit;
-    }
   }
 
   @Override
@@ -76,6 +64,6 @@ public final class NumericThreshold<E> implements BundlingThreshold<E> {
 
   @Override
   public BundlingThreshold<E> copyWithZeroedValue() {
-    return new NumericThreshold<E>(threshold, limit, extractor);
+    return new NumericThreshold<E>(threshold, extractor);
   }
 }

--- a/src/main/java/com/google/api/gax/grpc/BundlerFactory.java
+++ b/src/main/java/com/google/api/gax/grpc/BundlerFactory.java
@@ -130,14 +130,8 @@ public final class BundlerFactory<RequestT, ResponseT> implements AutoCloseable 
             }
           };
 
-      Long elementCountLimit = null;
-      if (bundlingSettings.getElementCountLimit() != null) {
-        elementCountLimit = bundlingSettings.getElementCountLimit().longValue();
-      }
-
       BundlingThreshold<BundlingContext<RequestT, ResponseT>> countThreshold =
-          new NumericThreshold<>(
-              bundlingSettings.getElementCountThreshold(), elementCountLimit, elementCounter);
+          new NumericThreshold<>(bundlingSettings.getElementCountThreshold(), elementCounter);
       listBuilder.add(countThreshold);
     }
 
@@ -150,14 +144,8 @@ public final class BundlerFactory<RequestT, ResponseT> implements AutoCloseable 
             }
           };
 
-      Long requestByteLimit = null;
-      if (bundlingSettings.getRequestByteLimit() != null) {
-        requestByteLimit = bundlingSettings.getRequestByteLimit().longValue();
-      }
-
       BundlingThreshold<BundlingContext<RequestT, ResponseT>> byteThreshold =
-          new NumericThreshold<>(
-              bundlingSettings.getRequestByteThreshold(), requestByteLimit, requestByteCounter);
+          new NumericThreshold<>(bundlingSettings.getRequestByteThreshold(), requestByteCounter);
       listBuilder.add(byteThreshold);
     }
 

--- a/src/test/java/com/google/api/gax/grpc/SettingsTest.java
+++ b/src/test/java/com/google/api/gax/grpc/SettingsTest.java
@@ -194,9 +194,7 @@ public class SettingsTest {
             .fakeMethodBundling()
             .getBundlingSettingsBuilder()
             .setElementCountThreshold(800L)
-            .setElementCountLimit(1000L)
             .setRequestByteThreshold(8388608L)
-            .setRequestByteLimit(10485760L)
             .setDelayThreshold(Duration.millis(100))
             .setBlockingCallCountThreshold(1L);
         builder

--- a/src/test/java/com/google/api/gax/grpc/UnaryCallableTest.java
+++ b/src/test/java/com/google/api/gax/grpc/UnaryCallableTest.java
@@ -204,7 +204,6 @@ public class UnaryCallableTest {
         BundlingSettings.newBuilder()
             .setDelayThreshold(Duration.standardSeconds(1))
             .setElementCountThreshold(2L)
-            .setBlockingCallCountThreshold(0L)
             .build();
     BundlerFactory<Integer, List<Integer>> bundlerFactory =
         new BundlerFactory<>(STASH_BUNDLING_DESC, bundlingSettings);
@@ -555,7 +554,6 @@ public class UnaryCallableTest {
         BundlingSettings.newBuilder()
             .setDelayThreshold(Duration.standardSeconds(1))
             .setElementCountThreshold(2L)
-            .setBlockingCallCountThreshold(0L)
             .build();
     BundlerFactory<LabeledIntList, List<Integer>> bundlerFactory =
         new BundlerFactory<>(SQUARER_BUNDLING_DESC, bundlingSettings);
@@ -637,7 +635,6 @@ public class UnaryCallableTest {
         BundlingSettings.newBuilder()
             .setDelayThreshold(Duration.standardSeconds(1))
             .setElementCountThreshold(2L)
-            .setBlockingCallCountThreshold(1L)
             .build();
     BundlerFactory<LabeledIntList, List<Integer>> bundlerFactory =
         new BundlerFactory<>(SQUARER_BUNDLING_DESC, bundlingSettings);
@@ -669,7 +666,6 @@ public class UnaryCallableTest {
         BundlingSettings.newBuilder()
             .setDelayThreshold(Duration.standardSeconds(1))
             .setElementCountThreshold(2L)
-            .setBlockingCallCountThreshold(0L)
             .build();
     BundlerFactory<LabeledIntList, List<Integer>> bundlerFactory =
         new BundlerFactory<>(SQUARER_BUNDLING_DESC, bundlingSettings);

--- a/src/test/java/com/google/api/gax/grpc/UnaryCallableTest.java
+++ b/src/test/java/com/google/api/gax/grpc/UnaryCallableTest.java
@@ -204,6 +204,7 @@ public class UnaryCallableTest {
         BundlingSettings.newBuilder()
             .setDelayThreshold(Duration.standardSeconds(1))
             .setElementCountThreshold(2L)
+            .setBlockingCallCountThreshold((Long) null)
             .build();
     BundlerFactory<Integer, List<Integer>> bundlerFactory =
         new BundlerFactory<>(STASH_BUNDLING_DESC, bundlingSettings);
@@ -554,6 +555,7 @@ public class UnaryCallableTest {
         BundlingSettings.newBuilder()
             .setDelayThreshold(Duration.standardSeconds(1))
             .setElementCountThreshold(2L)
+            .setBlockingCallCountThreshold((Long) null)
             .build();
     BundlerFactory<LabeledIntList, List<Integer>> bundlerFactory =
         new BundlerFactory<>(SQUARER_BUNDLING_DESC, bundlingSettings);

--- a/src/test/java/com/google/api/gax/grpc/UnaryCallableTest.java
+++ b/src/test/java/com/google/api/gax/grpc/UnaryCallableTest.java
@@ -666,6 +666,7 @@ public class UnaryCallableTest {
         BundlingSettings.newBuilder()
             .setDelayThreshold(Duration.standardSeconds(1))
             .setElementCountThreshold(2L)
+            .setBlockingCallCountThreshold((Long) null)
             .build();
     BundlerFactory<LabeledIntList, List<Integer>> bundlerFactory =
         new BundlerFactory<>(SQUARER_BUNDLING_DESC, bundlingSettings);


### PR DESCRIPTION
Fixes #168.

This commit also performed branch elimination and constant propagation.
In particular:
- All thresholds are required and therefore never null.
- All limits are gone and therefore "always null".
- BundlingThreshold::canAccept always return true,
  and therefore deleted.