### PR TITLE
Print warning instead of stacktrace while failed at reading properties.

### DIFF
--- a/src/main/java/com/google/api/gax/core/PropertiesProvider.java
+++ b/src/main/java/com/google/api/gax/core/PropertiesProvider.java
@@ -82,7 +82,7 @@ public class PropertiesProvider {
       }
       return gaxProperties.getProperty(key);
     } catch (Exception e) {
-      e.printStackTrace(System.err);
+      // Ignore
     }
     return null;
   }

--- a/src/main/java/com/google/api/gax/core/PropertiesProvider.java
+++ b/src/main/java/com/google/api/gax/core/PropertiesProvider.java
@@ -73,7 +73,7 @@ public class PropertiesProvider {
         properties.load(inputStream);
         return properties.getProperty(key);
       } else {
-        printFailedOpenFiledWarning(loadedClass, propertyFilePath);
+        printMissingProperties(loadedClass, propertyFilePath);
       }
     } catch (Exception e) {
       e.printStackTrace(System.err);
@@ -88,7 +88,7 @@ public class PropertiesProvider {
         if (inputStream != null) {
           gaxProperties.load(inputStream);
         } else {
-          printFailedOpenFiledWarning(PropertiesProvider.class, GAX_PROPERTY_FILE);
+          printMissingProperties(PropertiesProvider.class, GAX_PROPERTY_FILE);
           return null;
         }
       }
@@ -99,9 +99,9 @@ public class PropertiesProvider {
     return null;
   }
 
-  private static void printFailedOpenFiledWarning(Class<?> loadedClass, String propertyFilePath) {
+  private static void printMissingProperties(Class<?> loadedClass, String propertyFilePath) {
     System.err.format(
-        "Warning: Failed to open the file at '%s' of the given class '%s'\n",
+        "Warning: Failed to open properties resource at '%s' of the given class '%s'\n",
         propertyFilePath,
         loadedClass.getName());
   }

--- a/src/main/java/com/google/api/gax/core/PropertiesProvider.java
+++ b/src/main/java/com/google/api/gax/core/PropertiesProvider.java
@@ -102,7 +102,7 @@ public class PropertiesProvider {
 
   private static void printFileNotFoundWarning(Class<?> loadedClass, String propertyFilePath) {
     System.err.format(
-        "Warning: The property file is not found at %s of the given class %s\n",
+        "Warning: The property file is not found at '%s' of the given class '%s'\n",
         propertyFilePath,
         loadedClass);
   }

--- a/src/main/java/com/google/api/gax/core/PropertiesProvider.java
+++ b/src/main/java/com/google/api/gax/core/PropertiesProvider.java
@@ -77,7 +77,7 @@ public class PropertiesProvider {
         printFileNotFoundWarning(loadedClass, propertyFilePath);
       }
     } catch (Exception e) {
-      System.err.println(e.getStackTrace());
+      e.printStackTrace(System.err);
     }
     return null;
   }
@@ -95,7 +95,7 @@ public class PropertiesProvider {
         printFileNotFoundWarning(PropertiesProvider.class, GAX_PROPERTY_FILE);
       }
     } catch (Exception e) {
-      System.err.println(e.getStackTrace());
+      e.printStackTrace(System.err);
     }
     return null;
   }

--- a/src/main/java/com/google/api/gax/core/PropertiesProvider.java
+++ b/src/main/java/com/google/api/gax/core/PropertiesProvider.java
@@ -37,6 +37,7 @@ import java.util.Properties;
 public class PropertiesProvider {
 
   private static final Properties gaxProperties = new Properties();
+  private static final String GAX_PROPERTY_FILE = "/com/google/api/gax/gax.properties";
   private static final String DEFAULT_VERSION = "";
 
   /**
@@ -68,8 +69,10 @@ public class PropertiesProvider {
       Properties properties = new Properties();
       properties.load(loadedClass.getResourceAsStream(propertyFilePath));
       return properties.getProperty(key);
+    } catch (NullPointerException e) {
+      fileNotFoundWarning(loadedClass, propertyFilePath);
     } catch (Exception e) {
-      e.printStackTrace(System.err);
+      System.err.println(e.getStackTrace());
     }
     return null;
   }
@@ -77,13 +80,19 @@ public class PropertiesProvider {
   private static String loadGaxProperty(String key) {
     try {
       if (gaxProperties.isEmpty()) {
-        gaxProperties.load(
-            PropertiesProvider.class.getResourceAsStream("/com/google/api/gax/gax.properties"));
+        gaxProperties.load(PropertiesProvider.class.getResourceAsStream(GAX_PROPERTY_FILE));
       }
       return gaxProperties.getProperty(key);
+    } catch (NullPointerException e) {
+      fileNotFoundWarning(PropertiesProvider.class, GAX_PROPERTY_FILE);
     } catch (Exception e) {
-      // Ignore
+      System.err.println(e.getStackTrace());
     }
     return null;
+  }
+
+  private static void fileNotFoundWarning(Class<?> loadedClass, String propertyFilePath) {
+    System.err.format("Warning: The property file is not found at %s of the given class %s\n",
+        propertyFilePath, loadedClass);
   }
 }

--- a/src/main/java/com/google/api/gax/core/PropertiesProvider.java
+++ b/src/main/java/com/google/api/gax/core/PropertiesProvider.java
@@ -29,8 +29,7 @@
  */
 package com.google.api.gax.core;
 
-import java.io.File;
-import java.io.FileInputStream;
+import java.io.InputStream;
 import java.util.Properties;
 
 /**
@@ -68,13 +67,13 @@ public class PropertiesProvider {
    */
   public static String loadProperty(Class<?> loadedClass, String propertyFilePath, String key) {
     try {
-      File propertiesFile = new File(loadedClass.getResource(propertyFilePath).getPath());
-      if (propertiesFile.exists()) {
+      InputStream inputStream = loadedClass.getResourceAsStream(propertyFilePath);
+      if (inputStream != null) {
         Properties properties = new Properties();
-        properties.load(new FileInputStream(propertiesFile));
+        properties.load(inputStream);
         return properties.getProperty(key);
       } else {
-        printFileNotFoundWarning(loadedClass, propertyFilePath);
+        printFailedOpenFiledWarning(loadedClass, propertyFilePath);
       }
     } catch (Exception e) {
       e.printStackTrace(System.err);
@@ -84,26 +83,26 @@ public class PropertiesProvider {
 
   private static String loadGaxProperty(String key) {
     try {
-      File propertiesFile =
-          new File(PropertiesProvider.class.getResource(GAX_PROPERTY_FILE).getPath());
-      if (propertiesFile.exists()) {
-        if (gaxProperties.isEmpty()) {
-          gaxProperties.load(new FileInputStream(propertiesFile));
+      if (gaxProperties.isEmpty()) {
+        InputStream inputStream = PropertiesProvider.class.getResourceAsStream(GAX_PROPERTY_FILE);
+        if (inputStream != null) {
+          gaxProperties.load(inputStream);
+        } else {
+          printFailedOpenFiledWarning(PropertiesProvider.class, GAX_PROPERTY_FILE);
+          return null;
         }
-        return gaxProperties.getProperty(key);
-      } else {
-        printFileNotFoundWarning(PropertiesProvider.class, GAX_PROPERTY_FILE);
       }
+      return gaxProperties.getProperty(key);
     } catch (Exception e) {
       e.printStackTrace(System.err);
     }
     return null;
   }
 
-  private static void printFileNotFoundWarning(Class<?> loadedClass, String propertyFilePath) {
+  private static void printFailedOpenFiledWarning(Class<?> loadedClass, String propertyFilePath) {
     System.err.format(
-        "Warning: The property file is not found at '%s' of the given class '%s'\n",
+        "Warning: Failed to open the file at '%s' of the given class '%s'\n",
         propertyFilePath,
-        loadedClass);
+        loadedClass.getName());
   }
 }

--- a/src/main/java/com/google/api/gax/core/PropertiesProvider.java
+++ b/src/main/java/com/google/api/gax/core/PropertiesProvider.java
@@ -92,7 +92,9 @@ public class PropertiesProvider {
   }
 
   private static void fileNotFoundWarning(Class<?> loadedClass, String propertyFilePath) {
-    System.err.format("Warning: The property file is not found at %s of the given class %s\n",
-        propertyFilePath, loadedClass);
+    System.err.format(
+        "Warning: The property file is not found at %s of the given class %s\n",
+        propertyFilePath,
+        loadedClass);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/google-cloud-java/issues/1909