### PR TITLE
Fixing apidocs index.html template

### DIFF
--- a/templates/apidocs_index.html.template
+++ b/templates/apidocs_index.html.template
@@ -1,1 +1,1 @@
-<html><head><meta http-equiv=\"refresh\" content=\"0; URL='http://googleapis.github.io/gax-java/{{siteVersion}}/apidocs/'\" /></head><body></body></html>
+<html><head><meta http-equiv="refresh" content="0; URL='http://googleapis.github.io/gax-java/{{siteVersion}}/apidocs/'" /></head><body></body></html>


### PR DESCRIPTION
The backlashes were required in the context where this was copied from (inside a string); they need to be removed or the redirect simply doesn't work.
