### PR TITLE
make AuthInterceptor honor old credentials

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/AuthInterceptor.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/AuthInterceptor.java
@@ -49,6 +49,9 @@ class AuthInterceptor implements ClientInterceptor {
   @Override
   public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
       final MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, final Channel next) {
-    return next.newCall(method, callOptions.withCallCredentials(credentials));
+    if (callOptions.getCredentials() == null) {
+      callOptions = callOptions.withCallCredentials(credentials);
+    }
+    return next.newCall(method, callOptions);
   }
 }


### PR DESCRIPTION
If credentials are set elsewhere,
AuthInterceptor now honors that credentials instead of
overwriting.

@garrettjonesgoogle I'm really not sure how to test this, though AuthInterceptor seems to have never been tested.