### PR TITLE
make ClientContext work properly with old surface

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ClientContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ClientContext.java
@@ -37,6 +37,7 @@ import io.grpc.Channel;
 import io.grpc.ManagedChannel;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nullable;
 
@@ -59,7 +60,8 @@ public abstract class ClientContext {
   public abstract Credentials getCredentials();
 
   static Builder newBuilder() {
-    return new AutoValue_ClientContext.Builder();
+    return new AutoValue_ClientContext.Builder()
+        .setCloseables(Collections.<AutoCloseable>emptyList());
   }
 
   public static ClientContext create(ClientSettings settings) throws IOException {

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/UnaryCallableTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/UnaryCallableTest.java
@@ -39,6 +39,7 @@ import com.google.api.gax.batching.PartitionKey;
 import com.google.api.gax.batching.RequestBuilder;
 import com.google.api.gax.batching.TrackedFlowController;
 import com.google.api.gax.core.FakeApiClock;
+import com.google.api.gax.grpc.testing.FakeMethodDescriptor;
 import com.google.api.gax.paging.FixedSizeCollection;
 import com.google.api.gax.paging.Page;
 import com.google.api.gax.retrying.RetrySettings;
@@ -135,6 +136,27 @@ public class UnaryCallableTest {
       this.context = context;
       return immediateFuture(result);
     }
+  }
+
+  @Test
+  public void createNoThrow() {
+    SimpleCallSettings settings =
+        SimpleCallSettings.newBuilder(FakeMethodDescriptor.create())
+            .setRetryableCodes()
+            .setRetrySettingsBuilder(
+                RetrySettings.newBuilder()
+                    .setTotalTimeout(Duration.ZERO)
+                    .setInitialRetryDelay(Duration.ZERO)
+                    .setRetryDelayMultiplier(1)
+                    .setMaxRetryDelay(Duration.ZERO)
+                    .setMaxAttempts(1)
+                    .setInitialRpcTimeout(Duration.ZERO)
+                    .setRpcTimeoutMultiplier(1)
+                    .setMaxRpcTimeout(Duration.ZERO))
+            .build();
+    Channel channel = Mockito.mock(Channel.class);
+    ScheduledExecutorService executor = Mockito.mock(ScheduledExecutorService.class);
+    UnaryCallable.<Integer, Integer>create(settings, channel, executor);
   }
 
   @Test


### PR DESCRIPTION
This fixes a bug introduced in #305.
UnaryCallable uses ClientContext to pass values.
To ease transition, old surfaces are marked deprecated
but reimplemented using ClientContext.

These old surfaces did not populate closeables,
so ClientContext cannot be initialized.
This PR side steps this problem by initializing closeables
to empty list.