### PR TITLE
WIP: make ClientContext container-only, never initializing

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelAndExecutor.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelAndExecutor.java
@@ -41,7 +41,6 @@ import java.util.concurrent.ScheduledExecutorService;
  */
 @BetaApi
 @AutoValue
-@Deprecated
 public abstract class ChannelAndExecutor {
   public abstract ScheduledExecutorService getExecutor();
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ClientContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ClientContext.java
@@ -32,12 +32,7 @@ package com.google.api.gax.grpc;
 import com.google.api.core.BetaApi;
 import com.google.auth.Credentials;
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
 import io.grpc.Channel;
-import io.grpc.ManagedChannel;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nullable;
 
@@ -50,8 +45,6 @@ import javax.annotation.Nullable;
 @BetaApi
 @AutoValue
 public abstract class ClientContext {
-  public abstract Collection<AutoCloseable> getCloseables();
-
   public abstract Channel getChannel();
 
   public abstract ScheduledExecutorService getExecutor();
@@ -59,54 +52,12 @@ public abstract class ClientContext {
   @Nullable
   public abstract Credentials getCredentials();
 
-  static Builder newBuilder() {
-    return new AutoValue_ClientContext.Builder()
-        .setCloseables(Collections.<AutoCloseable>emptyList());
-  }
-
-  public static ClientContext create(ClientSettings settings) throws IOException {
-    ImmutableList.Builder<AutoCloseable> closeables = ImmutableList.builder();
-
-    ExecutorProvider executorProvider = settings.getExecutorProvider();
-    final ScheduledExecutorService executor = executorProvider.getExecutor();
-    if (executorProvider.shouldAutoClose()) {
-      closeables.add(
-          new AutoCloseable() {
-            @Override
-            public void close() {
-              executor.shutdown();
-            }
-          });
-    }
-
-    final ManagedChannel channel;
-    ChannelProvider channelProvider = settings.getChannelProvider();
-    if (channelProvider.needsExecutor()) {
-      channel = channelProvider.getChannel(executor);
-    } else {
-      channel = channelProvider.getChannel();
-    }
-    if (channelProvider.shouldAutoClose()) {
-      closeables.add(
-          new AutoCloseable() {
-            @Override
-            public void close() {
-              channel.shutdown();
-            }
-          });
-    }
-    return newBuilder()
-        .setCloseables(closeables.build())
-        .setChannel(channel)
-        .setExecutor(executor)
-        .setCredentials(settings.getCredentialsProvider().getCredentials())
-        .build();
+  public static Builder newBuilder() {
+    return new AutoValue_ClientContext.Builder();
   }
 
   @AutoValue.Builder
-  abstract static class Builder {
-    public abstract Builder setCloseables(Collection<AutoCloseable> value);
-
+  public abstract static class Builder {
     public abstract Builder setChannel(Channel value);
 
     public abstract Builder setExecutor(ScheduledExecutorService value);

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ClientSettings.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ClientSettings.java
@@ -34,10 +34,10 @@ import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 import io.grpc.Status;
 import java.io.IOException;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 /**
  * A base settings class to configure a service API class.
@@ -69,11 +69,11 @@ public abstract class ClientSettings {
 
   private final ExecutorProvider executorProvider;
   private final ChannelProvider channelProvider;
-  @Nullable private final CredentialsProvider credentialsProvider;
+  private final CredentialsProvider credentialsProvider;
 
   @Deprecated
   protected ClientSettings(ExecutorProvider executorProvider, ChannelProvider channelProvider) {
-    this(executorProvider, channelProvider, null);
+    this(executorProvider, channelProvider, new NoCredentialsProvider());
   }
 
   /** Constructs an instance of ClientSettings. */
@@ -83,11 +83,10 @@ public abstract class ClientSettings {
       CredentialsProvider credentialsProvider) {
     this.executorProvider = executorProvider;
     this.channelProvider = channelProvider;
-    this.credentialsProvider = credentialsProvider;
+    this.credentialsProvider = Preconditions.checkNotNull(credentialsProvider);
   }
 
   /** Gets a channel and an executor for making calls. */
-  @Deprecated
   public final ChannelAndExecutor getChannelAndExecutor() throws IOException {
     return ChannelAndExecutor.create(executorProvider, channelProvider);
   }
@@ -100,7 +99,6 @@ public abstract class ClientSettings {
     return channelProvider;
   }
 
-  @Nullable
   public final CredentialsProvider getCredentialsProvider() {
     return credentialsProvider;
   }
@@ -151,7 +149,7 @@ public abstract class ClientSettings {
 
     /** Sets the CredentialsProvider to use for getting the channel to make calls with. */
     public Builder setCredentialsProvider(CredentialsProvider credentialsProvider) {
-      this.credentialsProvider = credentialsProvider;
+      this.credentialsProvider = Preconditions.checkNotNull(credentialsProvider);
       return this;
     }
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingChannelProvider.java
@@ -118,12 +118,16 @@ public final class InstantiatingChannelProvider implements ChannelProvider {
   }
 
   private ManagedChannel createChannel(Executor executor) throws IOException {
-    CallCredentials callCredentials =
-        MoreCallCredentials.from(credentialsProvider.getCredentials());
-
     List<ClientInterceptor> interceptors = Lists.newArrayList();
-    interceptors.add(new AuthInterceptor(callCredentials));
     interceptors.add(new HeaderInterceptor(serviceHeader()));
+
+    if (credentialsProvider != null) {
+      Credentials credentials = credentialsProvider.getCredentials();
+      if (credentials != null) {
+        CallCredentials callCredentials = MoreCallCredentials.from(credentials);
+        interceptors.add(new AuthInterceptor(callCredentials));
+      }
+    }
 
     ManagedChannelBuilder builder =
         ManagedChannelBuilder.forAddress(serviceAddress, port)

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/OperationCallableTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/OperationCallableTest.java
@@ -42,7 +42,6 @@ import io.grpc.CallOptions;
 import io.grpc.Channel;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.junit.After;
@@ -99,7 +98,6 @@ public class OperationCallableTest {
             ClientContext.newBuilder()
                 .setChannel(Mockito.mock(Channel.class))
                 .setExecutor(executor)
-                .setCloseables(Collections.<AutoCloseable>emptyList())
                 .build(),
             operationsClient,
             Color.class,
@@ -130,7 +128,6 @@ public class OperationCallableTest {
             ClientContext.newBuilder()
                 .setChannel(Mockito.mock(Channel.class))
                 .setExecutor(executor)
-                .setCloseables(Collections.<AutoCloseable>emptyList())
                 .build(),
             operationsClient,
             Color.class,

--- a/gax/src/main/java/com/google/api/gax/core/FixedCredentialsProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/FixedCredentialsProvider.java
@@ -32,6 +32,7 @@ package com.google.api.gax.core;
 import com.google.api.core.BetaApi;
 import com.google.auth.Credentials;
 import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
 
 /** FixedCredentialsProvider is a CredentialsProvider which always provides the same credentials. */
 @BetaApi
@@ -39,6 +40,7 @@ import com.google.auto.value.AutoValue;
 public abstract class FixedCredentialsProvider implements CredentialsProvider {
 
   @Override
+  @Nullable
   public abstract Credentials getCredentials();
 
   /** Creates a FixedCredentialsProvider. */


### PR DESCRIPTION
WIP pending more tests,
but should be good enough for review.
All unit tests pass against both old and regenerated GCJ
but we should integ to make sure.

Adding Neo since a related change broke his code earlier.