### PR TITLE
Make grpc version more robust.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ task createProperties(dependsOn: processResources) << {
   new File("$buildDir/resources/main/com/google/api/gax/").mkdirs()
   Properties p = new Properties()
   p['version'] = project.version.toString()
+  p['grpc_version'] = grpcVersion
   p.store(new PrintWriter("$buildDir/resources/main/com/google/api/gax/gax.properties", "UTF-8"), null)
 }
 

--- a/src/main/java/com/google/api/gax/grpc/InstantiatingChannelProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/InstantiatingChannelProvider.java
@@ -58,7 +58,7 @@ import java.util.concurrent.Executor;
  */
 public final class InstantiatingChannelProvider implements ChannelProvider {
   private static final String DEFAULT_VERSION = "";
-  private static Properties gaxProperties = new Properties();
+  private static Properties gaxProperties = new Properties() ;
 
   private final ExecutorProvider executorProvider;
   private final CredentialsProvider credentialsProvider;
@@ -68,6 +68,7 @@ public final class InstantiatingChannelProvider implements ChannelProvider {
   private final String clientLibVersion;
   private final String generatorName;
   private final String generatorVersion;
+
 
   private InstantiatingChannelProvider(
       ExecutorProvider executorProvider,
@@ -190,9 +191,11 @@ public final class InstantiatingChannelProvider implements ChannelProvider {
 
   private static String loadGaxProperty(String key) {
     try {
-      gaxProperties.load(
-          InstantiatingChannelProvider.class
-              .getResourceAsStream("/com/google/api/gax/gax.properties"));
+      if (gaxProperties.isEmpty()) {
+        gaxProperties.load(
+            InstantiatingChannelProvider.class
+            .getResourceAsStream("/com/google/api/gax/gax.properties"));
+      }
       return gaxProperties.getProperty(key);
     } catch (IOException e) {
       e.printStackTrace(System.err);

--- a/src/main/java/com/google/api/gax/grpc/InstantiatingChannelProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/InstantiatingChannelProvider.java
@@ -191,9 +191,15 @@ public final class InstantiatingChannelProvider implements ChannelProvider {
   }
 
   private static String getGrpcVersion() {
-    String grpcVersion = ManagedChannel.class.getPackage().getImplementationVersion();
-    if (grpcVersion == null) {
-      grpcVersion = DEFAULT_VERSION;
+    String grpcVersion = DEFAULT_VERSION;
+    Properties gaxProperties = new Properties();
+    try {
+      gaxProperties.load(
+          InstantiatingChannelProvider.class
+              .getResourceAsStream("/com/google/api/gax/gax.properties"));
+      grpcVersion = gaxProperties.getProperty("grpc_version");
+    } catch (IOException e) {
+      e.printStackTrace(System.err);
     }
     return grpcVersion;
   }

--- a/src/main/java/com/google/api/gax/grpc/InstantiatingChannelProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/InstantiatingChannelProvider.java
@@ -58,6 +58,7 @@ import java.util.concurrent.Executor;
  */
 public final class InstantiatingChannelProvider implements ChannelProvider {
   private static final String DEFAULT_VERSION = "";
+  private static Properties gaxProperties = new Properties();
 
   private final ExecutorProvider executorProvider;
   private final CredentialsProvider credentialsProvider;
@@ -177,31 +178,26 @@ public final class InstantiatingChannelProvider implements ChannelProvider {
 
   @VisibleForTesting
   static String getGaxVersion() {
-    String gaxVersion = DEFAULT_VERSION;
-    Properties gaxProperties = new Properties();
-    try {
-      gaxProperties.load(
-          InstantiatingChannelProvider.class
-              .getResourceAsStream("/com/google/api/gax/gax.properties"));
-      gaxVersion = gaxProperties.getProperty("version");
-    } catch (IOException e) {
-      e.printStackTrace(System.err);
-    }
-    return gaxVersion;
+    String gaxVersion = loadGaxProperty("version");
+    return gaxVersion != null ? gaxVersion : DEFAULT_VERSION;
   }
 
-  private static String getGrpcVersion() {
-    String grpcVersion = DEFAULT_VERSION;
-    Properties gaxProperties = new Properties();
+  @VisibleForTesting
+  static String getGrpcVersion() {
+    String grpcVersion = loadGaxProperty("grpc_version");
+    return grpcVersion != null ? grpcVersion : DEFAULT_VERSION;
+  }
+
+  private static String loadGaxProperty(String key) {
     try {
       gaxProperties.load(
           InstantiatingChannelProvider.class
               .getResourceAsStream("/com/google/api/gax/gax.properties"));
-      grpcVersion = gaxProperties.getProperty("grpc_version");
+      return gaxProperties.getProperty(key);
     } catch (IOException e) {
       e.printStackTrace(System.err);
     }
-    return grpcVersion;
+    return null;
   }
 
   private static String getJavaVersion() {

--- a/src/main/java/com/google/api/gax/grpc/InstantiatingChannelProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/InstantiatingChannelProvider.java
@@ -58,7 +58,7 @@ import java.util.concurrent.Executor;
  */
 public final class InstantiatingChannelProvider implements ChannelProvider {
   private static final String DEFAULT_VERSION = "";
-  private static Properties gaxProperties = new Properties() ;
+  private static Properties gaxProperties = new Properties();
 
   private final ExecutorProvider executorProvider;
   private final CredentialsProvider credentialsProvider;
@@ -68,7 +68,6 @@ public final class InstantiatingChannelProvider implements ChannelProvider {
   private final String clientLibVersion;
   private final String generatorName;
   private final String generatorVersion;
-
 
   private InstantiatingChannelProvider(
       ExecutorProvider executorProvider,
@@ -194,7 +193,7 @@ public final class InstantiatingChannelProvider implements ChannelProvider {
       if (gaxProperties.isEmpty()) {
         gaxProperties.load(
             InstantiatingChannelProvider.class
-            .getResourceAsStream("/com/google/api/gax/gax.properties"));
+                .getResourceAsStream("/com/google/api/gax/gax.properties"));
       }
       return gaxProperties.getProperty(key);
     } catch (IOException e) {

--- a/src/test/java/com/google/api/gax/grpc/InstantiatingChannelProviderTest.java
+++ b/src/test/java/com/google/api/gax/grpc/InstantiatingChannelProviderTest.java
@@ -63,8 +63,14 @@ public class InstantiatingChannelProviderTest {
   }
 
   @Test
-  public void test() throws Exception {
+  public void testGaxVersion() throws Exception {
     String gaxVersion = InstantiatingChannelProvider.getGaxVersion();
     assertTrue(Pattern.compile("^\\d+\\.\\d+\\.\\d+").matcher(gaxVersion).find());
+  }
+
+  @Test
+  public void testGrpcVersionTest() throws Exception {
+    String grpcVersion = InstantiatingChannelProvider.getGrpcVersion();
+    assertTrue(Pattern.compile("^\\d+\\.\\d+\\.\\d+").matcher(grpcVersion).find());
   }
 }


### PR DESCRIPTION
We used to get the grpc version from runtime package but it does not guarantee that the version is always set. Switch to use the property file.