### PR TITLE
add Semaphore64

### DIFF
--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/UnaryCallableTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/UnaryCallableTest.java
@@ -763,7 +763,7 @@ public class UnaryCallableTest {
                 FlowControlSettings.newBuilder()
                     .setLimitExceededBehavior(LimitExceededBehavior.Block)
                     .setMaxOutstandingElementCount(10)
-                    .setMaxOutstandingRequestBytes(10)
+                    .setMaxOutstandingRequestBytes(10L)
                     .build())
             .build();
     TrackedFlowController trackedFlowController =

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/UnaryCallableTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/UnaryCallableTest.java
@@ -762,7 +762,7 @@ public class UnaryCallableTest {
             .setFlowControlSettings(
                 FlowControlSettings.newBuilder()
                     .setLimitExceededBehavior(LimitExceededBehavior.Block)
-                    .setMaxOutstandingElementCount(10)
+                    .setMaxOutstandingElementCount(10L)
                     .setMaxOutstandingRequestBytes(10L)
                     .build())
             .build();

--- a/gax/src/main/java/com/google/api/gax/batching/FlowControlSettings.java
+++ b/gax/src/main/java/com/google/api/gax/batching/FlowControlSettings.java
@@ -50,7 +50,7 @@ public abstract class FlowControlSettings {
 
   /** Maximum number of outstanding bytes to keep in memory before enforcing flow control. */
   @Nullable
-  public abstract Integer getMaxOutstandingRequestBytes();
+  public abstract Long getMaxOutstandingRequestBytes();
 
   /**
    * The behavior of {@link FlowController} when the specified limits are exceeded. Defaults to
@@ -82,7 +82,16 @@ public abstract class FlowControlSettings {
   public abstract static class Builder {
     public abstract Builder setMaxOutstandingElementCount(Integer value);
 
-    public abstract Builder setMaxOutstandingRequestBytes(Integer value);
+    public abstract Builder setMaxOutstandingRequestBytes(Long value);
+
+    @Deprecated
+    public Builder setMaxOutstandingRequestBytes(Integer value) {
+      Long l = null;
+      if (value != null) {
+        l = value.longValue();
+      }
+      return setMaxOutstandingRequestBytes(l);
+    }
 
     public abstract Builder setLimitExceededBehavior(LimitExceededBehavior value);
 

--- a/gax/src/main/java/com/google/api/gax/batching/FlowControlSettings.java
+++ b/gax/src/main/java/com/google/api/gax/batching/FlowControlSettings.java
@@ -46,7 +46,7 @@ public abstract class FlowControlSettings {
 
   /** Maximum number of outstanding elements to keep in memory before enforcing flow control. */
   @Nullable
-  public abstract Integer getMaxOutstandingElementCount();
+  public abstract Long getMaxOutstandingElementCount();
 
   /** Maximum number of outstanding bytes to keep in memory before enforcing flow control. */
   @Nullable
@@ -80,17 +80,18 @@ public abstract class FlowControlSettings {
   @BetaApi
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder setMaxOutstandingElementCount(Integer value);
+    public abstract Builder setMaxOutstandingElementCount(Long value);
+
+    @Deprecated
+    public Builder setMaxOutstandingElementCount(Integer value) {
+      return setMaxOutstandingElementCount(value == null ? null : value.longValue());
+    }
 
     public abstract Builder setMaxOutstandingRequestBytes(Long value);
 
     @Deprecated
     public Builder setMaxOutstandingRequestBytes(Integer value) {
-      Long l = null;
-      if (value != null) {
-        l = value.longValue();
-      }
-      return setMaxOutstandingRequestBytes(l);
+      return setMaxOutstandingRequestBytes(value == null ? null : value.longValue());
     }
 
     public abstract Builder setLimitExceededBehavior(LimitExceededBehavior value);

--- a/gax/src/main/java/com/google/api/gax/batching/FlowController.java
+++ b/gax/src/main/java/com/google/api/gax/batching/FlowController.java
@@ -31,7 +31,6 @@ package com.google.api.gax.batching;
 
 import com.google.api.core.BetaApi;
 import com.google.common.base.Preconditions;
-import java.util.concurrent.Semaphore;
 import javax.annotation.Nullable;
 
 /** Provides flow control capability. */
@@ -64,13 +63,13 @@ public class FlowController {
   @BetaApi
   public static final class MaxOutstandingElementCountReachedException
       extends FlowControlException {
-    private final int currentMaxElementCount;
+    private final long currentMaxElementCount;
 
-    public MaxOutstandingElementCountReachedException(int currentMaxElementCount) {
+    public MaxOutstandingElementCountReachedException(long currentMaxElementCount) {
       this.currentMaxElementCount = currentMaxElementCount;
     }
 
-    public int getCurrentMaxBatchElementCount() {
+    public long getCurrentMaxBatchElementCount() {
       return currentMaxElementCount;
     }
 
@@ -116,10 +115,10 @@ public class FlowController {
     Ignore,
   }
 
-  @Nullable private final Semaphore outstandingElementCount;
+  @Nullable private final Semaphore64 outstandingElementCount;
   @Nullable private final Semaphore64 outstandingByteCount;
   private final boolean failOnLimits;
-  @Nullable private final Integer maxOutstandingElementCount;
+  @Nullable private final Long maxOutstandingElementCount;
   @Nullable private final Long maxOutstandingRequestBytes;
 
   public FlowController(FlowControlSettings settings) {
@@ -144,7 +143,7 @@ public class FlowController {
     this.maxOutstandingElementCount = settings.getMaxOutstandingElementCount();
     this.maxOutstandingRequestBytes = settings.getMaxOutstandingRequestBytes();
     outstandingElementCount =
-        maxOutstandingElementCount != null ? new Semaphore(maxOutstandingElementCount) : null;
+        maxOutstandingElementCount != null ? new Semaphore64(maxOutstandingElementCount) : null;
     outstandingByteCount =
         maxOutstandingRequestBytes != null ? new Semaphore64(maxOutstandingRequestBytes) : null;
   }

--- a/gax/src/main/java/com/google/api/gax/batching/FlowController.java
+++ b/gax/src/main/java/com/google/api/gax/batching/FlowController.java
@@ -148,7 +148,7 @@ public class FlowController {
         maxOutstandingRequestBytes != null ? new Semaphore64(maxOutstandingRequestBytes) : null;
   }
 
-  public void reserve(int elements, long bytes) throws FlowControlException {
+  public void reserve(long elements, long bytes) throws FlowControlException {
     Preconditions.checkArgument(elements >= 0);
     Preconditions.checkArgument(bytes >= 0);
 
@@ -175,7 +175,7 @@ public class FlowController {
     }
   }
 
-  public void release(int elements, long bytes) {
+  public void release(long elements, long bytes) {
     Preconditions.checkArgument(elements >= 0);
     Preconditions.checkArgument(bytes >= 0);
 

--- a/gax/src/main/java/com/google/api/gax/batching/Semaphore64.java
+++ b/gax/src/main/java/com/google/api/gax/batching/Semaphore64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -33,7 +33,7 @@ import com.google.common.base.Preconditions;
 
 /**
  * Semaphore64 is similar to {@link java.util.concurrent.Semaphore} but allows up to {@code 2^63-1}
- * permits. It is named after the {@code Commodore 64} computer.
+ * permits.
  *
  * <p>Users who do not need such large number of permits are strongly encouraged to use Java's
  * {@code Semaphore} instead. It is almost certainly faster and less error prone.

--- a/gax/src/main/java/com/google/api/gax/batching/Semaphore64.java
+++ b/gax/src/main/java/com/google/api/gax/batching/Semaphore64.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.batching;
+
+import com.google.common.base.Preconditions;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Semaphore64 is similar to {@link java.util.concurrent.Semaphore} but allows up to {@code 2^63-1}
+ * permits. It is named after the {@code Commodore 64} computer.
+ *
+ * <p>Users who do not need such large number of permits are strongly encouraged to use Java's
+ * {@code Semaphore} instead. It is almost certainly faster and less error prone.
+ */
+final class Semaphore64 {
+  private final Lock lock;
+  private final Condition incremented;
+  private long currentPermits;
+
+  Semaphore64(long permits, boolean fair) {
+    this.lock = new ReentrantLock(fair);
+    this.incremented = this.lock.newCondition();
+    this.currentPermits = permits;
+  }
+
+  void release(long permits) {
+    notNegative(permits);
+
+    lock.lock();
+    try {
+      currentPermits += permits;
+      incremented.signalAll();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  void acquireUninterruptibly(long permits) {
+    notNegative(permits);
+
+    lock.lock();
+    try {
+      while (currentPermits < permits) {
+        incremented.awaitUninterruptibly();
+      }
+      currentPermits -= permits;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  boolean tryAcquire(long permits) {
+    notNegative(permits);
+
+    lock.lock();
+    try {
+      if (currentPermits >= permits) {
+        currentPermits -= permits;
+        return true;
+      }
+      return false;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private static void notNegative(long l) {
+    Preconditions.checkArgument(l >= 0, "negative permits not allowed: %s", l);
+  }
+}

--- a/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
@@ -49,7 +49,7 @@ public class FlowControllerTest {
     FlowController flowController =
         new FlowController(
             FlowControlSettings.newBuilder()
-                .setMaxOutstandingElementCount(10)
+                .setMaxOutstandingElementCount(10L)
                 .setMaxOutstandingRequestBytes(10L)
                 .setLimitExceededBehavior(LimitExceededBehavior.Block)
                 .build());
@@ -63,7 +63,7 @@ public class FlowControllerTest {
     FlowController flowController =
         new FlowController(
             FlowControlSettings.newBuilder()
-                .setMaxOutstandingElementCount(10)
+                .setMaxOutstandingElementCount(10L)
                 .setMaxOutstandingRequestBytes(10L)
                 .setLimitExceededBehavior(LimitExceededBehavior.Block)
                 .build());
@@ -88,7 +88,6 @@ public class FlowControllerTest {
     FlowController flowController =
         new FlowController(
             FlowControlSettings.newBuilder()
-                .setMaxOutstandingElementCount(null)
                 .setLimitExceededBehavior(LimitExceededBehavior.Block)
                 .build());
 
@@ -101,7 +100,7 @@ public class FlowControllerTest {
     FlowController flowController =
         new FlowController(
             FlowControlSettings.newBuilder()
-                .setMaxOutstandingElementCount(1)
+                .setMaxOutstandingElementCount(1L)
                 .setMaxOutstandingRequestBytes(1L)
                 .setLimitExceededBehavior(LimitExceededBehavior.Ignore)
                 .build());
@@ -115,7 +114,7 @@ public class FlowControllerTest {
     FlowController flowController =
         new FlowController(
             FlowControlSettings.newBuilder()
-                .setMaxOutstandingElementCount(10)
+                .setMaxOutstandingElementCount(10L)
                 .setMaxOutstandingRequestBytes(100L)
                 .setLimitExceededBehavior(LimitExceededBehavior.Block)
                 .build());
@@ -128,7 +127,7 @@ public class FlowControllerTest {
     FlowController flowController =
         new FlowController(
             FlowControlSettings.newBuilder()
-                .setMaxOutstandingElementCount(10)
+                .setMaxOutstandingElementCount(10L)
                 .setLimitExceededBehavior(LimitExceededBehavior.Block)
                 .build());
 
@@ -140,7 +139,7 @@ public class FlowControllerTest {
     FlowController flowController =
         new FlowController(
             FlowControlSettings.newBuilder()
-                .setMaxOutstandingElementCount(100)
+                .setMaxOutstandingElementCount(100L)
                 .setMaxOutstandingRequestBytes(10L)
                 .setLimitExceededBehavior(LimitExceededBehavior.Block)
                 .build());
@@ -153,7 +152,6 @@ public class FlowControllerTest {
     FlowController flowController =
         new FlowController(
             FlowControlSettings.newBuilder()
-                .setMaxOutstandingElementCount(null)
                 .setMaxOutstandingRequestBytes(10L)
                 .setLimitExceededBehavior(LimitExceededBehavior.Block)
                 .build());
@@ -194,7 +192,7 @@ public class FlowControllerTest {
     FlowController flowController =
         new FlowController(
             FlowControlSettings.newBuilder()
-                .setMaxOutstandingElementCount(10)
+                .setMaxOutstandingElementCount(10L)
                 .setMaxOutstandingRequestBytes(100L)
                 .setLimitExceededBehavior(LimitExceededBehavior.ThrowException)
                 .build());
@@ -208,7 +206,7 @@ public class FlowControllerTest {
     FlowController flowController =
         new FlowController(
             FlowControlSettings.newBuilder()
-                .setMaxOutstandingElementCount(10)
+                .setMaxOutstandingElementCount(10L)
                 .setLimitExceededBehavior(LimitExceededBehavior.ThrowException)
                 .build());
 
@@ -221,7 +219,7 @@ public class FlowControllerTest {
     FlowController flowController =
         new FlowController(
             FlowControlSettings.newBuilder()
-                .setMaxOutstandingElementCount(100)
+                .setMaxOutstandingElementCount(100L)
                 .setMaxOutstandingRequestBytes(10L)
                 .setLimitExceededBehavior(LimitExceededBehavior.ThrowException)
                 .build());
@@ -235,7 +233,6 @@ public class FlowControllerTest {
     FlowController flowController =
         new FlowController(
             FlowControlSettings.newBuilder()
-                .setMaxOutstandingElementCount(null)
                 .setMaxOutstandingRequestBytes(10L)
                 .setLimitExceededBehavior(LimitExceededBehavior.ThrowException)
                 .build());
@@ -249,7 +246,7 @@ public class FlowControllerTest {
     FlowController flowController =
         new FlowController(
             FlowControlSettings.newBuilder()
-                .setMaxOutstandingElementCount(2)
+                .setMaxOutstandingElementCount(2L)
                 .setMaxOutstandingRequestBytes(1L)
                 .setLimitExceededBehavior(LimitExceededBehavior.ThrowException)
                 .build());

--- a/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
@@ -50,7 +50,7 @@ public class FlowControllerTest {
         new FlowController(
             FlowControlSettings.newBuilder()
                 .setMaxOutstandingElementCount(10)
-                .setMaxOutstandingRequestBytes(10)
+                .setMaxOutstandingRequestBytes(10L)
                 .setLimitExceededBehavior(LimitExceededBehavior.Block)
                 .build());
 
@@ -64,7 +64,7 @@ public class FlowControllerTest {
         new FlowController(
             FlowControlSettings.newBuilder()
                 .setMaxOutstandingElementCount(10)
-                .setMaxOutstandingRequestBytes(10)
+                .setMaxOutstandingRequestBytes(10L)
                 .setLimitExceededBehavior(LimitExceededBehavior.Block)
                 .build());
 
@@ -89,7 +89,6 @@ public class FlowControllerTest {
         new FlowController(
             FlowControlSettings.newBuilder()
                 .setMaxOutstandingElementCount(null)
-                .setMaxOutstandingRequestBytes(null)
                 .setLimitExceededBehavior(LimitExceededBehavior.Block)
                 .build());
 
@@ -103,7 +102,7 @@ public class FlowControllerTest {
         new FlowController(
             FlowControlSettings.newBuilder()
                 .setMaxOutstandingElementCount(1)
-                .setMaxOutstandingRequestBytes(1)
+                .setMaxOutstandingRequestBytes(1L)
                 .setLimitExceededBehavior(LimitExceededBehavior.Ignore)
                 .build());
 
@@ -117,7 +116,7 @@ public class FlowControllerTest {
         new FlowController(
             FlowControlSettings.newBuilder()
                 .setMaxOutstandingElementCount(10)
-                .setMaxOutstandingRequestBytes(100)
+                .setMaxOutstandingRequestBytes(100L)
                 .setLimitExceededBehavior(LimitExceededBehavior.Block)
                 .build());
 
@@ -130,7 +129,6 @@ public class FlowControllerTest {
         new FlowController(
             FlowControlSettings.newBuilder()
                 .setMaxOutstandingElementCount(10)
-                .setMaxOutstandingRequestBytes(null)
                 .setLimitExceededBehavior(LimitExceededBehavior.Block)
                 .build());
 
@@ -143,7 +141,7 @@ public class FlowControllerTest {
         new FlowController(
             FlowControlSettings.newBuilder()
                 .setMaxOutstandingElementCount(100)
-                .setMaxOutstandingRequestBytes(10)
+                .setMaxOutstandingRequestBytes(10L)
                 .setLimitExceededBehavior(LimitExceededBehavior.Block)
                 .build());
 
@@ -156,7 +154,7 @@ public class FlowControllerTest {
         new FlowController(
             FlowControlSettings.newBuilder()
                 .setMaxOutstandingElementCount(null)
-                .setMaxOutstandingRequestBytes(10)
+                .setMaxOutstandingRequestBytes(10L)
                 .setLimitExceededBehavior(LimitExceededBehavior.Block)
                 .build());
 
@@ -197,7 +195,7 @@ public class FlowControllerTest {
         new FlowController(
             FlowControlSettings.newBuilder()
                 .setMaxOutstandingElementCount(10)
-                .setMaxOutstandingRequestBytes(100)
+                .setMaxOutstandingRequestBytes(100L)
                 .setLimitExceededBehavior(LimitExceededBehavior.ThrowException)
                 .build());
 
@@ -211,7 +209,6 @@ public class FlowControllerTest {
         new FlowController(
             FlowControlSettings.newBuilder()
                 .setMaxOutstandingElementCount(10)
-                .setMaxOutstandingRequestBytes(null)
                 .setLimitExceededBehavior(LimitExceededBehavior.ThrowException)
                 .build());
 
@@ -225,7 +222,7 @@ public class FlowControllerTest {
         new FlowController(
             FlowControlSettings.newBuilder()
                 .setMaxOutstandingElementCount(100)
-                .setMaxOutstandingRequestBytes(10)
+                .setMaxOutstandingRequestBytes(10L)
                 .setLimitExceededBehavior(LimitExceededBehavior.ThrowException)
                 .build());
 
@@ -239,7 +236,7 @@ public class FlowControllerTest {
         new FlowController(
             FlowControlSettings.newBuilder()
                 .setMaxOutstandingElementCount(null)
-                .setMaxOutstandingRequestBytes(10)
+                .setMaxOutstandingRequestBytes(10L)
                 .setLimitExceededBehavior(LimitExceededBehavior.ThrowException)
                 .build());
 

--- a/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
@@ -244,6 +244,28 @@ public class FlowControllerTest {
         flowController, 10, 10, FlowController.MaxOutstandingRequestBytesReachedException.class);
   }
 
+  @Test
+  public void testRestoreAfterFail() throws FlowController.FlowControlException {
+    FlowController flowController =
+        new FlowController(
+            FlowControlSettings.newBuilder()
+                .setMaxOutstandingElementCount(2)
+                .setMaxOutstandingRequestBytes(1L)
+                .setLimitExceededBehavior(LimitExceededBehavior.ThrowException)
+                .build());
+
+    flowController.reserve(1, 1);
+
+    try {
+      flowController.reserve(1, 1);
+      throw new IllegalStateException("flowController should not have any bytes left");
+    } catch (FlowController.MaxOutstandingRequestBytesReachedException e) {
+      // Ignore.
+    }
+
+    flowController.reserve(1, 0);
+  }
+
   private void testRejectedReserveRelease(
       FlowController flowController,
       int maxElementCount,

--- a/gax/src/test/java/com/google/api/gax/batching/Semaphore64Test.java
+++ b/gax/src/test/java/com/google/api/gax/batching/Semaphore64Test.java
@@ -42,13 +42,13 @@ import org.junit.runners.JUnit4;
 public class Semaphore64Test {
   @Test(expected = IllegalArgumentException.class)
   public void testNegative() {
-    Semaphore64 sema = new Semaphore64(1, false);
+    Semaphore64 sema = new Semaphore64(1);
     sema.tryAcquire(-1);
   }
 
   @Test
   public void testTryAcquire() {
-    Semaphore64 sema = new Semaphore64(1, false);
+    Semaphore64 sema = new Semaphore64(1);
     assertTrue(sema.tryAcquire(1));
     assertFalse(sema.tryAcquire(1));
     sema.release(1);
@@ -57,7 +57,7 @@ public class Semaphore64Test {
 
   @Test
   public void testAcquireUninterruptibly() throws InterruptedException {
-    final Semaphore64 sema = new Semaphore64(1, false);
+    final Semaphore64 sema = new Semaphore64(1);
     sema.acquireUninterruptibly(1);
 
     Runnable acquireOneRunnable =

--- a/gax/src/test/java/com/google/api/gax/batching/Semaphore64Test.java
+++ b/gax/src/test/java/com/google/api/gax/batching/Semaphore64Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Google Inc. All rights reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,58 +29,64 @@
  */
 package com.google.api.gax.batching;
 
-/**
- * An extension of FlowController that tracks the number of permits and calls to reserve and release
- */
-public class TrackedFlowController extends FlowController {
-  private int elementsReserved = 0;
-  private int elementsReleased = 0;
-  private long bytesReserved = 0;
-  private long bytesReleased = 0;
-  private int callsToReserve = 0;
-  private int callsToRelease = 0;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-  public TrackedFlowController(FlowControlSettings settings) {
-    super(settings);
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class Semaphore64Test {
+  @Test(expected = IllegalArgumentException.class)
+  public void testNegative() {
+    Semaphore64 sema = new Semaphore64(1, false);
+    sema.tryAcquire(-1);
   }
 
-  @Override
-  public void reserve(int elements, long bytes) throws FlowControlException {
-    super.reserve(elements, bytes);
-    this.elementsReserved += elements;
-    this.bytesReserved += bytes;
-    this.callsToReserve += 1;
+  @Test
+  public void testTryAcquire() {
+    Semaphore64 sema = new Semaphore64(1, false);
+    assertTrue(sema.tryAcquire(1));
+    assertFalse(sema.tryAcquire(1));
+    sema.release(1);
+    assertTrue(sema.tryAcquire(1));
   }
 
-  @Override
-  public void release(int elements, long bytes) {
-    super.release(elements, bytes);
-    this.elementsReleased += elements;
-    this.bytesReleased += bytes;
-    this.callsToRelease += 1;
-  }
+  @Test
+  public void testAcquireUninterruptibly() throws InterruptedException {
+    final Semaphore64 sema = new Semaphore64(1, false);
+    sema.acquireUninterruptibly(1);
 
-  public int getElementsReserved() {
-    return elementsReserved;
-  }
+    Runnable acquireOneRunnable =
+        new Runnable() {
+          @Override
+          public void run() {
+            sema.acquireUninterruptibly(1);
+          }
+        };
 
-  public int getElementsReleased() {
-    return elementsReleased;
-  }
+    List<Thread> acquirers = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      Thread t = new Thread(acquireOneRunnable);
+      acquirers.add(t);
+      t.start();
+    }
 
-  public long getBytesReserved() {
-    return bytesReserved;
-  }
+    Thread.sleep(500);
 
-  public long getBytesReleased() {
-    return bytesReleased;
-  }
+    for (Thread t : acquirers) {
+      assertTrue(t.isAlive());
+    }
 
-  public int getCallsToReserve() {
-    return callsToReserve;
-  }
+    sema.release(3);
+    sema.release(3);
 
-  public int getCallsToRelease() {
-    return callsToRelease;
+    for (Thread t : acquirers) {
+      t.join(500);
+      assertFalse(t.isAlive());
+    }
   }
 }

--- a/gax/src/test/java/com/google/api/gax/batching/Semaphore64Test.java
+++ b/gax/src/test/java/com/google/api/gax/batching/Semaphore64Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -42,29 +42,29 @@ import org.junit.runners.JUnit4;
 public class Semaphore64Test {
   @Test(expected = IllegalArgumentException.class)
   public void testNegative() {
-    Semaphore64 sema = new Semaphore64(1);
-    sema.tryAcquire(-1);
+    Semaphore64 semaphore = new Semaphore64(1);
+    semaphore.tryAcquire(-1);
   }
 
   @Test
   public void testTryAcquire() {
-    Semaphore64 sema = new Semaphore64(1);
-    assertTrue(sema.tryAcquire(1));
-    assertFalse(sema.tryAcquire(1));
-    sema.release(1);
-    assertTrue(sema.tryAcquire(1));
+    Semaphore64 semaphore = new Semaphore64(1);
+    assertTrue(semaphore.tryAcquire(1));
+    assertFalse(semaphore.tryAcquire(1));
+    semaphore.release(1);
+    assertTrue(semaphore.tryAcquire(1));
   }
 
   @Test
   public void testAcquireUninterruptibly() throws InterruptedException {
-    final Semaphore64 sema = new Semaphore64(1);
-    sema.acquireUninterruptibly(1);
+    final Semaphore64 semaphore = new Semaphore64(1);
+    semaphore.acquireUninterruptibly(1);
 
     Runnable acquireOneRunnable =
         new Runnable() {
           @Override
           public void run() {
-            sema.acquireUninterruptibly(1);
+            semaphore.acquireUninterruptibly(1);
           }
         };
 
@@ -81,8 +81,8 @@ public class Semaphore64Test {
       assertTrue(t.isAlive());
     }
 
-    sema.release(3);
-    sema.release(3);
+    semaphore.release(3);
+    semaphore.release(3);
 
     for (Thread t : acquirers) {
       t.join(500);

--- a/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
@@ -73,7 +73,7 @@ public class ThresholdBatcherTest {
   private static TrackedFlowController trackedFlowController;
 
   private static BatchingFlowController<SimpleBatch> getTrackedIntegerBatchingFlowController(
-      Integer elementCount, Long byteCount, LimitExceededBehavior limitExceededBehaviour) {
+      Long elementCount, Long byteCount, LimitExceededBehavior limitExceededBehaviour) {
     trackedFlowController =
         new TrackedFlowController(
             FlowControlSettings.newBuilder()
@@ -230,7 +230,7 @@ public class ThresholdBatcherTest {
         createSimpleBatcherBuidler(receiver)
             .setThresholds(BatchingThresholds.<SimpleBatch>of(2))
             .setFlowController(
-                getTrackedIntegerBatchingFlowController(2, null, LimitExceededBehavior.Block))
+                getTrackedIntegerBatchingFlowController(2L, null, LimitExceededBehavior.Block))
             .build();
 
     Truth.assertThat(trackedFlowController.getElementsReserved()).isEqualTo(0);
@@ -272,7 +272,7 @@ public class ThresholdBatcherTest {
             .setThresholds(BatchingThresholds.<SimpleBatch>of(4))
             .setFlowController(
                 getTrackedIntegerBatchingFlowController(
-                    3, null, LimitExceededBehavior.ThrowException))
+                    3L, null, LimitExceededBehavior.ThrowException))
             .build();
 
     Truth.assertThat(trackedFlowController.getElementsReserved()).isEqualTo(0);

--- a/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
@@ -73,7 +73,7 @@ public class ThresholdBatcherTest {
   private static TrackedFlowController trackedFlowController;
 
   private static BatchingFlowController<SimpleBatch> getTrackedIntegerBatchingFlowController(
-      Integer elementCount, Integer byteCount, LimitExceededBehavior limitExceededBehaviour) {
+      Integer elementCount, Long byteCount, LimitExceededBehavior limitExceededBehaviour) {
     trackedFlowController =
         new TrackedFlowController(
             FlowControlSettings.newBuilder()

--- a/gax/src/test/java/com/google/api/gax/batching/TrackedFlowController.java
+++ b/gax/src/test/java/com/google/api/gax/batching/TrackedFlowController.java
@@ -33,8 +33,8 @@ package com.google.api.gax.batching;
  * An extension of FlowController that tracks the number of permits and calls to reserve and release
  */
 public class TrackedFlowController extends FlowController {
-  private int elementsReserved = 0;
-  private int elementsReleased = 0;
+  private long elementsReserved = 0;
+  private long elementsReleased = 0;
   private long bytesReserved = 0;
   private long bytesReleased = 0;
   private int callsToReserve = 0;
@@ -45,7 +45,7 @@ public class TrackedFlowController extends FlowController {
   }
 
   @Override
-  public void reserve(int elements, long bytes) throws FlowControlException {
+  public void reserve(long elements, long bytes) throws FlowControlException {
     super.reserve(elements, bytes);
     this.elementsReserved += elements;
     this.bytesReserved += bytes;
@@ -53,18 +53,18 @@ public class TrackedFlowController extends FlowController {
   }
 
   @Override
-  public void release(int elements, long bytes) {
+  public void release(long elements, long bytes) {
     super.release(elements, bytes);
     this.elementsReleased += elements;
     this.bytesReleased += bytes;
     this.callsToRelease += 1;
   }
 
-  public int getElementsReserved() {
+  public long getElementsReserved() {
     return elementsReserved;
   }
 
-  public int getElementsReleased() {
+  public long getElementsReleased() {
     return elementsReleased;
   }
 


### PR DESCRIPTION
Create a simple implementation of 64-bit semaphore.
FlowController's byte-limit is migrated to use it.

setMaxOutstandingRequestBytes(Integer) method is added
to maintain source compatibility with google-cloud-java.
This is necessary since an int can be implicitly converted to
an Integer or a long but not a Long.

cc @davidtorres