### PR TITLE
Support custom polling interval

### DIFF
--- a/src/main/java/com/google/api/gax/grpc/OperationCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/OperationCallSettings.java
@@ -90,7 +90,7 @@ public final class OperationCallSettings<RequestT, ResponseT extends Message> {
   public static class Builder<RequestT, ResponseT extends Message> {
     private SimpleCallSettings.Builder<RequestT, Operation> initialCallSettings;
     private Class<ResponseT> responseClass;
-    private Duration pollingInterval = OperationFuture.POLLING_INTERVAL;
+    private Duration pollingInterval = OperationFuture.DEFAULT_POLLING_INTERVAL;
 
     public Builder(
         MethodDescriptor<RequestT, Operation> grpcMethodDescriptor,

--- a/src/main/java/com/google/api/gax/grpc/OperationCallSettings.java
+++ b/src/main/java/com/google/api/gax/grpc/OperationCallSettings.java
@@ -35,6 +35,7 @@ import com.google.protobuf.Message;
 import io.grpc.Channel;
 import io.grpc.MethodDescriptor;
 import java.util.concurrent.ScheduledExecutorService;
+import org.joda.time.Duration;
 
 /**
  * A settings class to configure an OperationCallable for calls to a long-running API method (i.e.
@@ -44,9 +45,14 @@ public final class OperationCallSettings<RequestT, ResponseT extends Message> {
 
   private final SimpleCallSettings<RequestT, Operation> initialCallSettings;
   private final Class<ResponseT> responseClass;
+  private final Duration pollingInterval;
 
   public final SimpleCallSettings<RequestT, Operation> getInitialCallSettings() {
     return initialCallSettings;
+  }
+
+  public final Duration getPollingInterval() {
+    return pollingInterval;
   }
 
   // package-private for internal use.
@@ -61,9 +67,12 @@ public final class OperationCallSettings<RequestT, ResponseT extends Message> {
   }
 
   private OperationCallSettings(
-      SimpleCallSettings<RequestT, Operation> initialCallSettings, Class<ResponseT> responseClass) {
+      SimpleCallSettings<RequestT, Operation> initialCallSettings,
+      Class<ResponseT> responseClass,
+      Duration pollingInterval) {
     this.initialCallSettings = initialCallSettings;
     this.responseClass = responseClass;
+    this.pollingInterval = pollingInterval;
   }
 
   /**
@@ -81,6 +90,7 @@ public final class OperationCallSettings<RequestT, ResponseT extends Message> {
   public static class Builder<RequestT, ResponseT extends Message> {
     private SimpleCallSettings.Builder<RequestT, Operation> initialCallSettings;
     private Class<ResponseT> responseClass;
+    private Duration pollingInterval = OperationFuture.POLLING_INTERVAL;
 
     public Builder(
         MethodDescriptor<RequestT, Operation> grpcMethodDescriptor,
@@ -92,6 +102,21 @@ public final class OperationCallSettings<RequestT, ResponseT extends Message> {
     public Builder(OperationCallSettings<RequestT, ResponseT> settings) {
       this.initialCallSettings = settings.initialCallSettings.toBuilder();
       this.responseClass = settings.responseClass;
+    }
+
+    /**
+     * Set the polling interval of the operation.
+     */
+    public Builder setPollingInterval(Duration pollingInterval) {
+      this.pollingInterval = pollingInterval;
+      return this;
+    }
+
+    /**
+     * Get the polling interval of the operation.
+     */
+    public Duration getPollingInterval() {
+      return pollingInterval;
     }
 
     /**
@@ -111,7 +136,8 @@ public final class OperationCallSettings<RequestT, ResponseT extends Message> {
     }
 
     public OperationCallSettings<RequestT, ResponseT> build() {
-      return new OperationCallSettings<>(initialCallSettings.build(), responseClass);
+      return new OperationCallSettings<>(
+          initialCallSettings.build(), responseClass, pollingInterval);
     }
   }
 }

--- a/src/main/java/com/google/api/gax/grpc/OperationCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/OperationCallable.java
@@ -38,6 +38,7 @@ import com.google.longrunning.OperationsClient;
 import com.google.protobuf.Message;
 import io.grpc.Channel;
 import java.util.concurrent.ScheduledExecutorService;
+import org.joda.time.Duration;
 
 /**
  * An OperationCallable is an immutable object which is capable of initiating RPC calls to
@@ -113,8 +114,11 @@ public final class OperationCallable<RequestT, ResponseT extends Message> {
       context = context.withChannel(channel);
     }
     RpcFuture<Operation> initialCallFuture = initialCallable.futureCall(request, context);
+    Duration pollingInterval =
+        settings != null ? settings.getPollingInterval() : OperationFuture.POLLING_INTERVAL;
     OperationFuture<ResponseT> operationFuture =
-        OperationFuture.create(operationsClient, initialCallFuture, executor, responseClass);
+        OperationFuture.create(
+            operationsClient, initialCallFuture, executor, responseClass, pollingInterval);
     return operationFuture;
   }
 

--- a/src/main/java/com/google/api/gax/grpc/OperationCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/OperationCallable.java
@@ -115,7 +115,7 @@ public final class OperationCallable<RequestT, ResponseT extends Message> {
     }
     RpcFuture<Operation> initialCallFuture = initialCallable.futureCall(request, context);
     Duration pollingInterval =
-        settings != null ? settings.getPollingInterval() : OperationFuture.POLLING_INTERVAL;
+        settings != null ? settings.getPollingInterval() : OperationFuture.DEFAULT_POLLING_INTERVAL;
     OperationFuture<ResponseT> operationFuture =
         OperationFuture.create(
             operationsClient, initialCallFuture, executor, responseClass, pollingInterval);

--- a/src/main/java/com/google/api/gax/grpc/OperationFuture.java
+++ b/src/main/java/com/google/api/gax/grpc/OperationFuture.java
@@ -50,7 +50,7 @@ import org.joda.time.Duration;
 
 /** A RpcFuture which polls a service through OperationsApi for the completion of an operation. */
 public final class OperationFuture<ResponseT extends Message> extends AbstractRpcFuture<ResponseT> {
-  public static final Duration POLLING_INTERVAL = Duration.standardSeconds(1);
+  static final Duration DEFAULT_POLLING_INTERVAL = Duration.standardSeconds(1);
 
   private final RpcFuture<Operation> initialOperationFuture;
   private final SettableFuture<ResponseT> finalResultFuture;
@@ -64,7 +64,11 @@ public final class OperationFuture<ResponseT extends Message> extends AbstractRp
       ScheduledExecutorService executor,
       Class<ResponseT> responseClass) {
     return create(
-        operationsClient, initialOperationFuture, executor, responseClass, POLLING_INTERVAL);
+        operationsClient,
+        initialOperationFuture,
+        executor,
+        responseClass,
+        DEFAULT_POLLING_INTERVAL);
   }
 
   /** Creates an OperationFuture with a custom polling interval. */

--- a/src/main/java/com/google/api/gax/grpc/OperationFuture.java
+++ b/src/main/java/com/google/api/gax/grpc/OperationFuture.java
@@ -50,9 +50,7 @@ import org.joda.time.Duration;
 
 /** A RpcFuture which polls a service through OperationsApi for the completion of an operation. */
 public final class OperationFuture<ResponseT extends Message> extends AbstractRpcFuture<ResponseT> {
-  // TODO: Use exponential backoff in polling schedule
-  // https://github.com/googleapis/gax-java/issues/146
-  private static final Duration POLLING_INTERVAL = Duration.standardSeconds(1);
+  public static final Duration POLLING_INTERVAL = Duration.standardSeconds(1);
 
   private final RpcFuture<Operation> initialOperationFuture;
   private final SettableFuture<ResponseT> finalResultFuture;


### PR DESCRIPTION
Now the API client can config the duration of polling interval through `OperationCallSettings`.

cc/ @pbogle