### PR TITLE
DO NOT SUBMIT: bump grpc dependency to 1.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,8 @@ targetCompatibility = 1.7
 ext {
   generatedSrcDir = "${projectDir}/generated/src"
 
-  grpcVersion = '1.0.3'
-  commonProtosVersion = '0.1.6'
+  grpcVersion = '1.2.0'
+  commonProtosVersion = '0.1.7'
 
   // Shortcuts for libraries we are using
   libraries = [

--- a/src/main/java/com/google/api/gax/grpc/FakeMethodDescriptor.java
+++ b/src/main/java/com/google/api/gax/grpc/FakeMethodDescriptor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.grpc;
+
+import io.grpc.MethodDescriptor;
+import java.io.InputStream;
+
+class FakeMethodDescriptor {
+  // Utility class, uninstantiable.
+  private FakeMethodDescriptor() {}
+
+  static <I, O> MethodDescriptor<I, O> create() {
+    return create(MethodDescriptor.MethodType.UNARY, "(default name)");
+  }
+
+  static <I, O> MethodDescriptor<I, O> create(MethodDescriptor.MethodType type, String name) {
+    return MethodDescriptor.create(type, name, new FakeMarshaller<I>(), new FakeMarshaller<O>());
+  }
+
+  private static class FakeMarshaller<T> implements MethodDescriptor.Marshaller<T> {
+    @Override
+    public T parse(InputStream stream) {
+      throw new UnsupportedOperationException("FakeMarshaller doesn't actually do anything");
+    }
+
+    @Override
+    public InputStream stream(T value) {
+      throw new UnsupportedOperationException("FakeMarshaller doesn't actually do anything");
+    }
+  }
+}

--- a/src/main/java/com/google/api/gax/grpc/RetryingCallable.java
+++ b/src/main/java/com/google/api/gax/grpc/RetryingCallable.java
@@ -98,10 +98,10 @@ class RetryingCallable<RequestT, ResponseT> implements FutureCallable<RequestT, 
         oldOptions.withDeadlineAfter(rpcTimeout.getMillis(), TimeUnit.MILLISECONDS);
     CallContext newContext = oldContext.withCallOptions(newOptions);
 
-    if (oldOptions.getDeadlineNanoTime() == null) {
+    if (oldOptions.getDeadline() == null) {
       return newContext;
     }
-    if (oldOptions.getDeadlineNanoTime() < newOptions.getDeadlineNanoTime()) {
+    if (oldOptions.getDeadline().isBefore(newOptions.getDeadline())) {
       return oldContext;
     }
     return newContext;

--- a/src/main/java/com/google/api/gax/testing/FakeMethodDescriptor.java
+++ b/src/main/java/com/google/api/gax/testing/FakeMethodDescriptor.java
@@ -27,20 +27,21 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.google.api.gax.grpc;
+package com.google.api.gax.grpc.testing;
 
 import io.grpc.MethodDescriptor;
 import java.io.InputStream;
 
-class FakeMethodDescriptor {
+public class FakeMethodDescriptor {
   // Utility class, uninstantiable.
   private FakeMethodDescriptor() {}
 
-  static <I, O> MethodDescriptor<I, O> create() {
+  public static <I, O> MethodDescriptor<I, O> create() {
     return create(MethodDescriptor.MethodType.UNARY, "(default name)");
   }
 
-  static <I, O> MethodDescriptor<I, O> create(MethodDescriptor.MethodType type, String name) {
+  public static <I, O> MethodDescriptor<I, O> create(
+      MethodDescriptor.MethodType type, String name) {
     return MethodDescriptor.create(type, name, new FakeMarshaller<I>(), new FakeMarshaller<O>());
   }
 

--- a/src/test/java/com/google/api/gax/grpc/HeaderInterceptorTest.java
+++ b/src/test/java/com/google/api/gax/grpc/HeaderInterceptorTest.java
@@ -61,7 +61,7 @@ public class HeaderInterceptorTest {
 
   @Mock private ClientCall<String, Integer> call;
 
-  @Mock private MethodDescriptor<String, Integer> method;
+  private static final MethodDescriptor<String, Integer> method = FakeMethodDescriptor.create();
 
   /**
    * Sets up mocks.

--- a/src/test/java/com/google/api/gax/grpc/HeaderInterceptorTest.java
+++ b/src/test/java/com/google/api/gax/grpc/HeaderInterceptorTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.api.gax.grpc.testing.FakeMethodDescriptor;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;

--- a/src/test/java/com/google/api/gax/grpc/SettingsTest.java
+++ b/src/test/java/com/google/api/gax/grpc/SettingsTest.java
@@ -66,7 +66,7 @@ public class SettingsTest {
 
     @SuppressWarnings("unchecked")
     private static final MethodDescriptor<Integer, Integer> fakeMethodMethodDescriptor =
-        Mockito.mock(MethodDescriptor.class);
+        FakeMethodDescriptor.create();
 
     @SuppressWarnings("unchecked")
     private static final PagedListResponseFactory<Integer, Integer, FakePagedListResponse>

--- a/src/test/java/com/google/api/gax/grpc/SettingsTest.java
+++ b/src/test/java/com/google/api/gax/grpc/SettingsTest.java
@@ -35,6 +35,7 @@ import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.PagedListResponse;
 import com.google.api.gax.core.RetrySettings;
+import com.google.api.gax.grpc.testing.FakeMethodDescriptor;
 import com.google.auth.Credentials;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/src/test/java/com/google/api/gax/grpc/StreamingCallableTest.java
+++ b/src/test/java/com/google/api/gax/grpc/StreamingCallableTest.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.grpc;
 
 import com.google.api.gax.core.ApiStreamObserver;
+import com.google.api.gax.grpc.testing.FakeMethodDescriptor;
 import com.google.common.truth.Truth;
 import io.grpc.CallOptions;
 import io.grpc.Channel;

--- a/src/test/java/com/google/api/gax/grpc/StreamingCallableTest.java
+++ b/src/test/java/com/google/api/gax/grpc/StreamingCallableTest.java
@@ -57,7 +57,7 @@ public class StreamingCallableTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testCreate() {
-    MethodDescriptor<Integer, Integer> methodDescriptor = Mockito.mock(MethodDescriptor.class);
+    MethodDescriptor<Integer, Integer> methodDescriptor = FakeMethodDescriptor.create();
     Channel channel = Mockito.mock(Channel.class);
     StreamingCallSettings<Integer, Integer> settings =
         StreamingCallSettings.newBuilder(methodDescriptor).build();


### PR DESCRIPTION
Dependency to common proto is also bumped to 0.1.7,
which depends on the same grpc version.

Wait until 0.1.7 is released
and google-cloud-java to be ready
before submitting this.