### PR TITLE
Update release instructions

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,8 @@
-###Overview
-
-Most of the release process is handled by the uploadArchives task. The task can be triggered by
-running "./gradlew uploadArchives" from the project's directory. A new artifact will be uploaded
-to the staging repository in Sonatype when "-SNAPSHOT" is not included in the version (as
-listed in the base directory's `pom.xml`). When "-SNAPSHOT" is included, the task only updates the
-artifact in the snapshot repository.
-
-###Release Instructions
+Versioning
+----------
+A new artifact will be uploaded to the staging repository in Sonatype when
+"-SNAPSHOT" is not included in the version. When "-SNAPSHOT" is included, the
+task only updates the artifact in the snapshot repository.
 
 Set up Sonatype Account
 -----------------------
@@ -16,7 +12,7 @@ Set up Sonatype Account
 Get access to repository
 ------------------------
 * Go to [community support](https://issues.sonatype.org/browse/OSSRH)
-* Ask for publish rights by creating an issue similar to [this one](https://issues.sonatype.org/browse/OSSRH-16798)
+* Ask for publish rights by creating an issue similar to [this one](https://issues.sonatype.org/browse/OSSRH-32031)
   * You must be logged in to create a new issue
   * Use the *Create* button at the top tab
 
@@ -44,12 +40,10 @@ ossrhPassword=<YOUR-NEXUS-PASSWORD>
 
 Deploy to Sonatype
 ------------------
-* Update all ```pom.xml``` files in the package to the release version you want. Sumit a pull request, get it reviewed, and submit
-* ```mvn clean install deploy -DperformRelease=true```
-* Verify the publishment [here](https://oss.sonatype.org/#nexus-search;quick~gax)
-  * If there is a problem, undo by ```mvn nexus-staging:drop```
-* ```mvn nexus-staging:release -DperformRelease=true```
-* Update all ```pom.xml``` files to the new snapshot version
+* Update the ```gax/version.txt``` and ```gax-grpc/version.txt``` files to the
+  release version you want
+* Run ```./gradlew stageRelease``` to update ```README.md``` and ```samples/pom.xml```
+* Submit a pull request, get it reviewed, and submit
 
 Publish the release
 -------------------
@@ -59,3 +53,4 @@ Publish the release
   * In our case, ```comgoogleapi```
 * Click the *close*, then *release* button just below the top tabs
 * It will take some time (up to 10 minutes) for the package to transition
+* Run ```./gradlew finalizeRelease```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -45,7 +45,7 @@ Update version and deploy to Sonatype
 Publish the release
 -------------------
 * Run ```./gradlew finalizeRelease```
-* It will take some time (up to 10 minutes) for the package to transition
+* It will take some time (~10 min to ~8 hours) for the package to transition
 
 Bump development version
 ------------------------

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,3 @@
-Versioning
-----------
-A new artifact will be uploaded to the staging repository in Sonatype when
-"-SNAPSHOT" is not included in the version. When "-SNAPSHOT" is included, the
-task only updates the artifact in the snapshot repository.
-
 Set up Sonatype Account
 -----------------------
 * Sign up for a Sonatype JIRA account [here](https://issues.sonatype.org)
@@ -38,11 +32,14 @@ ossrhUsername=<YOUR-NEXUS-USERNAME>
 ossrhPassword=<YOUR-NEXUS-PASSWORD>
 ```
 
-Deploy to Sonatype
-------------------
+Update version and deploy to Sonatype
+-------------------------------------
 * Update the ```gax/version.txt``` and ```gax-grpc/version.txt``` files to the
   release version you want
-* Run ```./gradlew stageRelease``` to update ```README.md``` and ```samples/pom.xml```
+* Run ```./gradlew stageRelease``` to:
+  * Update ```README.md``` and ```samples/pom.xml```
+  * Regenerate ```gh-pages``` branch containing Javadocs
+  * Stage artifacts on Sonatype: to the staging repository if "-SNAPSHOT" is *not* included in the version; otherwise to the snapshot repository only
 * Submit a pull request, get it reviewed, and submit
 
 Publish the release
@@ -54,3 +51,7 @@ Publish the release
 * Click the *close*, then *release* button just below the top tabs
 * It will take some time (up to 10 minutes) for the package to transition
 * Run ```./gradlew finalizeRelease```
+
+Bump development version
+------------------------
+* Repeat the section "Update version and deploy to Sonatype" above, updating versions to the following "-SNAPSHOT" version

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -49,4 +49,5 @@ Publish the release
 
 Bump development version
 ------------------------
-* Repeat the section "Update version and deploy to Sonatype" above, updating versions to the following "-SNAPSHOT" version
+* Update the ```gax/version.txt``` and ```gax-grpc/version.txt``` files to the
+  following "-SNAPSHOT" version

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,13 +44,8 @@ Update version and deploy to Sonatype
 
 Publish the release
 -------------------
-* Go to [Sonatype](https://oss.sonatype.org/) and log in
-* Click on *Staging Repositories* on the left
-* Filter down to the repository by typing the package's groupId without periods in the search box
-  * In our case, ```comgoogleapi```
-* Click the *close*, then *release* button just below the top tabs
-* It will take some time (up to 10 minutes) for the package to transition
 * Run ```./gradlew finalizeRelease```
+* It will take some time (up to 10 minutes) for the package to transition
 
 Bump development version
 ------------------------

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -45,6 +45,10 @@ Update version and deploy to Sonatype
 Publish the release
 -------------------
 * Run ```./gradlew finalizeRelease```
+  * Note: this will release **ALL** versions that have been staged to Sonatype:
+    if you have staged versions you do not intend to release, remove these first
+    from the [Nexus Repository Manager](https://oss.sonatype.org/) by logging in
+    (upper right) and browsing staging repositories (left panel)
 * It will take some time (~10 min to ~8 hours) for the package to transition
 
 Bump development version

--- a/build.gradle
+++ b/build.gradle
@@ -398,7 +398,6 @@ task createApiDocsRedirect {
 }
 
 task publishDocs {
-  dependsOn 'closeAndReleaseRepository'
   doLast {
     exec {
       workingDir './tmp_gh-pages'

--- a/build.gradle
+++ b/build.gradle
@@ -398,6 +398,7 @@ task createApiDocsRedirect {
 }
 
 task publishDocs {
+  dependsOn 'closeAndReleaseRepository'
   doLast {
     exec {
       workingDir './tmp_gh-pages'


### PR DESCRIPTION
Attempt to make the release instructions correct. It appears the previous `build.gradle` file was left in an incomplete state. This edit leaves out some apparently intended functionality, leaving it to be done manually.

Will rely on review of correctness to finalize https://github.com/googleapis/gax-java/pull/320.