### PR TITLE
Add setEndpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -404,3 +404,11 @@ task createApiDocsRedirect {
 task updateDocsWithCurrentVersion {
   dependsOn 'createApiDocsRedirect'
 }
+
+allprojects {
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+        }
+    }
+}

--- a/src/main/java/com/google/api/gax/grpc/InstantiatingChannelProvider.java
+++ b/src/main/java/com/google/api/gax/grpc/InstantiatingChannelProvider.java
@@ -139,14 +139,28 @@ public final class InstantiatingChannelProvider implements ChannelProvider {
     return credentialsProvider;
   }
 
-  /** The address used to reach the service. */
+  /**
+   * The address used to reach the service.
+   *
+   * @deprecated use {@link getEndpoint} instead.
+   */
+  @Deprecated
   public String getServiceAddress() {
     return serviceAddress;
   }
 
-  /** The port used to reach the service. */
+  /**
+   * The port used to reach the service.
+   *
+   * @deprecated use {@link getEndpoint} instead.
+   */
+  @Deprecated
   public int getPort() {
     return port;
+  }
+
+  public String getEndpoint() {
+    return serviceAddress + ':' + port;
   }
 
   @Override
@@ -264,24 +278,60 @@ public final class InstantiatingChannelProvider implements ChannelProvider {
       return credentialsProvider;
     }
 
-    /** Sets the address used to reach the service. */
+    /** Sets the endpoint used to reach the service, eg "localhost:8080". */
+    public Builder setEndpoint(String endpoint) {
+      int colon = endpoint.indexOf(':');
+      if (colon < 0) {
+        throw new IllegalArgumentException(
+            String.format("invalid endpoint, expecting \"<host>:<port>\""));
+      }
+      this.port = Integer.parseInt(endpoint.substring(colon + 1));
+      this.serviceAddress = endpoint.substring(0, colon);
+      return this;
+    }
+
+    public String getEndpoint() {
+      return serviceAddress + ':' + port;
+    }
+
+    /**
+     * Sets the address used to reach the service.
+     *
+     * @deprecated use {@link setEndpoint} instead.
+     */
+    @Deprecated
     public Builder setServiceAddress(String serviceAddress) {
       this.serviceAddress = serviceAddress;
       return this;
     }
 
-    /** The address used to reach the service. */
+    /**
+     * The address used to reach the service.
+     *
+     * @deprecated use {@link getEndpoint} instead.
+     */
+    @Deprecated
     public String getServiceAddress() {
       return serviceAddress;
     }
 
-    /** Sets the port used to reach the service. */
+    /**
+     * Sets the port used to reach the service.
+     *
+     * @deprecated use {@link setEndpoint} instead.
+     */
+    @Deprecated
     public Builder setPort(int port) {
       this.port = port;
       return this;
     }
 
-    /** The port used to reach the service. */
+    /**
+     * The port used to reach the service.
+     *
+     * @deprecated use {@link getEndpoint} instead.
+     */
+    @Deprecated
     public int getPort() {
       return port;
     }

--- a/src/test/java/com/google/api/gax/grpc/InstantiatingChannelProviderTest.java
+++ b/src/test/java/com/google/api/gax/grpc/InstantiatingChannelProviderTest.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.regex.Pattern;
@@ -38,6 +39,26 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class InstantiatingChannelProviderTest {
+  @Test
+  public void testEndpoint() {
+    String endpoint = "localhost:8080";
+    InstantiatingChannelProvider.Builder builder = InstantiatingChannelProvider.newBuilder();
+    builder.setEndpoint(endpoint);
+    assertEquals(builder.getEndpoint(), endpoint);
+
+    InstantiatingChannelProvider provider = builder.build();
+    assertEquals(provider.getEndpoint(), endpoint);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testEndpointNoPort() {
+    InstantiatingChannelProvider.newBuilder().setEndpoint("localhost");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testEndpointBadPort() {
+    InstantiatingChannelProvider.newBuilder().setEndpoint("localhost:abcd");
+  }
 
   @Test
   public void testServiceHeaderDefault() {

--- a/src/test/java/com/google/api/gax/grpc/SettingsTest.java
+++ b/src/test/java/com/google/api/gax/grpc/SettingsTest.java
@@ -78,6 +78,8 @@ public class SettingsTest {
 
     public static final String DEFAULT_SERVICE_ADDRESS = "pubsub-experimental.googleapis.com";
     public static final int DEFAULT_SERVICE_PORT = 443;
+    public static final String DEFAULT_SERVICE_ENDPOINT =
+        DEFAULT_SERVICE_ADDRESS + ':' + DEFAULT_SERVICE_PORT;
     public static final ImmutableList<String> DEFAULT_SERVICE_SCOPES =
         ImmutableList.<String>builder()
             .add("https://www.googleapis.com/auth/pubsub")
@@ -137,8 +139,7 @@ public class SettingsTest {
 
     public static InstantiatingChannelProvider.Builder defaultChannelProviderBuilder() {
       return InstantiatingChannelProvider.newBuilder()
-          .setServiceAddress(DEFAULT_SERVICE_ADDRESS)
-          .setPort(DEFAULT_SERVICE_PORT)
+          .setEndpoint(DEFAULT_SERVICE_ENDPOINT)
           .setCredentialsProvider(defaultCredentialsProviderBuilder().build());
     }
 
@@ -296,9 +297,7 @@ public class SettingsTest {
     InstantiatingChannelProvider actualInstChPr =
         (InstantiatingChannelProvider) actualChannelProvider;
 
-    Truth.assertThat(actualInstChPr.getServiceAddress())
-        .isEqualTo(FakeSettings.DEFAULT_SERVICE_ADDRESS);
-    Truth.assertThat(actualInstChPr.getPort()).isEqualTo(FakeSettings.DEFAULT_SERVICE_PORT);
+    Truth.assertThat(actualInstChPr.getEndpoint()).isEqualTo(FakeSettings.DEFAULT_SERVICE_ENDPOINT);
     //TODO(michaelbausor): create JSON with credentials and define GOOGLE_APPLICATION_CREDENTIALS
     // environment variable to allow travis build to access application default credentials
     Truth.assertThat(actualInstChPr.getCredentials()).isSameAs(credentials);
@@ -422,9 +421,7 @@ public class SettingsTest {
     InstantiatingChannelProvider actualInstChPr =
         (InstantiatingChannelProvider) actualChannelProvider;
 
-    Truth.assertThat(actualInstChPr.getServiceAddress())
-        .isEqualTo(FakeSettings.DEFAULT_SERVICE_ADDRESS);
-    Truth.assertThat(actualInstChPr.getPort()).isEqualTo(FakeSettings.DEFAULT_SERVICE_PORT);
+    Truth.assertThat(actualInstChPr.getEndpoint()).isEqualTo(FakeSettings.DEFAULT_SERVICE_ENDPOINT);
 
     CredentialsProvider actualCredentialsProvider = actualInstChPr.getCredentialsProvider();
     Truth.assertThat(actualCredentialsProvider).isInstanceOf(GoogleCredentialsProvider.class);


### PR DESCRIPTION
This PR also deprecates service address and port methods.
They will eventually be removed, but is kept for now
for backward compatibility.

Updates GoogleCloudPlatform/google-cloud-java#1835