### PR TITLE
Marking more classes @BetaApi

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ API surface to callers.
 
 Currently, this library shouldn't be used independently from google-cloud-java, otherwise there is
 a high risk of diamond dependency problems, because google-cloud-java uses beta features from this
-library which can change in breaking ways between versions. Beta features are annotated with
-`@BetaApi`.
+library which can change in breaking ways between versions. See [VERSIONING](#versioning) for
+more information.
 
 [//]: # (_QUICKSTART_ WARNING: This section is automatically inserted by build scripts)
 
@@ -72,7 +72,26 @@ See the [CONTRIBUTING] documentation for more information on how to get started.
 Versioning
 ----------
 
-This library follows [Semantic Versioning](http://semver.org/).
+This library follows [Semantic Versioning](http://semver.org/), but with some
+additional qualifications:
+
+1. Components marked with `@BetaApi` are considered to be "0.x" features inside
+   a "1.x" library. This means they can change between minor and patch releases
+   in incompatible ways. These features should not be used by any library "B"
+   that itself has consumers, unless the components of library B that use
+   `@BetaApi` features are also marked with `@BetaApi`. Features marked as
+   `@BetaApi` are on a path to eventually become "1.x" features with the marker
+   removed.
+
+   **Special exception for google-cloud-java**: google-cloud-java is
+   allowed to depend on `@BetaApi` features without declaring the consuming
+   code `@BetaApi`, because gax-java and google-cloud-java move in step
+   with each other. For this reason, gax-java should not be used
+   independently of google-cloud-java.
+
+1. Components marked with `@InternalApi` are technically public, but are only
+   public for technical reasons, because of the limitations of Java's access
+   modifiers. For the purposes of semver, they should be considered private.
 
 It is currently in major version zero (``0.y.z``), which means that anything
 may change at any time and the public API should not be considered

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/AbstractFixedSizeCollection.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/AbstractFixedSizeCollection.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.grpc;
 
 import com.google.api.client.util.Lists;
+import com.google.api.core.BetaApi;
 import com.google.api.gax.paging.FixedSizeCollection;
 import com.google.api.pathtemplate.ValidationException;
 import com.google.common.base.Preconditions;
@@ -42,6 +43,7 @@ import java.util.List;
  *
  * <p>This is public only for technical reasons, for advanced usage.
  */
+@BetaApi
 public abstract class AbstractFixedSizeCollection<
         RequestT,
         ResponseT,

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/AbstractPage.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/AbstractPage.java
@@ -32,6 +32,7 @@ package com.google.api.gax.grpc;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
+import com.google.api.core.BetaApi;
 import com.google.api.gax.paging.AsyncPage;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterables;
@@ -42,6 +43,7 @@ import java.util.Iterator;
  *
  * <p>This is public only for technical reasons, for advanced usage.
  */
+@BetaApi
 public abstract class AbstractPage<
         RequestT,
         ResponseT,

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/AbstractPagedListResponse.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/AbstractPagedListResponse.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.paging.PagedListResponse;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.AbstractIterator;
@@ -40,6 +41,7 @@ import java.util.List;
  *
  * <p>This is public only for technical reasons, for advanced usage.
  */
+@BetaApi
 public abstract class AbstractPagedListResponse<
         RequestT,
         ResponseT,

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ApiException.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ApiException.java
@@ -41,6 +41,7 @@ import io.grpc.Status;
  * exception see
  * https://github.com/grpc/grpc-java/blob/master/core/src/main/java/io/grpc/Status.java
  */
+@BetaApi
 public class ApiException extends RuntimeException {
   private static final long serialVersionUID = -725668425459379694L;
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ApiExceptions.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ApiExceptions.java
@@ -30,12 +30,14 @@
 package com.google.api.gax.grpc;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.BetaApi;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.grpc.StatusRuntimeException;
 
 /** A utility class for working with ApiException. */
+@BetaApi
 public class ApiExceptions {
 
   /**

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/AuthInterceptor.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/AuthInterceptor.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.common.base.Preconditions;
 import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
@@ -37,6 +38,7 @@ import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.MethodDescriptor;
 
+@BetaApi
 class AuthInterceptor implements ClientInterceptor {
   private final CallCredentials credentials;
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/Batch.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/Batch.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.batching.RequestBuilder;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,6 +44,7 @@ import java.util.List;
  * <p>Additional batches can be merged into an existing batch using the {@link #merge(Batch)}
  * method. Request objects are combined using a {@link RequestBuilder} into a single request.
  */
+@BetaApi
 public class Batch<RequestT, ResponseT> {
   private final List<BatchedRequestIssuer<ResponseT>> requestIssuerList;
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/BatchedRequestIssuer.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/BatchedRequestIssuer.java
@@ -29,8 +29,10 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.common.base.Preconditions;
 
+@BetaApi
 public final class BatchedRequestIssuer<ResponseT> {
   private final BatchedFuture<ResponseT> batchedFuture;
   private final long messageCount;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/BatcherFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/BatcherFactory.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.batching.BatchMerger;
 import com.google.api.gax.batching.BatchingFlowController;
 import com.google.api.gax.batching.BatchingSettings;
@@ -52,6 +53,7 @@ import java.util.concurrent.ScheduledExecutorService;
  *
  * <p>This is public only for technical reasons, for advanced usage.
  */
+@BetaApi
 public final class BatcherFactory<RequestT, ResponseT> {
   private final Map<PartitionKey, ThresholdBatcher<Batch<RequestT, ResponseT>>> batchers =
       new ConcurrentHashMap<>();

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/BatchingCallSettings.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/BatchingCallSettings.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.common.base.Preconditions;
@@ -43,6 +44,7 @@ import java.util.concurrent.ScheduledExecutorService;
  * A settings class to configure a UnaryCallable for calls to an API method that supports batching.
  * The settings are provided using an instance of {@link BatchingSettings}.
  */
+@BetaApi
 public final class BatchingCallSettings<RequestT, ResponseT>
     extends UnaryCallSettingsTyped<RequestT, ResponseT> {
   private final BatchingDescriptor<RequestT, ResponseT> batchingDescriptor;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/BatchingDescriptor.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/BatchingDescriptor.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.batching.PartitionKey;
 import com.google.api.gax.batching.RequestBuilder;
 import java.util.Collection;
@@ -42,6 +43,7 @@ import java.util.Collection;
  *
  * <p>This is public only for technical reasons, for advanced usage.
  */
+@BetaApi
 public interface BatchingDescriptor<RequestT, ResponseT> {
 
   /** Returns the value of the partition key for the given request. */

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/CallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/CallContext.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 
@@ -40,6 +41,7 @@ import io.grpc.Channel;
  * copies of the object, but with one field changed. The immutability and thread safety of the
  * arguments solely depends on the arguments themselves.
  */
+@BetaApi
 public final class CallContext {
   private final Channel channel;
   private final CallOptions callOptions;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelAndExecutor.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelAndExecutor.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.auto.value.AutoValue;
 import io.grpc.ManagedChannel;
 import java.io.IOException;
@@ -38,6 +39,7 @@ import java.util.concurrent.ScheduledExecutorService;
  * ChannelAndExecutor holds a ManagedChannel and a ScheduledExecutorService that are being provided
  * as a pair.
  */
+@BetaApi
 @AutoValue
 public abstract class ChannelAndExecutor {
   public abstract ScheduledExecutorService getExecutor();

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelProvider.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import io.grpc.ManagedChannel;
 import java.io.IOException;
 import java.util.concurrent.Executor;
@@ -50,6 +51,7 @@ import java.util.concurrent.Executor;
  * }
  * </code></pre>
  */
+@BetaApi
 public interface ChannelProvider {
   /** Indicates whether the channel should be closed by the containing service API class. */
   boolean shouldAutoClose();

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ClientCallFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ClientCallFactory.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -42,6 +43,7 @@ import io.grpc.ClientCall;
  *
  * <p>Package-private for internal use.
  */
+@BetaApi
 interface ClientCallFactory<RequestT, ResponseT> {
   ClientCall<RequestT, ResponseT> newCall(Channel channel, CallOptions callOptions);
 }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ClientSettings.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ClientSettings.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.retrying.RetrySettings;
 import io.grpc.Status;
 import java.io.IOException;
@@ -59,6 +60,7 @@ import java.util.Set;
  *       called on the ProviderManager once all of the service API objects are no longer in use.
  * </ol>
  */
+@BetaApi
 public abstract class ClientSettings {
 
   private final ExecutorProvider executorProvider;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ExecutorProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ExecutorProvider.java
@@ -29,12 +29,14 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Provides an interface to either build a ScheduledExecutorService or provide a fixed
  * ScheduledExecutorService that will be used to make calls to a service.
  */
+@BetaApi
 public interface ExecutorProvider {
   /** Indicates whether the executor should be closed by the containing service API class. */
   boolean shouldAutoClose();

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/FixedChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/FixedChannelProvider.java
@@ -29,10 +29,12 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import io.grpc.ManagedChannel;
 import java.util.concurrent.Executor;
 
 /** FixedChannelProvider is a ChannelProvider which always provides the same channel. */
+@BetaApi
 public final class FixedChannelProvider implements ChannelProvider {
   private final ManagedChannel channel;
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/FixedExecutorProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/FixedExecutorProvider.java
@@ -29,9 +29,11 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import java.util.concurrent.ScheduledExecutorService;
 
 /** FixedExecutorProvider is an ExecutorProvider which always returns the same executor. */
+@BetaApi
 public final class FixedExecutorProvider implements ExecutorProvider {
 
   private final ScheduledExecutorService executor;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/FutureCallable.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/FutureCallable.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.grpc;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.BetaApi;
 
 /**
  * {@code FutureCallable} is the basic abstraction for creating gRPC requests.
@@ -41,6 +42,7 @@ import com.google.api.core.ApiFuture;
  *
  * <p>Package-private for internal use.
  */
+@BetaApi
 interface FutureCallable<RequestT, ResponseT> {
   ApiFuture<ResponseT> futureCall(RequestT request, CallContext context);
 }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GaxGrpcProperties.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GaxGrpcProperties.java
@@ -29,10 +29,12 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.core.PropertiesProvider;
 import java.util.Properties;
 
 /** Provides properties of the GAX-GRPC library. */
+@BetaApi
 public class GaxGrpcProperties {
   private static final Properties gaxProperties = new Properties();
   private static final String GAX_PROPERTY_FILE = "/com/google/api/gax/grpc/project.properties";

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingChannelProvider.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.GaxProperties;
 import com.google.auth.Credentials;
@@ -57,6 +58,7 @@ import javax.annotation.Nullable;
  * <p>The client lib header and generator header values are used to form a value that goes into the
  * http header of requests to the service.
  */
+@BetaApi
 public final class InstantiatingChannelProvider implements ChannelProvider {
   private static final String DEFAULT_VERSION = "";
   private static Properties gaxProperties = new Properties();

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingExecutorProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingExecutorProvider.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.auto.value.AutoValue;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -38,6 +39,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
  * InstantiatingChannelProvider is an ExecutorProvider which constructs a new
  * ScheduledExecutorService every time getExecutor() is called.
  */
+@BetaApi
 @AutoValue
 public abstract class InstantiatingExecutorProvider implements ExecutorProvider {
   // The number of threads to use with the default executor.

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/OperationCallSettings.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/OperationCallSettings.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.longrunning.Operation;
 import com.google.longrunning.OperationsClient;
 import com.google.protobuf.Message;
@@ -41,6 +42,7 @@ import org.joda.time.Duration;
  * A settings class to configure an OperationCallable for calls to a long-running API method (i.e.
  * that returns the {@link Operation} type.)
  */
+@BetaApi
 public final class OperationCallSettings<RequestT, ResponseT extends Message> {
 
   private final SimpleCallSettings<RequestT, Operation> initialCallSettings;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/OperationCallable.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/OperationCallable.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.grpc;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.BetaApi;
 import com.google.common.base.Preconditions;
 import com.google.longrunning.GetOperationRequest;
 import com.google.longrunning.Operation;
@@ -44,6 +45,7 @@ import org.joda.time.Duration;
  * long-running API methods and returning an OperationFuture to manage the polling of the Operation
  * and getting the response.
  */
+@BetaApi
 public final class OperationCallable<RequestT, ResponseT extends Message> {
   private final UnaryCallable<RequestT, Operation> initialCallable;
   private final Channel channel;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/OperationFuture.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/OperationFuture.java
@@ -31,6 +31,7 @@ package com.google.api.gax.grpc;
 
 import com.google.api.core.AbstractApiFuture;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.BetaApi;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.longrunning.Operation;
@@ -50,6 +51,7 @@ import java.util.concurrent.TimeoutException;
 import org.joda.time.Duration;
 
 /** An ApiFuture which polls a service through OperationsApi for the completion of an operation. */
+@BetaApi
 public final class OperationFuture<ResponseT extends Message> extends AbstractApiFuture<ResponseT> {
   static final Duration DEFAULT_POLLING_INTERVAL = Duration.standardSeconds(1);
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/PageContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/PageContext.java
@@ -29,8 +29,10 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.auto.value.AutoValue;
 
+@BetaApi
 @AutoValue
 public abstract class PageContext<RequestT, ResponseT, ResourceT> {
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/PagedCallSettings.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/PagedCallSettings.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.common.collect.ImmutableSet;
 import io.grpc.Channel;
@@ -41,6 +42,7 @@ import java.util.concurrent.ScheduledExecutorService;
  * A settings class to configure a UnaryCallable for calls to an API method that supports page
  * streaming.
  */
+@BetaApi
 public final class PagedCallSettings<RequestT, ResponseT, PagedListResponseT>
     extends UnaryCallSettingsTyped<RequestT, ResponseT> {
   private final PagedListResponseFactory<RequestT, ResponseT, PagedListResponseT>

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/PagedListDescriptor.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/PagedListDescriptor.java
@@ -29,11 +29,14 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
+
 /**
  * An interface which describes the paging pattern.
  *
  * <p>This is public only for technical reasons, for advanced usage.
  */
+@BetaApi
 public interface PagedListDescriptor<RequestT, ResponseT, ResourceT> {
 
   /** Delivers the empty page token. */

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/PagedListResponseFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/PagedListResponseFactory.java
@@ -30,12 +30,14 @@
 package com.google.api.gax.grpc;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.BetaApi;
 
 /**
  * Interface for constructing PagedListResponse objects, used by {@link UnaryCallable}.
  *
  * <p>This is public only for technical reasons, for advanced usage.
  */
+@BetaApi
 public interface PagedListResponseFactory<RequestT, ResponseT, PagedListResponseT> {
 
   ApiFuture<PagedListResponseT> getFuturePagedResponse(

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ProviderManager.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ProviderManager.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import io.grpc.ManagedChannel;
 import java.io.IOException;
 import java.util.concurrent.Executor;
@@ -65,6 +66,7 @@ import java.util.concurrent.ScheduledExecutorService;
  * </code>
  * </pre>
  */
+@BetaApi
 public class ProviderManager implements ExecutorProvider, ChannelProvider {
   private final ExecutorProvider executorProvider;
   private final ChannelProvider channelProvider;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/SimpleCallSettings.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/SimpleCallSettings.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.common.collect.ImmutableSet;
 import io.grpc.Channel;
@@ -41,6 +42,7 @@ import java.util.concurrent.ScheduledExecutorService;
  * A settings class to configure a UnaryCallable for calls to a simple API method (i.e. that doesn't
  * support paged or batching functionalities.)
  */
+@BetaApi
 public final class SimpleCallSettings<RequestT, ResponseT>
     extends UnaryCallSettingsTyped<RequestT, ResponseT> {
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/StreamingCallSettings.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/StreamingCallSettings.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import io.grpc.Channel;
 import io.grpc.MethodDescriptor;
 
@@ -38,6 +39,7 @@ import io.grpc.MethodDescriptor;
  * <p>Currently this class is used to create the StreamingCallable object based on the configured
  * MethodDescriptor from the gRPC method and the given channel.
  */
+@BetaApi
 public final class StreamingCallSettings<RequestT, ResponseT> {
   private final MethodDescriptor<RequestT, ResponseT> methodDescriptor;
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/StreamingCallable.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/StreamingCallable.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.grpc.Channel;
@@ -44,6 +45,7 @@ import javax.annotation.Nullable;
  * instances of StreamingCallSettings.Builder which are exposed through the API wrapper class's
  * settings class.
  */
+@BetaApi
 public class StreamingCallable<RequestT, ResponseT> {
   private final DirectStreamingCallable<RequestT, ResponseT> callable;
   private final Channel channel;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/UnaryCallSettings.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/UnaryCallSettings.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
@@ -56,6 +57,7 @@ import org.joda.time.Duration;
  * other than the creation of an instance type, such as by applyToAllUnaryMethods in {@link
  * ClientSettings}.
  */
+@BetaApi
 public abstract class UnaryCallSettings {
 
   private final ImmutableSet<Status.Code> retryableCodes;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/UnaryCallSettingsTyped.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/UnaryCallSettingsTyped.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.common.collect.ImmutableSet;
 import io.grpc.Channel;
@@ -46,6 +47,7 @@ import java.util.concurrent.ScheduledExecutorService;
  * <p>This class is package-private; use the concrete settings classes instead of this class from
  * outside of the package.
  */
+@BetaApi
 abstract class UnaryCallSettingsTyped<RequestT, ResponseT> extends UnaryCallSettings {
 
   private final MethodDescriptor<RequestT, ResponseT> methodDescriptor;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/UnaryCallable.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/UnaryCallable.java
@@ -31,6 +31,7 @@ package com.google.api.gax.grpc;
 
 import com.google.api.core.ApiClock;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.BetaApi;
 import com.google.api.core.NanoClock;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.retrying.RetrySettings;
@@ -87,6 +88,7 @@ import javax.annotation.Nullable;
  * ResponseType response = resultFuture.get();
  * }</pre>
  */
+@BetaApi
 public final class UnaryCallable<RequestT, ResponseT> {
 
   private final FutureCallable<RequestT, ResponseT> callable;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/testing/FakeMethodDescriptor.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/testing/FakeMethodDescriptor.java
@@ -29,9 +29,11 @@
  */
 package com.google.api.gax.grpc.testing;
 
+import com.google.api.core.BetaApi;
 import io.grpc.MethodDescriptor;
 import java.io.InputStream;
 
+@BetaApi
 public class FakeMethodDescriptor {
   // Utility class, uninstantiable.
   private FakeMethodDescriptor() {}

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/testing/MockGrpcService.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/testing/MockGrpcService.java
@@ -29,11 +29,13 @@
  */
 package com.google.api.gax.grpc.testing;
 
+import com.google.api.core.BetaApi;
 import com.google.protobuf.GeneratedMessageV3;
 import io.grpc.ServerServiceDefinition;
 import java.util.List;
 
 /** An interface of mock gRPC service. */
+@BetaApi
 public interface MockGrpcService {
   /** Returns all the requests received. */
   List<GeneratedMessageV3> getRequests();

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/testing/MockServiceHelper.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/testing/MockServiceHelper.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc.testing;
 
+import com.google.api.core.BetaApi;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import io.grpc.Server;
@@ -41,6 +42,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /** A utility class to control a local service which is used by testing. */
+@BetaApi
 public class MockServiceHelper {
   private static final int FLOW_CONTROL_WINDOW = 65 * 1024;
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/testing/MockStreamObserver.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/testing/MockStreamObserver.java
@@ -29,12 +29,14 @@
  */
 package com.google.api.gax.grpc.testing;
 
+import com.google.api.core.BetaApi;
 import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.grpc.ApiStreamObserver;
 import java.util.ArrayList;
 import java.util.List;
 
 /** An implementation of ApiStreamObserver used by testing. */
+@BetaApi
 public class MockStreamObserver<T> implements ApiStreamObserver<T> {
 
   private final SettableApiFuture<List<T>> future = SettableApiFuture.create();

--- a/gax/src/main/java/com/google/api/gax/batching/AccumulatingBatchReceiver.java
+++ b/gax/src/main/java/com/google/api/gax/batching/AccumulatingBatchReceiver.java
@@ -31,10 +31,12 @@ package com.google.api.gax.batching;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
+import com.google.api.core.BetaApi;
 import java.util.ArrayList;
 import java.util.List;
 
 /** A simple ThresholdBatchReceiver that just accumulates batches. Not thread-safe. */
+@BetaApi
 public final class AccumulatingBatchReceiver<T> implements ThresholdBatchReceiver<T> {
   private final List<T> batches = new ArrayList<>();
 

--- a/gax/src/main/java/com/google/api/gax/batching/BatchMerger.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchMerger.java
@@ -29,6 +29,9 @@
  */
 package com.google.api.gax.batching;
 
+import com.google.api.core.BetaApi;
+
+@BetaApi
 public interface BatchMerger<B> {
   void merge(B batch, B newBatch);
 }

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingFlowController.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingFlowController.java
@@ -29,11 +29,13 @@
  */
 package com.google.api.gax.batching;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.batching.FlowController.FlowControlException;
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
 
 /** Wraps a {@link FlowController} for use by batching. */
+@BetaApi
 public class BatchingFlowController<T> {
 
   private final FlowController flowController;

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingSettings.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingSettings.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.batching;
 
+import com.google.api.core.BetaApi;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
@@ -85,6 +86,7 @@ import org.joda.time.Duration;
  * can occur if messages are created and added to batching faster than they can be processed. The
  * flow control behavior is controlled using FlowControlSettings.
  */
+@BetaApi
 @AutoValue
 public abstract class BatchingSettings {
   /** Get the element count threshold to use for batching. */

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingThreshold.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingThreshold.java
@@ -29,10 +29,13 @@
  */
 package com.google.api.gax.batching;
 
+import com.google.api.core.BetaApi;
+
 /**
  * The interface representing a threshold to be used in ThresholdBatcher. Thresholds do not need to
  * be thread-safe if they are only used inside ThresholdBatcher.
  */
+@BetaApi
 public interface BatchingThreshold<E> {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingThresholds.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingThresholds.java
@@ -29,10 +29,12 @@
  */
 package com.google.api.gax.batching;
 
+import com.google.api.core.BetaApi;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 /** Factory methods for general-purpose batching thresholds. */
+@BetaApi
 public final class BatchingThresholds {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/batching/ElementCounter.java
+++ b/gax/src/main/java/com/google/api/gax/batching/ElementCounter.java
@@ -29,10 +29,13 @@
  */
 package com.google.api.gax.batching;
 
+import com.google.api.core.BetaApi;
+
 /**
  * Interface representing an object that provides a numerical count given an object of the
  * parameterized type.
  */
+@BetaApi
 public interface ElementCounter<E> {
   /** Provides the numerical count associated with the given object. */
   public long count(E element);

--- a/gax/src/main/java/com/google/api/gax/batching/NumericThreshold.java
+++ b/gax/src/main/java/com/google/api/gax/batching/NumericThreshold.java
@@ -29,9 +29,11 @@
  */
 package com.google.api.gax.batching;
 
+import com.google.api.core.BetaApi;
 import com.google.common.base.Preconditions;
 
 /** A threshold which accumulates a count based on the provided ElementCounter. */
+@BetaApi
 public final class NumericThreshold<E> implements BatchingThreshold<E> {
   private final long threshold;
   private final ElementCounter<E> extractor;

--- a/gax/src/main/java/com/google/api/gax/batching/PartitionKey.java
+++ b/gax/src/main/java/com/google/api/gax/batching/PartitionKey.java
@@ -30,8 +30,10 @@
 
 package com.google.api.gax.batching;
 
+import com.google.api.core.BetaApi;
 import com.google.common.collect.ImmutableList;
 
+@BetaApi
 public final class PartitionKey {
   private final ImmutableList<Object> keys;
   private final int hash;

--- a/gax/src/main/java/com/google/api/gax/batching/RequestBuilder.java
+++ b/gax/src/main/java/com/google/api/gax/batching/RequestBuilder.java
@@ -29,6 +29,9 @@
  */
 package com.google.api.gax.batching;
 
+import com.google.api.core.BetaApi;
+
+@BetaApi
 public interface RequestBuilder<RequestT> {
   void appendRequest(RequestT request);
 

--- a/gax/src/main/java/com/google/api/gax/batching/ThresholdBatchReceiver.java
+++ b/gax/src/main/java/com/google/api/gax/batching/ThresholdBatchReceiver.java
@@ -30,11 +30,13 @@
 package com.google.api.gax.batching;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.BetaApi;
 
 /**
  * Interface representing an object that receives batches from a ThresholdBatcher and takes action
  * on them. Implementations of ThresholdBatchReceiver should be thread-safe.
  */
+@BetaApi
 public interface ThresholdBatchReceiver<BatchT> {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/batching/ThresholdBatcher.java
+++ b/gax/src/main/java/com/google/api/gax/batching/ThresholdBatcher.java
@@ -32,6 +32,7 @@ package com.google.api.gax.batching;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
+import com.google.api.core.BetaApi;
 import com.google.api.gax.batching.FlowController.FlowControlException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -47,6 +48,7 @@ import org.joda.time.Duration;
  * Queues up elements until either a duration of time has passed or any threshold in a given set of
  * thresholds is breached, and then delivers the elements in a batch to the consumer.
  */
+@BetaApi
 public final class ThresholdBatcher<E> {
 
   private class ReleaseResourcesFunction<T> implements ApiFunction<T, Void> {

--- a/gax/src/main/java/com/google/api/gax/core/Distribution.java
+++ b/gax/src/main/java/com/google/api/gax/core/Distribution.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.core;
 
+import com.google.api.core.BetaApi;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.base.Preconditions;
@@ -38,6 +39,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * Takes measurements and stores them in linear buckets from 0 to totalBuckets - 1, along with
  * utilities to calculate percentiles for analysis of results.
  */
+@BetaApi
 public class Distribution {
 
   private final AtomicLong[] bucketCounts;

--- a/gax/src/main/java/com/google/api/gax/retrying/DirectRetryingExecutor.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/DirectRetryingExecutor.java
@@ -31,6 +31,7 @@ package com.google.api.gax.retrying;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.api.core.BetaApi;
 import com.google.api.core.ListenableFutureToApiFuture;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -47,6 +48,7 @@ import org.joda.time.Duration;
  *
  * @param <ResponseT> response type
  */
+@BetaApi
 public class DirectRetryingExecutor<ResponseT> implements RetryingExecutor<ResponseT> {
 
   private final RetryAlgorithm retryAlgorithm;

--- a/gax/src/main/java/com/google/api/gax/retrying/ExceptionRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/ExceptionRetryAlgorithm.java
@@ -29,6 +29,8 @@
  */
 package com.google.api.gax.retrying;
 
+import com.google.api.core.BetaApi;
+
 /**
  * An exception retry algorithm is responsible for the following operations:
  *
@@ -40,6 +42,7 @@ package com.google.api.gax.retrying;
  *
  * Implementations of this interface must be thread-safe.
  */
+@BetaApi
 public interface ExceptionRetryAlgorithm {
   /**
    * Creates a next attempt {@link TimedAttemptSettings}.

--- a/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
@@ -32,6 +32,7 @@ package com.google.api.gax.retrying;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.core.ApiClock;
+import com.google.api.core.BetaApi;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import org.joda.time.Duration;
@@ -42,6 +43,7 @@ import org.joda.time.Duration;
  *
  * <p>This class is thread-safe.
  */
+@BetaApi
 public class ExponentialRetryAlgorithm implements TimedRetryAlgorithm {
 
   private final RetrySettings globalSettings;

--- a/gax/src/main/java/com/google/api/gax/retrying/RetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetryAlgorithm.java
@@ -31,12 +31,15 @@ package com.google.api.gax.retrying;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.api.core.BetaApi;
+
 /**
  * The retry algorithm, which makes decision based on the thrown exception and execution time
  * settings of the previous attempt.
  *
  * <p>This class is thread-safe.
  */
+@BetaApi
 public class RetryAlgorithm {
   private final TimedRetryAlgorithm timedAlgorithm;
   private final ExceptionRetryAlgorithm exceptionAlgorithm;

--- a/gax/src/main/java/com/google/api/gax/retrying/RetryingExecutor.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetryingExecutor.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.retrying;
 
+import com.google.api.core.BetaApi;
 import java.util.concurrent.Callable;
 
 /**
@@ -44,6 +45,7 @@ import java.util.concurrent.Callable;
  *
  * @param <ResponseT> response type
  */
+@BetaApi
 public interface RetryingExecutor<ResponseT> {
   /**
    * Creates the {@link RetryingFuture}, which is a facade, returned to the client code to wait for

--- a/gax/src/main/java/com/google/api/gax/retrying/RetryingFuture.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetryingFuture.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.retrying;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.BetaApi;
 import java.util.concurrent.Callable;
 
 /**
@@ -40,6 +41,7 @@ import java.util.concurrent.Callable;
  *
  * @param <ResponseT> response type
  */
+@BetaApi
 public interface RetryingFuture<ResponseT> extends ApiFuture<ResponseT> {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/retrying/ScheduledRetryingExecutor.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/ScheduledRetryingExecutor.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.retrying;
 
+import com.google.api.core.BetaApi;
 import com.google.api.core.ListenableFutureToApiFuture;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -46,6 +47,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @param <ResponseT> response type
  */
+@BetaApi
 public class ScheduledRetryingExecutor<ResponseT> implements RetryingExecutor<ResponseT> {
 
   private final RetryAlgorithm retryAlgorithm;

--- a/gax/src/main/java/com/google/api/gax/retrying/TimedAttemptSettings.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/TimedAttemptSettings.java
@@ -30,9 +30,11 @@
 package com.google.api.gax.retrying;
 
 import com.google.api.core.ApiClock;
+import com.google.api.core.BetaApi;
 import org.joda.time.Duration;
 
 /** Timed attempt execution settings. Defines time-specific properties of a retry attempt. */
+@BetaApi
 public class TimedAttemptSettings {
 
   private final RetrySettings globalSettings;

--- a/gax/src/main/java/com/google/api/gax/retrying/TimedRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/TimedRetryAlgorithm.java
@@ -30,6 +30,8 @@
 
 package com.google.api.gax.retrying;
 
+import com.google.api.core.BetaApi;
+
 /**
  * A timed retry algorithm is responsible for the following operations:
  *
@@ -42,6 +44,7 @@ package com.google.api.gax.retrying;
  *
  * Implementations of this interface must be be thread-save.
  */
+@BetaApi
 public interface TimedRetryAlgorithm {
 
   /**


### PR DESCRIPTION
In gax, all of `retrying` (except `RetrySettings`) and all of `batching` are marked; all public gax-grpc classes are being marked. 
