### PR TITLE
Adding @BetaApi to some core classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ files can use services such as paged list iteration, request batching, and
 polling of long-running operations to provide a more convenient and idiomatic
 API surface to callers.
 
+Currently, this library shouldn't be used independently from google-cloud-java, otherwise there is
+a high risk of diamond dependency problems, because google-cloud-java uses beta features from this
+library which can change in breaking ways between versions. Beta features are annotated with
+`@BetaApi`.
+
 [//]: # (_QUICKSTART_ WARNING: This section is automatically inserted by build scripts)
 
 Quickstart
@@ -81,6 +86,7 @@ This repository contains the following java packages.
   top of protocol buffers. This includes things like expressions (to evaluate
   conditions on protocol buffers), path templates (to compose and decompose
   resource names), type (to represent field types in protocol buffers), etc.
+- `com.google.api.gax.retrying` - Contains classes related to retrying API calls.
 - `com.google.api.gax.testing` - Contains classes which help with testing code
   that interacts with gRPC.
 - `com.google.longrunning` - Contains the mix-in client for long-running operations

--- a/src/main/java/com/google/api/gax/core/ApiStreamObserver.java
+++ b/src/main/java/com/google/api/gax/core/ApiStreamObserver.java
@@ -29,6 +29,8 @@
  */
 package com.google.api.gax.core;
 
+import com.google.api.core.BetaApi;
+
 /**
  * Receives notifications from an observable stream of messages.
  *
@@ -52,6 +54,7 @@ package com.google.api.gax.core;
  *
  * This class is a fork of io.grpc.stub.StreamObserver to enable shadowing of Guava.
  */
+@BetaApi
 public interface ApiStreamObserver<V> {
   /**
    * Receives a value from the stream.

--- a/src/main/java/com/google/api/gax/core/CredentialsProvider.java
+++ b/src/main/java/com/google/api/gax/core/CredentialsProvider.java
@@ -29,12 +29,14 @@
  */
 package com.google.api.gax.core;
 
+import com.google.api.core.BetaApi;
 import com.google.auth.Credentials;
 import java.io.IOException;
 
 /**
  * Provides an interface to hold and acquire the credentials that will be used to call the service.
  */
+@BetaApi
 public interface CredentialsProvider {
   /**
    * Gets the credentials which will be used to call the service. If the credentials have not been

--- a/src/main/java/com/google/api/gax/core/FixedCredentialsProvider.java
+++ b/src/main/java/com/google/api/gax/core/FixedCredentialsProvider.java
@@ -29,12 +29,14 @@
  */
 package com.google.api.gax.core;
 
+import com.google.api.core.BetaApi;
 import com.google.auth.Credentials;
 import com.google.auto.value.AutoValue;
 
 /**
  * FixedCredentialsProvider is a CredentialsProvider which always provides the same credentials.
  */
+@BetaApi
 @AutoValue
 public abstract class FixedCredentialsProvider implements CredentialsProvider {
 

--- a/src/main/java/com/google/api/gax/core/FixedSizeCollection.java
+++ b/src/main/java/com/google/api/gax/core/FixedSizeCollection.java
@@ -29,6 +29,8 @@
  */
 package com.google.api.gax.core;
 
+import com.google.api.core.BetaApi;
+
 /**
  * A FixedSizeCollection object wraps multiple API list method responses into a single collection
  * with a fixed number of elements.
@@ -39,6 +41,7 @@ package com.google.api.gax.core;
  * passed to expandPage(), unless the API has no more elements to return. The FixedSizeCollection
  * object also provides methods to retrieve additional FixedSizeCollections using the page token.
  */
+@BetaApi
 public interface FixedSizeCollection<ResourceT> {
 
   /**

--- a/src/main/java/com/google/api/gax/core/FlowControlSettings.java
+++ b/src/main/java/com/google/api/gax/core/FlowControlSettings.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.core;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.core.FlowController.FlowControlException;
 import com.google.api.gax.core.FlowController.LimitExceededBehavior;
 import com.google.auto.value.AutoValue;
@@ -36,6 +37,7 @@ import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
 
 /** Settings for {@link FlowController}. */
+@BetaApi
 @AutoValue
 public abstract class FlowControlSettings {
   public static FlowControlSettings getDefaultInstance() {
@@ -76,6 +78,7 @@ public abstract class FlowControlSettings {
         .setLimitExceededBehavior(LimitExceededBehavior.Block);
   }
 
+  @BetaApi
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setMaxOutstandingElementCount(Integer value);

--- a/src/main/java/com/google/api/gax/core/FlowController.java
+++ b/src/main/java/com/google/api/gax/core/FlowController.java
@@ -29,11 +29,13 @@
  */
 package com.google.api.gax.core;
 
+import com.google.api.core.BetaApi;
 import com.google.common.base.Preconditions;
 import java.util.concurrent.Semaphore;
 import javax.annotation.Nullable;
 
 /** Provides flow control capability. */
+@BetaApi
 public class FlowController {
   /** Base exception that signals a flow control state. */
   public abstract static class FlowControlException extends Exception {
@@ -44,6 +46,7 @@ public class FlowController {
    * Runtime exception that can be used in place of FlowControlException when an unchecked exception
    * is required.
    */
+  @BetaApi
   public static class FlowControlRuntimeException extends RuntimeException {
     private FlowControlRuntimeException(FlowControlException e) {
       super(e);
@@ -58,6 +61,7 @@ public class FlowController {
    * Exception thrown when client-side flow control is enforced based on the maximum number of
    * outstanding in-memory elements.
    */
+  @BetaApi
   public final static class MaxOutstandingElementCountReachedException
       extends FlowControlException {
     private final int currentMaxElementCount;
@@ -81,6 +85,7 @@ public class FlowController {
    * Exception thrown when client-side flow control is enforced based on the maximum number of
    * unacknowledged in-memory bytes.
    */
+  @BetaApi
   public final static class MaxOutstandingRequestBytesReachedException
       extends FlowControlException {
     private final int currentMaxBytes;
@@ -104,6 +109,7 @@ public class FlowController {
    * Enumeration of behaviors that FlowController can use in case the flow control limits are
    * exceeded.
    */
+  @BetaApi
   public enum LimitExceededBehavior {
     ThrowException,
     Block,

--- a/src/main/java/com/google/api/gax/core/GoogleCredentialsProvider.java
+++ b/src/main/java/com/google/api/gax/core/GoogleCredentialsProvider.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.core;
 
+import com.google.api.core.BetaApi;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auto.value.AutoValue;
@@ -43,6 +44,7 @@ import java.util.List;
  * href="https://developers.google.com/identity/protocols/application-default-credentials">
  * https://developers.google.com/identity/protocols/application-default-credentials</a>.
  */
+@BetaApi
 @AutoValue
 public abstract class GoogleCredentialsProvider implements CredentialsProvider {
 
@@ -65,6 +67,7 @@ public abstract class GoogleCredentialsProvider implements CredentialsProvider {
     return new AutoValue_GoogleCredentialsProvider.Builder(this);
   }
 
+  @BetaApi
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/src/main/java/com/google/api/gax/core/PagedListResponse.java
+++ b/src/main/java/com/google/api/gax/core/PagedListResponse.java
@@ -29,6 +29,8 @@
  */
 package com.google.api.gax.core;
 
+import com.google.api.core.BetaApi;
+
 /**
  * Response for paged results from a list API method
  *
@@ -37,6 +39,7 @@ package com.google.api.gax.core;
  * tokens can be handled automatically, or by the caller. Results can be accessed on a per-element
  * or per-page basis.
  */
+@BetaApi
 public interface PagedListResponse<ResourceT> {
   /**
    * Returns an iterable over the full list of elements. Elements of the list are retrieved lazily

--- a/src/main/java/com/google/api/gax/core/PropertiesProvider.java
+++ b/src/main/java/com/google/api/gax/core/PropertiesProvider.java
@@ -29,12 +29,14 @@
  */
 package com.google.api.gax.core;
 
+import com.google.api.core.BetaApi;
 import java.io.InputStream;
 import java.util.Properties;
 
 /**
  * Provides meta-data properties stored in a properties file.
  */
+@BetaApi
 public class PropertiesProvider {
 
   private static final Properties gaxProperties = new Properties();


### PR DESCRIPTION
Here are the list of classes in core not getting the annotation (meaning they will go to GA when the library goes to 1.0.0):

- AsyncPage
- Page
- RetrySettings
