### PR TITLE
Tweak Gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,15 @@ jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk7
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
 install: ./gradlew assemble
 script: ./gradlew build install
 after_success:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.caching=true
+org.gradle.configureondemand=true
+org.gradle.daemon=true
+org.gradle.parallel=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Mon Oct 12 06:02:46 PDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-bin.zip


### PR DESCRIPTION
* Update gradle from 2.7 version to 3.5
* Enabled Gradle caching and building in parallel
* Enabled Travis caching

Clean `build install` time before: 58 seconds
Clean `build install` after: 41 seconds
Clean `build install` after with Gradle demon already running: 27 seconds