### PR TITLE
WIP: Renames: Function -> ApiFunction, RpcStreamObserver -> ApiStreamObserver

### DIFF
--- a/src/main/java/com/google/api/gax/batching/ThresholdBatcher.java
+++ b/src/main/java/com/google/api/gax/batching/ThresholdBatcher.java
@@ -29,10 +29,10 @@
  */
 package com.google.api.gax.batching;
 
+import com.google.api.gax.core.ApiFunction;
 import com.google.api.gax.core.ApiFuture;
 import com.google.api.gax.core.ApiFutures;
 import com.google.api.gax.core.FlowController.FlowControlException;
-import com.google.api.gax.core.Function;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
@@ -49,7 +49,7 @@ import org.joda.time.Duration;
  */
 public final class ThresholdBatcher<E> {
 
-  private class ReleaseResourcesFunction<T> implements Function<T, Void> {
+  private class ReleaseResourcesFunction<T> implements ApiFunction<T, Void> {
     private final E batch;
 
     private ReleaseResourcesFunction(E batch) {

--- a/src/main/java/com/google/api/gax/core/ApiFunction.java
+++ b/src/main/java/com/google/api/gax/core/ApiFunction.java
@@ -35,6 +35,6 @@ package com.google.api.gax.core;
  * <p>
  * It is similar to Guava's {@code Function}, redeclared so that Guava can be shaded.
  */
-public interface Function<F, T> {
+public interface ApiFunction<F, T> {
   T apply(F input);
 }

--- a/src/main/java/com/google/api/gax/core/ApiFutures.java
+++ b/src/main/java/com/google/api/gax/core/ApiFutures.java
@@ -62,7 +62,7 @@ public final class ApiFutures {
   public static <V, X extends Throwable> ApiFuture catching(
       ApiFuture<? extends V> input,
       Class<X> exceptionType,
-      Function<? super X, ? extends V> callback) {
+      ApiFunction<? super X, ? extends V> callback) {
     ListenableFuture<V> catchingFuture =
         Futures.catching(
             listenableFutureForApiFuture(input),
@@ -80,7 +80,7 @@ public final class ApiFutures {
   }
 
   public static <V, X> ApiFuture<X> transform(
-      ApiFuture<? extends V> input, final Function<? super V, ? extends X> function) {
+      ApiFuture<? extends V> input, final ApiFunction<? super V, ? extends X> function) {
     return new ListenableFutureToApiFuture<>(
         Futures.transform(
             listenableFutureForApiFuture(input), new GaxFunctionToGuavaFunction<V, X>(function)));
@@ -99,9 +99,9 @@ public final class ApiFutures {
 
   private static class GaxFunctionToGuavaFunction<X, V>
       implements com.google.common.base.Function<X, V> {
-    private Function<? super X, ? extends V> f;
+    private ApiFunction<? super X, ? extends V> f;
 
-    public GaxFunctionToGuavaFunction(Function<? super X, ? extends V> f) {
+    public GaxFunctionToGuavaFunction(ApiFunction<? super X, ? extends V> f) {
       this.f = f;
     }
 

--- a/src/main/java/com/google/api/gax/core/ApiStreamObserver.java
+++ b/src/main/java/com/google/api/gax/core/ApiStreamObserver.java
@@ -37,22 +37,22 @@ package com.google.api.gax.core;
  * receiving messages in bidi or server-streaming calls.
  *
  * <p>
- * For outgoing messages, an {@code RpcStreamObserver} is provided by GAX to the application, and
+ * For outgoing messages, an {@code ApiStreamObserver} is provided by GAX to the application, and
  * the application then provides the messages to send. For incoming messages, the application
- * implements the {@code RpcStreamObserver} and passes it to GAX, which then calls the observer with
+ * implements the {@code ApiStreamObserver} and passes it to GAX, which then calls the observer with
  * the messages for the application to receive them.
  *
  * <p>
  * Implementations are expected to be <a
  * href="http://www.ibm.com/developerworks/library/j-jtp09263/">thread-compatible</a>. Separate
- * {@code RpcStreamObserver}s do not need to be synchronized together; incoming and outgoing
- * directions are independent. Since individual {@code RpcStreamObserver}s are not thread-safe, if
- * multiple threads will be writing to a {@code RpcStreamObserver} concurrently, the application
+ * {@code ApiStreamObserver}s do not need to be synchronized together; incoming and outgoing
+ * directions are independent. Since individual {@code ApiStreamObserver}s are not thread-safe, if
+ * multiple threads will be writing to a {@code ApiStreamObserver} concurrently, the application
  * must synchronize calls.
  *
  * This class is a fork of io.grpc.stub.StreamObserver to enable shadowing of Guava.
  */
-public interface RpcStreamObserver<V> {
+public interface ApiStreamObserver<V> {
   /**
    * Receives a value from the stream.
    *

--- a/src/main/java/com/google/api/gax/grpc/DirectStreamingCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/DirectStreamingCallable.java
@@ -29,7 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
-import com.google.api.gax.core.RpcStreamObserver;
+import com.google.api.gax.core.ApiStreamObserver;
 import com.google.common.base.Preconditions;
 import io.grpc.ClientCall;
 import io.grpc.stub.ClientCalls;
@@ -56,7 +56,7 @@ class DirectStreamingCallable<RequestT, ResponseT> {
   }
 
   void serverStreamingCall(
-      RequestT request, RpcStreamObserver<ResponseT> responseObserver, CallContext context) {
+      RequestT request, ApiStreamObserver<ResponseT> responseObserver, CallContext context) {
     Preconditions.checkNotNull(request);
     Preconditions.checkNotNull(responseObserver);
     ClientCall<RequestT, ResponseT> call =
@@ -72,8 +72,8 @@ class DirectStreamingCallable<RequestT, ResponseT> {
     return ClientCalls.blockingServerStreamingCall(call, request);
   }
 
-  RpcStreamObserver<RequestT> bidiStreamingCall(
-      RpcStreamObserver<ResponseT> responseObserver, CallContext context) {
+  ApiStreamObserver<RequestT> bidiStreamingCall(
+      ApiStreamObserver<ResponseT> responseObserver, CallContext context) {
     Preconditions.checkNotNull(responseObserver);
     ClientCall<RequestT, ResponseT> call =
         factory.newCall(context.getChannel(), context.getCallOptions());
@@ -81,8 +81,8 @@ class DirectStreamingCallable<RequestT, ResponseT> {
         ClientCalls.asyncBidiStreamingCall(call, new RpcStreamObserverDelegate(responseObserver)));
   }
 
-  RpcStreamObserver<RequestT> clientStreamingCall(
-      RpcStreamObserver<ResponseT> responseObserver, CallContext context) {
+  ApiStreamObserver<RequestT> clientStreamingCall(
+      ApiStreamObserver<ResponseT> responseObserver, CallContext context) {
     Preconditions.checkNotNull(responseObserver);
     ClientCall<RequestT, ResponseT> call =
         factory.newCall(context.getChannel(), context.getCallOptions());
@@ -93,9 +93,9 @@ class DirectStreamingCallable<RequestT, ResponseT> {
 
   private static class RpcStreamObserverDelegate<V> implements StreamObserver<V> {
 
-    private final RpcStreamObserver<V> delegate;
+    private final ApiStreamObserver<V> delegate;
 
-    public RpcStreamObserverDelegate(RpcStreamObserver<V> delegate) {
+    public RpcStreamObserverDelegate(ApiStreamObserver<V> delegate) {
       this.delegate = delegate;
     }
 
@@ -115,7 +115,7 @@ class DirectStreamingCallable<RequestT, ResponseT> {
     }
   }
 
-  private static class StreamObserverDelegate<V> implements RpcStreamObserver<V> {
+  private static class StreamObserverDelegate<V> implements ApiStreamObserver<V> {
 
     private final StreamObserver<V> delegate;
 

--- a/src/main/java/com/google/api/gax/grpc/StreamingCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/StreamingCallable.java
@@ -29,7 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
-import com.google.api.gax.core.RpcStreamObserver;
+import com.google.api.gax.core.ApiStreamObserver;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.grpc.Channel;
@@ -87,11 +87,11 @@ public class StreamingCallable<RequestT, ResponseT> {
   /**
    * Conduct a bidirectional streaming call
    *
-   * @param responseObserver {@link RpcStreamObserver} to observe the streaming responses
-   * @return {@link RpcStreamObserver} which is used for making streaming requests.
+   * @param responseObserver {@link ApiStreamObserver} to observe the streaming responses
+   * @return {@link ApiStreamObserver} which is used for making streaming requests.
    */
-  public RpcStreamObserver<RequestT> bidiStreamingCall(
-      RpcStreamObserver<ResponseT> responseObserver) {
+  public ApiStreamObserver<RequestT> bidiStreamingCall(
+      ApiStreamObserver<ResponseT> responseObserver) {
     Preconditions.checkNotNull(channel);
     return callable.bidiStreamingCall(
         responseObserver, CallContext.createDefault().withChannel(channel));
@@ -101,13 +101,13 @@ public class StreamingCallable<RequestT, ResponseT> {
    * Conduct a bidirectional streaming call with the given
    * {@link com.google.api.gax.grpc.CallContext}.
    *
-   * @param responseObserver {@link RpcStreamObserver} to observe the streaming responses
+   * @param responseObserver {@link ApiStreamObserver} to observe the streaming responses
    * @param context {@link CallContext} to provide context information of the gRPC call. The
    * existing channel will be overridden by the channel contained in the context (if any).
-   * @return {@link RpcStreamObserver} which is used for making streaming requests.
+   * @return {@link ApiStreamObserver} which is used for making streaming requests.
    */
-  public RpcStreamObserver<RequestT> bidiStreamingCall(
-      RpcStreamObserver<ResponseT> responseObserver, CallContext context) {
+  public ApiStreamObserver<RequestT> bidiStreamingCall(
+      ApiStreamObserver<ResponseT> responseObserver, CallContext context) {
     if (context.getChannel() == null) {
       context = context.withChannel(channel);
     }
@@ -119,9 +119,9 @@ public class StreamingCallable<RequestT, ResponseT> {
    * Conduct a server streaming call
    *
    * @param request request
-   * @param responseObserver {@link RpcStreamObserver} to observe the streaming responses
+   * @param responseObserver {@link ApiStreamObserver} to observe the streaming responses
    */
-  public void serverStreamingCall(RequestT request, RpcStreamObserver<ResponseT> responseObserver) {
+  public void serverStreamingCall(RequestT request, ApiStreamObserver<ResponseT> responseObserver) {
     Preconditions.checkNotNull(channel);
     callable.serverStreamingCall(
         request, responseObserver, CallContext.createDefault().withChannel(channel));
@@ -131,12 +131,12 @@ public class StreamingCallable<RequestT, ResponseT> {
    * Conduct a server streaming call with the given {@link com.google.api.gax.grpc.CallContext}.
    *
    * @param request request
-   * @param responseObserver {@link RpcStreamObserver} to observe the streaming responses
+   * @param responseObserver {@link ApiStreamObserver} to observe the streaming responses
    * @param context {@link CallContext} to provide context information of the gRPC call. The
    * existing channel will be overridden by the channel contained in the context (if any).
    */
   public void serverStreamingCall(
-      RequestT request, RpcStreamObserver<ResponseT> responseObserver, CallContext context) {
+      RequestT request, ApiStreamObserver<ResponseT> responseObserver, CallContext context) {
     if (context.getChannel() == null) {
       context = context.withChannel(channel);
     }
@@ -174,11 +174,11 @@ public class StreamingCallable<RequestT, ResponseT> {
   /**
    * Conduct a client streaming call
    *
-   * @param responseObserver {@link RpcStreamObserver} to receive the non-streaming response.
-   * @return {@link RpcStreamObserver} which is used for making streaming requests.
+   * @param responseObserver {@link ApiStreamObserver} to receive the non-streaming response.
+   * @return {@link ApiStreamObserver} which is used for making streaming requests.
    */
-  public RpcStreamObserver<RequestT> clientStreamingCall(
-      RpcStreamObserver<ResponseT> responseObserver) {
+  public ApiStreamObserver<RequestT> clientStreamingCall(
+      ApiStreamObserver<ResponseT> responseObserver) {
     Preconditions.checkNotNull(channel);
     return callable.clientStreamingCall(
         responseObserver, CallContext.createDefault().withChannel(channel));
@@ -187,13 +187,13 @@ public class StreamingCallable<RequestT, ResponseT> {
   /**
    * Conduct a client streaming call with the given {@link CallContext}
    *
-   * @param responseObserver {@link RpcStreamObserver} to receive the non-streaming response.
+   * @param responseObserver {@link ApiStreamObserver} to receive the non-streaming response.
    * @param context {@link CallContext} to provide context information of the gRPC call. The
    * existing channel will be overridden by the channel contained in the context (if any)
-   * @return {@link RpcStreamObserver} which is used for making streaming requests.
+   * @return {@link ApiStreamObserver} which is used for making streaming requests.
    */
-  public RpcStreamObserver<RequestT> clientStreamingCall(
-      RpcStreamObserver<ResponseT> responseObserver, CallContext context) {
+  public ApiStreamObserver<RequestT> clientStreamingCall(
+      ApiStreamObserver<ResponseT> responseObserver, CallContext context) {
     if (context.getChannel() == null) {
       context = context.withChannel(channel);
     }

--- a/src/main/java/com/google/api/gax/testing/MockStreamObserver.java
+++ b/src/main/java/com/google/api/gax/testing/MockStreamObserver.java
@@ -29,15 +29,15 @@
  */
 package com.google.api.gax.testing;
 
-import com.google.api.gax.core.RpcStreamObserver;
+import com.google.api.gax.core.ApiStreamObserver;
 import com.google.common.util.concurrent.SettableFuture;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * An implementation of RpcStreamObserver used by testing.
+ * An implementation of ApiStreamObserver used by testing.
  */
-public class MockStreamObserver<T> implements RpcStreamObserver<T> {
+public class MockStreamObserver<T> implements ApiStreamObserver<T> {
 
   private final SettableFuture<List<T>> future = SettableFuture.create();
   private final List<T> actualMessages = new ArrayList<>();

--- a/src/test/java/com/google/api/gax/core/ApiFuturesTest.java
+++ b/src/test/java/com/google/api/gax/core/ApiFuturesTest.java
@@ -63,7 +63,7 @@ public class ApiFuturesTest {
         ApiFutures.catching(
             future,
             Exception.class,
-            new Function<Exception, Integer>() {
+            new ApiFunction<Exception, Integer>() {
               @Override
               public Integer apply(Exception ex) {
                 return 42;
@@ -79,7 +79,7 @@ public class ApiFuturesTest {
     ApiFuture<String> transformedFuture =
         ApiFutures.transform(
             inputFuture,
-            new Function<Integer, String>() {
+            new ApiFunction<Integer, String>() {
               @Override
               public String apply(Integer input) {
                 return input.toString();

--- a/src/test/java/com/google/api/gax/grpc/BatchedFutureTest.java
+++ b/src/test/java/com/google/api/gax/grpc/BatchedFutureTest.java
@@ -29,9 +29,9 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.gax.core.ApiFunction;
 import com.google.api.gax.core.ApiFuture;
 import com.google.api.gax.core.ApiFutures;
-import com.google.api.gax.core.Function;
 import com.google.common.truth.Truth;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
@@ -53,7 +53,7 @@ public class BatchedFutureTest {
     ApiFuture<String> transformedFuture =
         ApiFutures.transform(
             inputFuture,
-            new Function<Integer, String>() {
+            new ApiFunction<Integer, String>() {
               @Override
               public String apply(Integer input) {
                 return input.toString();

--- a/src/test/java/com/google/api/gax/grpc/StreamingCallableTest.java
+++ b/src/test/java/com/google/api/gax/grpc/StreamingCallableTest.java
@@ -29,7 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
-import com.google.api.gax.core.RpcStreamObserver;
+import com.google.api.gax.core.ApiStreamObserver;
 import com.google.common.truth.Truth;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -49,7 +49,7 @@ public class StreamingCallableTest {
     ClientCallFactory<Integer, Integer> factory = Mockito.mock(ClientCallFactory.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(factory);
     StreamingCallable<Integer, Integer> apiCallable = new StreamingCallable<>(stash, channel, null);
-    RpcStreamObserver<Integer> observer = Mockito.mock(RpcStreamObserver.class);
+    ApiStreamObserver<Integer> observer = Mockito.mock(ApiStreamObserver.class);
     apiCallable.bidiStreamingCall(observer);
     Truth.assertThat(stash.context.getChannel()).isSameAs(channel);
   }
@@ -72,7 +72,7 @@ public class StreamingCallableTest {
     ClientCallFactory<Integer, Integer> factory = Mockito.mock(ClientCallFactory.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(factory);
     StreamingCallable<Integer, Integer> apiCallable = new StreamingCallable<>(stash, channel, null);
-    RpcStreamObserver<Integer> observer = Mockito.mock(RpcStreamObserver.class);
+    ApiStreamObserver<Integer> observer = Mockito.mock(ApiStreamObserver.class);
     apiCallable.bidiStreamingCall(observer);
     Truth.assertThat(stash.actualObserver).isSameAs(observer);
   }
@@ -85,7 +85,7 @@ public class StreamingCallableTest {
     ClientCallFactory<Integer, Integer> factory = Mockito.mock(ClientCallFactory.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(factory);
     StreamingCallable<Integer, Integer> apiCallable = new StreamingCallable<>(stash, channel, null);
-    RpcStreamObserver<Integer> observer = Mockito.mock(RpcStreamObserver.class);
+    ApiStreamObserver<Integer> observer = Mockito.mock(ApiStreamObserver.class);
     apiCallable.bidiStreamingCall(observer, context);
     Truth.assertThat(stash.actualObserver).isSameAs(observer);
     Truth.assertThat(stash.context).isSameAs(context);
@@ -98,7 +98,7 @@ public class StreamingCallableTest {
     ClientCallFactory<Integer, Integer> factory = Mockito.mock(ClientCallFactory.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(factory);
     StreamingCallable<Integer, Integer> apiCallable = new StreamingCallable<>(stash, channel, null);
-    RpcStreamObserver<Integer> observer = Mockito.mock(RpcStreamObserver.class);
+    ApiStreamObserver<Integer> observer = Mockito.mock(ApiStreamObserver.class);
     apiCallable.clientStreamingCall(observer);
     Truth.assertThat(stash.actualObserver).isSameAs(observer);
   }
@@ -111,7 +111,7 @@ public class StreamingCallableTest {
     ClientCallFactory<Integer, Integer> factory = Mockito.mock(ClientCallFactory.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(factory);
     StreamingCallable<Integer, Integer> apiCallable = new StreamingCallable<>(stash, channel, null);
-    RpcStreamObserver<Integer> observer = Mockito.mock(RpcStreamObserver.class);
+    ApiStreamObserver<Integer> observer = Mockito.mock(ApiStreamObserver.class);
     apiCallable.clientStreamingCall(observer, context);
     Truth.assertThat(stash.actualObserver).isSameAs(observer);
     Truth.assertThat(stash.context).isSameAs(context);
@@ -124,7 +124,7 @@ public class StreamingCallableTest {
     ClientCallFactory<Integer, Integer> factory = Mockito.mock(ClientCallFactory.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(factory);
     StreamingCallable<Integer, Integer> apiCallable = new StreamingCallable<>(stash, channel, null);
-    RpcStreamObserver<Integer> observer = Mockito.mock(RpcStreamObserver.class);
+    ApiStreamObserver<Integer> observer = Mockito.mock(ApiStreamObserver.class);
     Integer request = 1;
     apiCallable.serverStreamingCall(request, observer);
     Truth.assertThat(stash.actualObserver).isSameAs(observer);
@@ -139,7 +139,7 @@ public class StreamingCallableTest {
     ClientCallFactory<Integer, Integer> factory = Mockito.mock(ClientCallFactory.class);
     StashCallable<Integer, Integer> stash = new StashCallable<>(factory);
     StreamingCallable<Integer, Integer> apiCallable = new StreamingCallable<>(stash, channel, null);
-    RpcStreamObserver<Integer> observer = Mockito.mock(RpcStreamObserver.class);
+    ApiStreamObserver<Integer> observer = Mockito.mock(ApiStreamObserver.class);
     Integer request = 1;
     apiCallable.serverStreamingCall(request, observer, context);
     Truth.assertThat(stash.actualObserver).isSameAs(observer);
@@ -176,7 +176,7 @@ public class StreamingCallableTest {
   private static class StashCallable<RequestT, ResponseT>
       extends DirectStreamingCallable<RequestT, ResponseT> {
     CallContext context;
-    RpcStreamObserver<ResponseT> actualObserver;
+    ApiStreamObserver<ResponseT> actualObserver;
     RequestT actualRequest;
 
     StashCallable(ClientCallFactory<RequestT, ResponseT> factory) {
@@ -185,7 +185,7 @@ public class StreamingCallableTest {
 
     @Override
     void serverStreamingCall(
-        RequestT request, RpcStreamObserver<ResponseT> responseObserver, CallContext context) {
+        RequestT request, ApiStreamObserver<ResponseT> responseObserver, CallContext context) {
       Truth.assertThat(request).isNotNull();
       Truth.assertThat(responseObserver).isNotNull();
       actualRequest = request;
@@ -202,8 +202,8 @@ public class StreamingCallableTest {
     }
 
     @Override
-    RpcStreamObserver<RequestT> bidiStreamingCall(
-        RpcStreamObserver<ResponseT> responseObserver, CallContext context) {
+    ApiStreamObserver<RequestT> bidiStreamingCall(
+        ApiStreamObserver<ResponseT> responseObserver, CallContext context) {
       Truth.assertThat(responseObserver).isNotNull();
       actualObserver = responseObserver;
       this.context = context;
@@ -211,8 +211,8 @@ public class StreamingCallableTest {
     }
 
     @Override
-    RpcStreamObserver<RequestT> clientStreamingCall(
-        RpcStreamObserver<ResponseT> responseObserver, CallContext context) {
+    ApiStreamObserver<RequestT> clientStreamingCall(
+        ApiStreamObserver<ResponseT> responseObserver, CallContext context) {
       Truth.assertThat(responseObserver).isNotNull();
       actualObserver = responseObserver;
       this.context = context;


### PR DESCRIPTION
Reasons:

* `Function` clashes with the corresponding class in Guava, requiring us to fully qualify one of them in google-cloud-java; prefixing `Api` solves that
* `RpcStreamObserver` won't necessarily involve an RPC; changing the prefix to `Api` makes it more accurate (and matches what we did with `ApiFuture`)
