### PR TITLE
Improve release flow of gax-java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,8 @@ buildscript {
   }
   dependencies {
     classpath "net.ltgt.gradle:gradle-apt-plugin:0.9",
-      "com.github.jengelman.gradle.plugins:shadow:1.2.4"
+      "com.github.jengelman.gradle.plugins:shadow:1.2.4",
+      "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.8.0"
 
     classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.6"
   }
@@ -19,6 +20,7 @@ buildscript {
 
 apply plugin: 'java'
 apply plugin: 'com.github.sherter.google-java-format'
+apply plugin: 'io.codearte.nexus-staging'
 
 project.version = new File("gax/version.txt").text.trim()
 
@@ -31,6 +33,17 @@ googleJavaFormat {
   exclude '.apt_generated/**'
   exclude 'bin/**'
   exclude 'build/**'
+}
+
+if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword') &&
+    project.name != 'benchmark') {
+  // Nexus staging plugin only works at root project level
+  // See https://github.com/Codearte/gradle-nexus-staging-plugin/issues/47
+  nexusStaging {
+    username = ossrhUsername
+    password = ossrhPassword
+    packageGroup = "com.google.api"
+  }
 }
 
 allprojects {
@@ -333,7 +346,7 @@ task checkOutGhPages {
     if (!new File('tmp_gh-pages').exists()) {
       exec {
         commandLine 'git', 'clone', '--branch', 'gh-pages',
-            '--single-branch', 'https://github.com/googleapis/gax-java/', 'tmp_gh-pages'
+            '--single-branch', 'git@github.com:googleapis/gax-java.git', 'tmp_gh-pages'
       }
     }
   }
@@ -372,9 +385,38 @@ task createApiDocsRedirect {
   }
 }
 
+task publishDocs {
+  dependsOn 'closeAndReleaseRepository'
+  doLast {
+    exec {
+      workingDir './tmp_gh-pages'
+      commandLine 'git', 'commit', '-a', '-m', '"Release docs for ' + project.version + '"'
+    }
+    exec {
+      workingDir './tmp_gh-pages'
+      commandLine 'git', 'push'
+    }
+  }
+}
+
 // 1. Updates samples/pom.xml
 // 2. Updates README.md
-// 3. Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
+// 3. Regenerates the gh-pages branch under tmp_gh-pages
+// 4. Stages the artifact on Sonatype
+task stageRelease {
   dependsOn 'createApiDocsRedirect'
+  dependsOn 'uploadArchives'
+}
+
+// 1. Closes and releases the artifact on Sonatype
+// 2. Commits and pushes the new docs
+// 3. Remove tmp_gh-pages
+// Note: This task assumes that the 'stage_release' task has been completed.
+task release {
+  dependsOn 'publishDocs'
+  doLast {
+    exec {
+      commandLine 'rm', '-r', 'tmp_gh-pages'
+    }
+  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -405,7 +405,13 @@ task publishDocs {
 // 4. Stages the artifact on Sonatype
 task stageRelease {
   dependsOn 'createApiDocsRedirect'
-  dependsOn 'uploadArchives'
+  doLast {
+    exec {
+      // We need to spawn a new gradle build process in order to upload appropriately
+      // More details: http://stackoverflow.com/questions/31614735/gradle-uploadarchives-artificats-namespace-when-depending-on-a-plugin
+      commandLine './gradlew', 'uploadArchives'
+    }
+  }
 }
 
 // 1. Closes and releases the artifact on Sonatype

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ project.version = new File("gax/version.txt").text.trim()
 ext {
   grpcVersion = '1.2.0'
   commonProtosVersion = '0.1.9'
+  // Project names not used for release
+  nonReleaseProjects = ['benchmark']
 }
 
 googleJavaFormat {
@@ -36,7 +38,7 @@ googleJavaFormat {
 }
 
 if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword') &&
-    project.name != 'benchmark') {
+    !nonReleaseProjects.contains(project.name)) {
   // Nexus staging plugin only works at root project level
   // See https://github.com/Codearte/gradle-nexus-staging-plugin/issues/47
   nexusStaging {
@@ -261,7 +263,7 @@ subprojects {
   }
 
   if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword') &&
-      project.name != 'benchmark') {
+      !nonReleaseProjects.contains(project.name)) {
     uploadArchives {
       repositories {
         mavenDeployer {
@@ -343,11 +345,9 @@ task updateReadme << {
 
 task checkOutGhPages {
   doLast {
-    if (!new File('tmp_gh-pages').exists()) {
-      exec {
-        commandLine 'git', 'clone', '--branch', 'gh-pages',
-            '--single-branch', 'git@github.com:googleapis/gax-java.git', 'tmp_gh-pages'
-      }
+    exec {
+      commandLine 'git', 'clone', '--branch', 'gh-pages',
+          '--single-branch', 'git@github.com:googleapis/gax-java.git', 'tmp_gh-pages'
     }
   }
 }
@@ -412,7 +412,7 @@ task stageRelease {
 // 2. Commits and pushes the new docs
 // 3. Remove tmp_gh-pages
 // Note: This task assumes that the 'stage_release' task has been completed.
-task release {
+task finalizeRelease {
   dependsOn 'publishDocs'
   doLast {
     exec {


### PR DESCRIPTION
The new GAX release process:

1. Sync and check there is no local changes in your local `gax-java`
2. Run `./gradlew stageRelease`. This task will:
    a) Build & upload the artifact to Sonatype.
    b) Update docs and regenerate gh-pages
3. (Optional) Check the staging artifact and generated gh-pages to make sure everything looks okay
4. Run `./gradlew finalizeRelease`. This task will:
    a) Close and release the staging artifact on Sonatype
    b) Commit and push gh-pages

_NOTE: This PR switch the git task from using HTTP to SSH because HTTP requires command line input of user credentials._