### PR TITLE
Moving code out of TransportDescriptor

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallSettings.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallSettings.java
@@ -27,39 +27,54 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.google.api.gax.rpc;
+package com.google.api.gax.grpc;
 
-import com.google.api.core.AbstractApiFuture;
-import com.google.api.core.BetaApi;
-import com.google.auto.value.AutoValue;
-import java.util.Set;
+import io.grpc.MethodDescriptor;
 
-/** Data necessary to translate an API call exception to a transport-agnostic form. */
-@AutoValue
-@BetaApi
-public abstract class TranslateExceptionParameters {
-  public abstract Throwable getThrowable();
+/** Grpc-specific settings for creating callables. */
+public class GrpcCallSettings<RequestT, ResponseT> {
+  private final MethodDescriptor<RequestT, ResponseT> methodDescriptor;
 
-  public abstract Set<StatusCode.Code> getRetryableCodes();
-
-  public abstract boolean isCancelled();
-
-  public abstract AbstractApiFuture<?> getResultFuture();
-
-  public static Builder newBuilder() {
-    return new AutoValue_TranslateExceptionParameters.Builder();
+  private GrpcCallSettings(MethodDescriptor<RequestT, ResponseT> methodDescriptor) {
+    this.methodDescriptor = methodDescriptor;
   }
 
-  @AutoValue.Builder
-  public abstract static class Builder {
-    public abstract Builder setThrowable(Throwable throwable);
+  public MethodDescriptor<RequestT, ResponseT> getMethodDescriptor() {
+    return methodDescriptor;
+  }
 
-    public abstract Builder setRetryableCodes(Set<StatusCode.Code> retryableCodes);
+  public static <RequestT, ResponseT> Builder<RequestT, ResponseT> newBuilder() {
+    return new Builder<>();
+  }
 
-    public abstract Builder setCancelled(boolean cancelled);
+  public static <RequestT, ResponseT> GrpcCallSettings<RequestT, ResponseT> of(
+      MethodDescriptor<RequestT, ResponseT> methodDescriptor) {
+    return GrpcCallSettings.<RequestT, ResponseT>newBuilder()
+        .setMethodDescriptor(methodDescriptor)
+        .build();
+  }
 
-    public abstract Builder setResultFuture(AbstractApiFuture<?> resultFuture);
+  public Builder toBuilder() {
+    return new Builder<>(this);
+  }
 
-    public abstract TranslateExceptionParameters build();
+  public static class Builder<RequestT, ResponseT> {
+    private MethodDescriptor<RequestT, ResponseT> methodDescriptor;
+
+    private Builder() {}
+
+    private Builder(GrpcCallSettings<RequestT, ResponseT> settings) {
+      this.methodDescriptor = settings.methodDescriptor;
+    }
+
+    public Builder<RequestT, ResponseT> setMethodDescriptor(
+        MethodDescriptor<RequestT, ResponseT> methodDescriptor) {
+      this.methodDescriptor = methodDescriptor;
+      return this;
+    }
+
+    public GrpcCallSettings<RequestT, ResponseT> build() {
+      return new GrpcCallSettings<>(methodDescriptor);
+    }
   }
 }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -30,7 +30,13 @@
 package com.google.api.gax.grpc;
 
 import com.google.api.core.BetaApi;
-import io.grpc.MethodDescriptor;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientStreamingCallable;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StreamingCallSettings;
+import com.google.api.gax.rpc.UnaryCallSettingsTyped;
+import com.google.api.gax.rpc.UnaryCallable;
 
 /** Class with utility methods to create grpc-based direct callables. */
 @BetaApi
@@ -39,49 +45,62 @@ public class GrpcCallableFactory {
   private GrpcCallableFactory() {}
 
   /**
-   * Create a callable object that directly issues the call to the underlying API with nothing
-   * wrapping it. Designed for use by generated code.
+   * Create a callable object with grpc-specific functionality. Designed for use by generated code.
    *
-   * @param methodDescriptor the gRPC method descriptor
+   * @param grpcCallSettings the gRPC call settings
    */
-  public static <RequestT, ResponseT> GrpcDirectCallable<RequestT, ResponseT> createDirectCallable(
-      MethodDescriptor<RequestT, ResponseT> methodDescriptor) {
-    return new GrpcDirectCallable<>(methodDescriptor);
+  public static <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createUnaryCallable(
+      GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+      UnaryCallSettingsTyped<RequestT, ResponseT> callSettings,
+      ClientContext clientContext) {
+    UnaryCallable<RequestT, ResponseT> callable =
+        new GrpcDirectCallable<>(grpcCallSettings.getMethodDescriptor());
+    callable = new GrpcExceptionCallable<>(callable, callSettings.getRetryableCodes());
+    return callable;
   }
 
   /**
-   * Create a callable object that directly issues the bidirectional streaming call to the
-   * underlying API with nothing wrapping it. Designed for use by generated code.
+   * Create a bidirectional streaming callable object with grpc-specific functionality. Designed for
+   * use by generated code.
    *
-   * @param methodDescriptor the gRPC method descriptor
+   * @param grpcCallSettings the gRPC call settings
    */
+  @BetaApi
   public static <RequestT, ResponseT>
-      GrpcDirectBidiStreamingCallable<RequestT, ResponseT> createDirectBidiStreamingCallable(
-          MethodDescriptor<RequestT, ResponseT> methodDescriptor) {
-    return new GrpcDirectBidiStreamingCallable<>(methodDescriptor);
+      BidiStreamingCallable<RequestT, ResponseT> createBidiStreamingCallable(
+          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+          StreamingCallSettings<RequestT, ResponseT> streamingCallSettings,
+          ClientContext clientContext) {
+    return new GrpcDirectBidiStreamingCallable<>(grpcCallSettings.getMethodDescriptor());
   }
 
   /**
-   * Create a callable object that directly issues the server streaming call to the underlying API
-   * with nothing wrapping it. Designed for use by generated code.
+   * Create a server-streaming callable with grpc-specific functionality. Designed for use by
+   * generated code.
    *
-   * @param methodDescriptor the gRPC method descriptor
+   * @param grpcCallSettings the gRPC call settings
    */
+  @BetaApi
   public static <RequestT, ResponseT>
-      GrpcDirectServerStreamingCallable<RequestT, ResponseT> createDirectServerStreamingCallable(
-          MethodDescriptor<RequestT, ResponseT> methodDescriptor) {
-    return new GrpcDirectServerStreamingCallable<>(methodDescriptor);
+      ServerStreamingCallable<RequestT, ResponseT> createServerStreamingCallable(
+          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+          StreamingCallSettings<RequestT, ResponseT> streamingCallSettings,
+          ClientContext clientContext) {
+    return new GrpcDirectServerStreamingCallable<>(grpcCallSettings.getMethodDescriptor());
   }
 
   /**
-   * Create a callable object that directly issues the client streaming call to the underlying API
-   * with nothing wrapping it. Designed for use by generated code.
+   * Create a client-streaming callable object with grpc-specific functionality. Designed for use by
+   * generated code.
    *
-   * @param methodDescriptor the gRPC method descriptor
+   * @param grpcCallSettings the gRPC call settings
    */
+  @BetaApi
   public static <RequestT, ResponseT>
-      GrpcDirectClientStreamingCallable<RequestT, ResponseT> createDirectClientStreamingCallable(
-          MethodDescriptor<RequestT, ResponseT> methodDescriptor) {
-    return new GrpcDirectClientStreamingCallable<>(methodDescriptor);
+      ClientStreamingCallable<RequestT, ResponseT> createClientStreamingCallable(
+          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+          StreamingCallSettings<RequestT, ResponseT> streamingCallSettings,
+          ClientContext clientContext) {
+    return new GrpcDirectClientStreamingCallable<>(grpcCallSettings.getMethodDescriptor());
   }
 }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcStatusCode.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcStatusCode.java
@@ -46,7 +46,7 @@ public class GrpcStatusCode implements StatusCode {
     return new GrpcStatusCode(grpcCode, grpcCodeToStatusCode(grpcCode));
   }
 
-  private static StatusCode.Code grpcCodeToStatusCode(Status.Code code) {
+  static StatusCode.Code grpcCodeToStatusCode(Status.Code code) {
     switch (code) {
       case OK:
         return StatusCode.Code.OK;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/testing/FakeMethodDescriptor.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/testing/FakeMethodDescriptor.java
@@ -44,7 +44,12 @@ public class FakeMethodDescriptor {
 
   public static <I, O> MethodDescriptor<I, O> create(
       MethodDescriptor.MethodType type, String name) {
-    return MethodDescriptor.create(type, name, new FakeMarshaller<I>(), new FakeMarshaller<O>());
+    return MethodDescriptor.<I, O>newBuilder()
+        .setType(MethodDescriptor.MethodType.UNARY)
+        .setFullMethodName(name)
+        .setRequestMarshaller(new FakeMarshaller<I>())
+        .setResponseMarshaller(new FakeMarshaller<O>())
+        .build();
   }
 
   private static class FakeMarshaller<T> implements MethodDescriptor.Marshaller<T> {

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/testing/FakeServiceGrpc.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/testing/FakeServiceGrpc.java
@@ -67,47 +67,56 @@ public final class FakeServiceGrpc {
   public static final String SERVICE_NAME = "google.gax.FakeService";
 
   public static final MethodDescriptor<Color, Money> METHOD_RECOGNIZE =
-      MethodDescriptor.create(
-          MethodType.UNARY,
-          generateFullMethodName("google.gax.FakeService", "Recognize"),
-          ProtoUtils.marshaller(Color.getDefaultInstance()),
-          ProtoUtils.marshaller(Money.getDefaultInstance()));
+      MethodDescriptor.<Color, Money>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName(generateFullMethodName("google.gax.FakeService", "Recognize"))
+          .setRequestMarshaller(ProtoUtils.marshaller(Color.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Money.getDefaultInstance()))
+          .build();
 
-  public static final MethodDescriptor<Color, com.google.longrunning.Operation>
-      METHOD_LONG_RUNNING_RECOGNIZE =
-          MethodDescriptor.create(
-              MethodType.UNARY,
-              generateFullMethodName("google.gax.FakeService", "LongRunningRecognize"),
-              ProtoUtils.marshaller(Color.getDefaultInstance()),
-              ProtoUtils.marshaller(Operation.getDefaultInstance()));
+  public static final MethodDescriptor<Color, Operation> METHOD_LONG_RUNNING_RECOGNIZE =
+      MethodDescriptor.<Color, Operation>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName(
+              generateFullMethodName("google.gax.FakeService", "LongRunningRecognize"))
+          .setRequestMarshaller(ProtoUtils.marshaller(Color.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
+          .build();
 
   public static final MethodDescriptor<Color, Money> METHOD_STREAMING_RECOGNIZE =
-      MethodDescriptor.create(
-          MethodType.BIDI_STREAMING,
-          generateFullMethodName("google.gax.FakeService", "StreamingRecognize"),
-          ProtoUtils.marshaller(Color.getDefaultInstance()),
-          ProtoUtils.marshaller(Money.getDefaultInstance()));
+      MethodDescriptor.<Color, Money>newBuilder()
+          .setType(MethodDescriptor.MethodType.BIDI_STREAMING)
+          .setFullMethodName(generateFullMethodName("google.gax.FakeService", "StreamingRecognize"))
+          .setRequestMarshaller(ProtoUtils.marshaller(Color.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Money.getDefaultInstance()))
+          .build();
 
   public static final MethodDescriptor<Color, Money> METHOD_STREAMING_RECOGNIZE_ERROR =
-      MethodDescriptor.create(
-          MethodType.BIDI_STREAMING,
-          generateFullMethodName("google.gax.FakeService", "StreamingRecognizeError"),
-          ProtoUtils.marshaller(Color.getDefaultInstance()),
-          ProtoUtils.marshaller(Money.getDefaultInstance()));
+      MethodDescriptor.<Color, Money>newBuilder()
+          .setType(MethodDescriptor.MethodType.BIDI_STREAMING)
+          .setFullMethodName(
+              generateFullMethodName("google.gax.FakeService", "StreamingRecognizeError"))
+          .setRequestMarshaller(ProtoUtils.marshaller(Color.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Money.getDefaultInstance()))
+          .build();
 
   public static final MethodDescriptor<Color, Money> METHOD_SERVER_STREAMING_RECOGNIZE =
-      MethodDescriptor.create(
-          MethodType.SERVER_STREAMING,
-          generateFullMethodName("google.gax.FakeService", "ServerStreamingRecognize"),
-          ProtoUtils.marshaller(Color.getDefaultInstance()),
-          ProtoUtils.marshaller(Money.getDefaultInstance()));
+      MethodDescriptor.<Color, Money>newBuilder()
+          .setType(MethodDescriptor.MethodType.SERVER_STREAMING)
+          .setFullMethodName(
+              generateFullMethodName("google.gax.FakeService", "ServerStreamingRecognize"))
+          .setRequestMarshaller(ProtoUtils.marshaller(Color.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Money.getDefaultInstance()))
+          .build();
 
   public static final MethodDescriptor<Color, Money> METHOD_CLIENT_STREAMING_RECOGNIZE =
-      MethodDescriptor.create(
-          MethodType.CLIENT_STREAMING,
-          generateFullMethodName("google.gax.FakeService", "ClientStreamingRecognize"),
-          ProtoUtils.marshaller(Color.getDefaultInstance()),
-          ProtoUtils.marshaller(Money.getDefaultInstance()));
+      MethodDescriptor.<Color, Money>newBuilder()
+          .setType(MethodDescriptor.MethodType.CLIENT_STREAMING)
+          .setFullMethodName(
+              generateFullMethodName("google.gax.FakeService", "ClientStreamingRecognize"))
+          .setRequestMarshaller(ProtoUtils.marshaller(Color.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Money.getDefaultInstance()))
+          .build();
 
   public abstract static class FakeServiceImplBase implements BindableService {
 

--- a/gax-grpc/src/main/java/com/google/longrunning/stub/GrpcOperationsStub.java
+++ b/gax-grpc/src/main/java/com/google/longrunning/stub/GrpcOperationsStub.java
@@ -34,6 +34,7 @@ import static com.google.longrunning.PagedResponseWrappers.ListOperationsPagedRe
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.BackgroundResourceAggregation;
+import com.google.api.gax.grpc.GrpcCallSettings;
 import com.google.api.gax.grpc.GrpcCallableFactory;
 import com.google.api.gax.grpc.GrpcTransportDescriptor;
 import com.google.api.gax.rpc.CallableFactory;
@@ -47,6 +48,8 @@ import com.google.longrunning.ListOperationsResponse;
 import com.google.longrunning.Operation;
 import com.google.longrunning.OperationsSettings;
 import com.google.protobuf.Empty;
+import io.grpc.MethodDescriptor;
+import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
@@ -58,37 +61,42 @@ public class GrpcOperationsStub extends OperationsStub {
   private static final CallableFactory callableFactory =
       CallableFactory.create(GrpcTransportDescriptor.create());
 
-  private static final UnaryCallable<GetOperationRequest, Operation> directGetOperationCallable =
-      GrpcCallableFactory.createDirectCallable(
-          io.grpc.MethodDescriptor.create(
-              io.grpc.MethodDescriptor.MethodType.UNARY,
-              "google.longrunning.Operations/GetOperation",
-              io.grpc.protobuf.ProtoUtils.marshaller(GetOperationRequest.getDefaultInstance()),
-              io.grpc.protobuf.ProtoUtils.marshaller(Operation.getDefaultInstance())));
-  private static final UnaryCallable<ListOperationsRequest, ListOperationsResponse>
-      directListOperationsCallable =
-          GrpcCallableFactory.createDirectCallable(
-              io.grpc.MethodDescriptor.create(
-                  io.grpc.MethodDescriptor.MethodType.UNARY,
-                  "google.longrunning.Operations/ListOperations",
-                  io.grpc.protobuf.ProtoUtils.marshaller(
-                      ListOperationsRequest.getDefaultInstance()),
-                  io.grpc.protobuf.ProtoUtils.marshaller(
-                      ListOperationsResponse.getDefaultInstance())));
-  private static final UnaryCallable<CancelOperationRequest, Empty> directCancelOperationCallable =
-      GrpcCallableFactory.createDirectCallable(
-          io.grpc.MethodDescriptor.create(
-              io.grpc.MethodDescriptor.MethodType.UNARY,
-              "google.longrunning.Operations/CancelOperation",
-              io.grpc.protobuf.ProtoUtils.marshaller(CancelOperationRequest.getDefaultInstance()),
-              io.grpc.protobuf.ProtoUtils.marshaller(Empty.getDefaultInstance())));
-  private static final UnaryCallable<DeleteOperationRequest, Empty> directDeleteOperationCallable =
-      GrpcCallableFactory.createDirectCallable(
-          io.grpc.MethodDescriptor.create(
-              io.grpc.MethodDescriptor.MethodType.UNARY,
-              "google.longrunning.Operations/DeleteOperation",
-              io.grpc.protobuf.ProtoUtils.marshaller(DeleteOperationRequest.getDefaultInstance()),
-              io.grpc.protobuf.ProtoUtils.marshaller(Empty.getDefaultInstance())));
+  private static final MethodDescriptor<GetOperationRequest, Operation>
+      getOperationMethodDescriptor =
+          MethodDescriptor.<GetOperationRequest, Operation>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.longrunning.Operations/GetOperation")
+              .setRequestMarshaller(ProtoUtils.marshaller(GetOperationRequest.getDefaultInstance()))
+              .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
+              .build();
+  private static final MethodDescriptor<ListOperationsRequest, ListOperationsResponse>
+      listOperationsMethodDescriptor =
+          MethodDescriptor.<ListOperationsRequest, ListOperationsResponse>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.longrunning.Operations/ListOperations")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(ListOperationsRequest.getDefaultInstance()))
+              .setResponseMarshaller(
+                  ProtoUtils.marshaller(ListOperationsResponse.getDefaultInstance()))
+              .build();
+  private static final MethodDescriptor<CancelOperationRequest, Empty>
+      cancelOperationMethodDescriptor =
+          MethodDescriptor.<CancelOperationRequest, Empty>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.longrunning.Operations/CancelOperation")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(CancelOperationRequest.getDefaultInstance()))
+              .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
+              .build();
+  private static final MethodDescriptor<DeleteOperationRequest, Empty>
+      deleteOperationMethodDescriptor =
+          MethodDescriptor.<DeleteOperationRequest, Empty>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.longrunning.Operations/DeleteOperation")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(DeleteOperationRequest.getDefaultInstance()))
+              .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
+              .build();
   private final BackgroundResource backgroundResources;
 
   private final UnaryCallable<GetOperationRequest, Operation> getOperationCallable;
@@ -113,21 +121,49 @@ public class GrpcOperationsStub extends OperationsStub {
   protected GrpcOperationsStub(OperationsSettings settings, ClientContext clientContext)
       throws IOException {
 
+    GrpcCallSettings<GetOperationRequest, Operation> getOperationGrpcSettings =
+        GrpcCallSettings.<GetOperationRequest, Operation>newBuilder()
+            .setMethodDescriptor(getOperationMethodDescriptor)
+            .build();
+    UnaryCallable<GetOperationRequest, Operation> getOperationBaseCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            getOperationGrpcSettings, settings.getOperationSettings(), clientContext);
     this.getOperationCallable =
         callableFactory.create(
-            directGetOperationCallable, settings.getOperationSettings(), clientContext);
+            getOperationBaseCallable, settings.getOperationSettings(), clientContext);
+    GrpcCallSettings<ListOperationsRequest, ListOperationsResponse> listOperationsGrpcSettings =
+        GrpcCallSettings.<ListOperationsRequest, ListOperationsResponse>newBuilder()
+            .setMethodDescriptor(listOperationsMethodDescriptor)
+            .build();
+    UnaryCallable<ListOperationsRequest, ListOperationsResponse> listOperationsBaseCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            listOperationsGrpcSettings, settings.listOperationsSettings(), clientContext);
     this.listOperationsCallable =
         callableFactory.create(
-            directListOperationsCallable, settings.listOperationsSettings(), clientContext);
+            listOperationsBaseCallable, settings.listOperationsSettings(), clientContext);
     this.listOperationsPagedCallable =
         callableFactory.createPagedVariant(
-            directListOperationsCallable, settings.listOperationsSettings(), clientContext);
+            listOperationsBaseCallable, settings.listOperationsSettings(), clientContext);
+    GrpcCallSettings<CancelOperationRequest, Empty> cancelOperationGrpcSettings =
+        GrpcCallSettings.<CancelOperationRequest, Empty>newBuilder()
+            .setMethodDescriptor(cancelOperationMethodDescriptor)
+            .build();
+    UnaryCallable<CancelOperationRequest, Empty> cancelOperationBaseCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            cancelOperationGrpcSettings, settings.cancelOperationSettings(), clientContext);
     this.cancelOperationCallable =
         callableFactory.create(
-            directCancelOperationCallable, settings.cancelOperationSettings(), clientContext);
+            cancelOperationBaseCallable, settings.cancelOperationSettings(), clientContext);
+    GrpcCallSettings<DeleteOperationRequest, Empty> deleteOperationGrpcSettings =
+        GrpcCallSettings.<DeleteOperationRequest, Empty>newBuilder()
+            .setMethodDescriptor(deleteOperationMethodDescriptor)
+            .build();
+    UnaryCallable<DeleteOperationRequest, Empty> deleteOperationBaseCallable =
+        GrpcCallableFactory.createUnaryCallable(
+            deleteOperationGrpcSettings, settings.deleteOperationSettings(), clientContext);
     this.deleteOperationCallable =
         callableFactory.create(
-            directDeleteOperationCallable, settings.deleteOperationSettings(), clientContext);
+            deleteOperationBaseCallable, settings.deleteOperationSettings(), clientContext);
 
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectStreamingCallableTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectStreamingCallableTest.java
@@ -36,7 +36,6 @@ import static com.google.api.gax.grpc.testing.FakeServiceGrpc.METHOD_STREAMING_R
 
 import com.google.api.gax.grpc.testing.FakeServiceImpl;
 import com.google.api.gax.grpc.testing.InProcessServer;
-import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ApiStreamObserver;
 import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.ClientStreamingCallable;
@@ -44,6 +43,7 @@ import com.google.api.gax.rpc.EntryPointBidiStreamingCallable;
 import com.google.api.gax.rpc.EntryPointClientStreamingCallable;
 import com.google.api.gax.rpc.EntryPointServerStreamingCallable;
 import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.testing.FakeApiCallContext;
 import com.google.common.collect.Iterators;
 import com.google.common.truth.Truth;
 import com.google.type.Color;
@@ -94,8 +94,9 @@ public class GrpcDirectStreamingCallableTest {
 
   @Test
   public void testBidiStreaming() throws Exception {
-    GrpcDirectBidiStreamingCallable<Color, Money> callable =
-        GrpcCallableFactory.createDirectBidiStreamingCallable(METHOD_STREAMING_RECOGNIZE);
+    BidiStreamingCallable<Color, Money> callable =
+        GrpcCallableFactory.createBidiStreamingCallable(
+            GrpcCallSettings.of(METHOD_STREAMING_RECOGNIZE), null, null);
     GrpcCallContext callContext = GrpcCallContext.of(channel, CallOptions.DEFAULT);
     BidiStreamingCallable<Color, Money> streamingCallable =
         new EntryPointBidiStreamingCallable<>(callable, callContext);
@@ -117,8 +118,9 @@ public class GrpcDirectStreamingCallableTest {
 
   @Test
   public void testBidiStreamingServerError() throws Exception {
-    GrpcDirectBidiStreamingCallable<Color, Money> callable =
-        GrpcCallableFactory.createDirectBidiStreamingCallable(METHOD_STREAMING_RECOGNIZE_ERROR);
+    BidiStreamingCallable<Color, Money> callable =
+        GrpcCallableFactory.createBidiStreamingCallable(
+            GrpcCallSettings.of(METHOD_STREAMING_RECOGNIZE_ERROR), null, null);
     GrpcCallContext callContext = GrpcCallContext.of(channel, CallOptions.DEFAULT);
     BidiStreamingCallable<Color, Money> streamingCallable =
         new EntryPointBidiStreamingCallable<>(callable, callContext);
@@ -140,8 +142,9 @@ public class GrpcDirectStreamingCallableTest {
 
   @Test
   public void testBidiStreamingClientError() throws Exception {
-    GrpcDirectBidiStreamingCallable<Color, Money> callable =
-        GrpcCallableFactory.createDirectBidiStreamingCallable(METHOD_STREAMING_RECOGNIZE_ERROR);
+    BidiStreamingCallable<Color, Money> callable =
+        GrpcCallableFactory.createBidiStreamingCallable(
+            GrpcCallSettings.of(METHOD_STREAMING_RECOGNIZE_ERROR), null, null);
     GrpcCallContext callContext = GrpcCallContext.of(channel, CallOptions.DEFAULT);
     BidiStreamingCallable<Color, Money> streamingCallable =
         new EntryPointBidiStreamingCallable<>(callable, callContext);
@@ -166,8 +169,9 @@ public class GrpcDirectStreamingCallableTest {
 
   @Test
   public void testServerStreaming() throws Exception {
-    GrpcDirectServerStreamingCallable<Color, Money> callable =
-        GrpcCallableFactory.createDirectServerStreamingCallable(METHOD_SERVER_STREAMING_RECOGNIZE);
+    ServerStreamingCallable<Color, Money> callable =
+        GrpcCallableFactory.createServerStreamingCallable(
+            GrpcCallSettings.of(METHOD_SERVER_STREAMING_RECOGNIZE), null, null);
     GrpcCallContext callContext = GrpcCallContext.of(channel, CallOptions.DEFAULT);
     ServerStreamingCallable<Color, Money> streamingCallable =
         new EntryPointServerStreamingCallable<>(callable, callContext);
@@ -186,8 +190,9 @@ public class GrpcDirectStreamingCallableTest {
 
   @Test
   public void testBlockingServerStreaming() throws Exception {
-    GrpcDirectServerStreamingCallable<Color, Money> callable =
-        GrpcCallableFactory.createDirectServerStreamingCallable(METHOD_SERVER_STREAMING_RECOGNIZE);
+    ServerStreamingCallable<Color, Money> callable =
+        GrpcCallableFactory.createServerStreamingCallable(
+            GrpcCallSettings.of(METHOD_SERVER_STREAMING_RECOGNIZE), null, null);
     GrpcCallContext callContext = GrpcCallContext.of(channel, CallOptions.DEFAULT);
     ServerStreamingCallable<Color, Money> streamingCallable =
         new EntryPointServerStreamingCallable<>(callable, callContext);
@@ -203,8 +208,9 @@ public class GrpcDirectStreamingCallableTest {
 
   @Test
   public void testClientStreaming() throws Exception {
-    GrpcDirectClientStreamingCallable<Color, Money> callable =
-        GrpcCallableFactory.createDirectClientStreamingCallable(METHOD_CLIENT_STREAMING_RECOGNIZE);
+    ClientStreamingCallable<Color, Money> callable =
+        GrpcCallableFactory.createClientStreamingCallable(
+            GrpcCallSettings.of(METHOD_CLIENT_STREAMING_RECOGNIZE), null, null);
     GrpcCallContext callContext = GrpcCallContext.of(channel, CallOptions.DEFAULT);
     ClientStreamingCallable<Color, Money> streamingCallable =
         new EntryPointClientStreamingCallable<>(callable, callContext);
@@ -227,10 +233,11 @@ public class GrpcDirectStreamingCallableTest {
   @Test
   public void testBadContext() {
     thrown.expect(IllegalArgumentException.class);
-    GrpcDirectServerStreamingCallable<Color, Money> callable =
-        GrpcCallableFactory.createDirectServerStreamingCallable(METHOD_SERVER_STREAMING_RECOGNIZE);
+    ServerStreamingCallable<Color, Money> callable =
+        GrpcCallableFactory.createServerStreamingCallable(
+            GrpcCallSettings.of(METHOD_SERVER_STREAMING_RECOGNIZE), null, null);
     ServerStreamingCallable<Color, Money> streamingCallable =
-        new EntryPointServerStreamingCallable<>(callable, new ApiCallContext() {});
+        new EntryPointServerStreamingCallable<>(callable, FakeApiCallContext.of());
     Color request = Color.newBuilder().setRed(0.5f).build();
     streamingCallable.blockingServerStreamingCall(request);
   }

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -32,6 +32,8 @@ package com.google.api.gax.httpjson;
 import com.google.api.core.BetaApi;
 import com.google.api.gax.rpc.ApiCallContext;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import org.threeten.bp.Duration;
 
 /**
  * HttpJsonCallContext encapsulates context data used to make an http-json call.
@@ -76,6 +78,22 @@ public final class HttpJsonCallContext implements ApiCallContext {
   /** Returns an empty instance. */
   public static HttpJsonCallContext createDefault() {
     return new HttpJsonCallContext(null, HttpJsonCallOptions.createDefault());
+  }
+
+  @Override
+  public HttpJsonCallContext withTimeout(Duration rpcTimeout) {
+    HttpJsonCallOptions oldOptions = callOptions;
+    HttpJsonCallOptions newOptions =
+        oldOptions.withDeadlineAfter(rpcTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    HttpJsonCallContext nextContext = withCallOptions(newOptions);
+
+    if (oldOptions.getDeadline() == null) {
+      return nextContext;
+    }
+    if (oldOptions.getDeadline().isBefore(newOptions.getDeadline())) {
+      return this;
+    }
+    return nextContext;
   }
 
   public HttpJsonChannel getChannel() {

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonExceptionCallable.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonExceptionCallable.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.httpjson;
+
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.core.AbstractApiFuture;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.ApiExceptionFactory;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+
+/**
+ * Transforms all {@code Throwable}s thrown during a call into an instance of {@link ApiException}.
+ *
+ * <p>Package-private for internal use.
+ */
+class HttpJsonExceptionCallable<RequestT, ResponseT> extends UnaryCallable<RequestT, ResponseT> {
+  private final UnaryCallable<RequestT, ResponseT> callable;
+  private final ImmutableSet<StatusCode.Code> retryableCodes;
+
+  HttpJsonExceptionCallable(
+      UnaryCallable<RequestT, ResponseT> callable, Set<StatusCode.Code> retryableCodes) {
+    this.callable = Preconditions.checkNotNull(callable);
+    this.retryableCodes = ImmutableSet.copyOf(retryableCodes);
+  }
+
+  @Override
+  public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext inputContext) {
+    HttpJsonCallContext context =
+        HttpJsonCallContext.getAsHttpJsonCallContextWithDefault(inputContext);
+    ApiFuture<ResponseT> innerCallFuture = callable.futureCall(request, context);
+    ExceptionTransformingFuture transformingFuture =
+        new ExceptionTransformingFuture(innerCallFuture);
+    ApiFutures.addCallback(innerCallFuture, transformingFuture);
+    return transformingFuture;
+  }
+
+  private class ExceptionTransformingFuture extends AbstractApiFuture<ResponseT>
+      implements ApiFutureCallback<ResponseT> {
+    private ApiFuture<ResponseT> innerCallFuture;
+    private volatile boolean cancelled = false;
+
+    public ExceptionTransformingFuture(ApiFuture<ResponseT> innerCallFuture) {
+      this.innerCallFuture = innerCallFuture;
+    }
+
+    @Override
+    protected void interruptTask() {
+      cancelled = true;
+      innerCallFuture.cancel(true);
+    }
+
+    @Override
+    public void onSuccess(ResponseT r) {
+      super.set(r);
+    }
+
+    @Override
+    public void onFailure(Throwable throwable) {
+      StatusCode.Code statusCode = StatusCode.Code.UNKNOWN;
+      boolean canRetry = false;
+      boolean rethrow = false;
+      String message = null;
+      if (throwable instanceof HttpResponseException) {
+        HttpResponseException e = (HttpResponseException) throwable;
+        statusCode = HttpJsonStatusCode.httpStatusToStatusCode(e.getStatusCode(), e.getMessage());
+        canRetry = retryableCodes.contains(statusCode);
+        message = e.getStatusMessage();
+      } else if (throwable instanceof CancellationException && cancelled) {
+        // this just circled around, so ignore.
+        return;
+      } else if (throwable instanceof ApiException) {
+        rethrow = true;
+      } else {
+        // Do not retry on unknown throwable, even when UNKNOWN is in retryableCodes
+        statusCode = StatusCode.Code.UNKNOWN;
+        canRetry = false;
+      }
+      if (rethrow) {
+        super.setException(throwable);
+      } else {
+        ApiException newException =
+            message == null
+                ? ApiExceptionFactory.createException(
+                    throwable, HttpJsonStatusCode.of(statusCode), canRetry)
+                : ApiExceptionFactory.createException(
+                    message, throwable, HttpJsonStatusCode.of(statusCode), canRetry);
+        super.setException(newException);
+      }
+    }
+  }
+}

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStatusCode.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStatusCode.java
@@ -55,7 +55,7 @@ public class HttpJsonStatusCode implements StatusCode {
     return new HttpJsonStatusCode(statusCodeToHttpStatus(statusCode), statusCode);
   }
 
-  private static StatusCode.Code httpStatusToStatusCode(int httpStatus, String errorMessage) {
+  static StatusCode.Code httpStatusToStatusCode(int httpStatus, String errorMessage) {
     String causeMessage = Strings.nullToEmpty(errorMessage).toUpperCase();
     switch (httpStatus) {
       case 400:
@@ -99,7 +99,7 @@ public class HttpJsonStatusCode implements StatusCode {
     }
   }
 
-  private static int statusCodeToHttpStatus(StatusCode.Code statusCode) {
+  static int statusCodeToHttpStatus(StatusCode.Code statusCode) {
     switch (statusCode) {
       case CANCELLED:
         return 499;

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/RetryingTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/RetryingTest.java
@@ -129,7 +129,8 @@ public class RetryingTest {
     SimpleCallSettings<Integer, Integer> callSettings =
         createSettings(retryable, FAST_RETRY_SETTINGS);
     UnaryCallable<Integer, Integer> callable =
-        callableFactory.create(callInt, callSettings, clientContext);
+        callableFactory.create(
+            translateExceptions(callInt, retryable), callSettings, clientContext);
     Truth.assertThat(callable.call(1)).isEqualTo(2);
   }
 
@@ -160,7 +161,8 @@ public class RetryingTest {
             .build();
     SimpleCallSettings<Integer, Integer> callSettings = createSettings(retryable, retrySettings);
     UnaryCallable<Integer, Integer> callable =
-        callableFactory.create(callInt, callSettings, clientContext);
+        callableFactory.create(
+            translateExceptions(callInt, retryable), callSettings, clientContext);
     callable.call(1);
   }
 
@@ -175,7 +177,8 @@ public class RetryingTest {
     RetrySettings retrySettings = FAST_RETRY_SETTINGS.toBuilder().setMaxAttempts(2).build();
     SimpleCallSettings<Integer, Integer> callSettings = createSettings(retryable, retrySettings);
     UnaryCallable<Integer, Integer> callable =
-        callableFactory.create(callInt, callSettings, clientContext);
+        callableFactory.create(
+            translateExceptions(callInt, retryable), callSettings, clientContext);
     callable.call(1);
   }
 
@@ -190,7 +193,8 @@ public class RetryingTest {
     RetrySettings retrySettings = FAST_RETRY_SETTINGS.toBuilder().setMaxAttempts(3).build();
     SimpleCallSettings<Integer, Integer> callSettings = createSettings(retryable, retrySettings);
     UnaryCallable<Integer, Integer> callable =
-        callableFactory.create(callInt, callSettings, clientContext);
+        callableFactory.create(
+            translateExceptions(callInt, retryable), callSettings, clientContext);
     callable.call(1);
     Truth.assertThat(callable.call(1)).isEqualTo(2);
   }
@@ -211,7 +215,8 @@ public class RetryingTest {
     SimpleCallSettings<Integer, Integer> callSettings =
         createSettings(retryable, FAST_RETRY_SETTINGS);
     UnaryCallable<Integer, Integer> callable =
-        callableFactory.create(callInt, callSettings, clientContext);
+        callableFactory.create(
+            translateExceptions(callInt, retryable), callSettings, clientContext);
     Truth.assertThat(callable.call(1)).isEqualTo(2);
   }
 
@@ -226,7 +231,8 @@ public class RetryingTest {
     SimpleCallSettings<Integer, Integer> callSettings =
         createSettings(retryable, FAST_RETRY_SETTINGS);
     UnaryCallable<Integer, Integer> callable =
-        callableFactory.create(callInt, callSettings, clientContext);
+        callableFactory.create(
+            translateExceptions(callInt, retryable), callSettings, clientContext);
     callable.call(1);
   }
 
@@ -250,7 +256,8 @@ public class RetryingTest {
     SimpleCallSettings<Integer, Integer> callSettings =
         createSettings(retryable, FAST_RETRY_SETTINGS);
     UnaryCallable<Integer, Integer> callable =
-        callableFactory.create(callInt, callSettings, clientContext);
+        callableFactory.create(
+            translateExceptions(callInt, retryable), callSettings, clientContext);
     callable.call(1);
   }
 
@@ -270,7 +277,8 @@ public class RetryingTest {
     SimpleCallSettings<Integer, Integer> callSettings =
         createSettings(retryable, FAST_RETRY_SETTINGS);
     UnaryCallable<Integer, Integer> callable =
-        callableFactory.create(callInt, callSettings, clientContext);
+        callableFactory.create(
+            translateExceptions(callInt, retryable), callSettings, clientContext);
     // Need to advance time inside the call.
     ApiFuture<Integer> future = callable.futureCall(1);
     Futures.getUnchecked(future);
@@ -291,7 +299,8 @@ public class RetryingTest {
     SimpleCallSettings<Integer, Integer> callSettings =
         createSettings(retryable, FAST_RETRY_SETTINGS);
     UnaryCallable<Integer, Integer> callable =
-        callableFactory.create(callInt, callSettings, clientContext);
+        callableFactory.create(
+            translateExceptions(callInt, retryable), callSettings, clientContext);
     callable.call(1);
     Truth.assertThat(executor.getSleepDurations().size()).isEqualTo(1);
     Truth.assertThat(executor.getSleepDurations().get(0)).isEqualTo(Duration.ofMillis(1));
@@ -325,7 +334,8 @@ public class RetryingTest {
     SimpleCallSettings<Integer, Integer> callSettings =
         SimpleCallSettings.<Integer, Integer>newBuilder().setRetryableCodes(retryable).build();
     UnaryCallable<Integer, Integer> callable =
-        callableFactory.create(callInt, callSettings, clientContext);
+        callableFactory.create(
+            translateExceptions(callInt, retryable), callSettings, clientContext);
     try {
       callable.call(1);
     } catch (FailedPreconditionException exception) {
@@ -343,7 +353,8 @@ public class RetryingTest {
     SimpleCallSettings<Integer, Integer> callSettings =
         SimpleCallSettings.<Integer, Integer>newBuilder().setRetryableCodes(retryable).build();
     UnaryCallable<Integer, Integer> callable =
-        callableFactory.create(callInt, callSettings, clientContext);
+        callableFactory.create(
+            translateExceptions(callInt, retryable), callSettings, clientContext);
     try {
       callable.call(1);
     } catch (UnknownException exception) {
@@ -357,5 +368,10 @@ public class RetryingTest {
         .setRetryableCodes(retryableCodes)
         .setRetrySettings(retrySettings)
         .build();
+  }
+
+  public static <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> translateExceptions(
+      UnaryCallable<RequestT, ResponseT> innerCallable, Set<StatusCode.Code> retryableCodes) {
+    return new HttpJsonExceptionCallable<>(innerCallable, retryableCodes);
   }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.BetaApi;
+import org.threeten.bp.Duration;
 
 /**
  * Context for an API call.
@@ -39,4 +40,7 @@ import com.google.api.core.BetaApi;
  * <p>This is transport specific and each transport has an implementation with its own options.
  */
 @BetaApi
-public interface ApiCallContext {}
+public interface ApiCallContext {
+  /** Returns a new ApiCallContext with the given timeout set. */
+  ApiCallContext withTimeout(Duration rpcTimeout);
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/AttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/AttemptCallable.java
@@ -71,9 +71,7 @@ class AttemptCallable<RequestT, ResponseT> implements Callable<ResponseT> {
   public ResponseT call() {
     try {
       if (callContext != null) {
-        callContext =
-            transportDescriptor.getCallContextWithTimeout(
-                callContext, externalFuture.getAttemptSettings().getRpcTimeout());
+        callContext = callContext.withTimeout(externalFuture.getAttemptSettings().getRpcTimeout());
       }
       externalFuture.setAttemptFuture(new NonCancellableFuture<ResponseT>());
       if (externalFuture.isDone()) {

--- a/gax/src/main/java/com/google/api/gax/rpc/CallableFactory.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/CallableFactory.java
@@ -60,13 +60,10 @@ public class CallableFactory {
   }
 
   private <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createBaseCallable(
-      UnaryCallable<RequestT, ResponseT> directCallable,
+      UnaryCallable<RequestT, ResponseT> callable,
       UnaryCallSettingsTyped<RequestT, ResponseT> callSettings,
       ClientContext clientContext) {
 
-    UnaryCallable<RequestT, ResponseT> callable =
-        new ExceptionCallable<>(
-            transportDescriptor, directCallable, callSettings.getRetryableCodes());
     RetryAlgorithm<ResponseT> retryAlgorithm =
         new RetryAlgorithm<>(
             new ApiResultRetryAlgorithm<ResponseT>(),
@@ -81,18 +78,18 @@ public class CallableFactory {
    * Create a callable object that represents a simple API method. Designed for use by generated
    * code.
    *
-   * @param directCallable the callable that directly issues the call to the underlying API
+   * @param transportCallable the callable that directly issues the call to the underlying API
    * @param simpleCallSettings {@link SimpleCallSettings} to configure the method-level settings
    *     with.
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link UnaryCallable} callable object.
    */
   public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> create(
-      UnaryCallable<RequestT, ResponseT> directCallable,
+      UnaryCallable<RequestT, ResponseT> transportCallable,
       SimpleCallSettings<RequestT, ResponseT> simpleCallSettings,
       ClientContext clientContext) {
     UnaryCallable<RequestT, ResponseT> unaryCallable =
-        createBaseCallable(directCallable, simpleCallSettings, clientContext);
+        createBaseCallable(transportCallable, simpleCallSettings, clientContext);
     return new EntryPointUnaryCallable<>(
         unaryCallable,
         transportDescriptor.createDefaultCallContext(),
@@ -103,18 +100,18 @@ public class CallableFactory {
    * Create a paged callable object that represents a paged API method. Designed for use by
    * generated code.
    *
-   * @param directCallable the callable that directly issues the call to the underlying API
+   * @param transportCallable the callable that directly issues the call to the underlying API
    * @param pagedCallSettings {@link PagedCallSettings} to configure the paged settings with.
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link UnaryCallable} callable object.
    */
   public <RequestT, ResponseT, PagedListResponseT>
       UnaryCallable<RequestT, PagedListResponseT> createPagedVariant(
-          UnaryCallable<RequestT, ResponseT> directCallable,
+          UnaryCallable<RequestT, ResponseT> transportCallable,
           PagedCallSettings<RequestT, ResponseT, PagedListResponseT> pagedCallSettings,
           ClientContext clientContext) {
     UnaryCallable<RequestT, ResponseT> unaryCallable =
-        createBaseCallable(directCallable, pagedCallSettings, clientContext);
+        createBaseCallable(transportCallable, pagedCallSettings, clientContext);
     UnaryCallable<RequestT, PagedListResponseT> pagedCallable =
         new PagedCallable<>(unaryCallable, pagedCallSettings.getPagedListResponseFactory());
     return new EntryPointUnaryCallable<>(
@@ -127,17 +124,17 @@ public class CallableFactory {
    * Create a callable object that represents a simple call to a paged API method. Designed for use
    * by generated code.
    *
-   * @param directCallable the callable that directly issues the call to the underlying API
+   * @param transportCallable the callable that directly issues the call to the underlying API
    * @param pagedCallSettings {@link PagedCallSettings} to configure the method-level settings with.
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link UnaryCallable} callable object.
    */
   public <RequestT, ResponseT, PagedListResponseT> UnaryCallable<RequestT, ResponseT> create(
-      UnaryCallable<RequestT, ResponseT> directCallable,
+      UnaryCallable<RequestT, ResponseT> transportCallable,
       PagedCallSettings<RequestT, ResponseT, PagedListResponseT> pagedCallSettings,
       ClientContext clientContext) {
     UnaryCallable<RequestT, ResponseT> unaryCallable =
-        createBaseCallable(directCallable, pagedCallSettings, clientContext);
+        createBaseCallable(transportCallable, pagedCallSettings, clientContext);
     return new EntryPointUnaryCallable<>(
         unaryCallable,
         transportDescriptor.createDefaultCallContext(),
@@ -148,17 +145,17 @@ public class CallableFactory {
    * Create a callable object that represents a batching API method. Designed for use by generated
    * code.
    *
-   * @param directCallable the callable that directly issues the call to the underlying API
+   * @param transportCallable the callable that directly issues the call to the underlying API
    * @param batchingCallSettings {@link BatchingSettings} to configure the batching related settings
    *     with.
    * @param context {@link ClientContext} to use to connect to the service.
    * @return {@link UnaryCallable} callable object.
    */
   public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> create(
-      UnaryCallable<RequestT, ResponseT> directCallable,
+      UnaryCallable<RequestT, ResponseT> transportCallable,
       BatchingCallSettings<RequestT, ResponseT> batchingCallSettings,
       ClientContext context) {
-    return internalCreate(directCallable, batchingCallSettings, context).unaryCallable;
+    return internalCreate(transportCallable, batchingCallSettings, context).unaryCallable;
   }
 
   /** This only exists to give tests access to batcherFactory for flushing purposes. */
@@ -183,11 +180,11 @@ public class CallableFactory {
   }
 
   <RequestT, ResponseT> BatchingCreateResult<RequestT, ResponseT> internalCreate(
-      UnaryCallable<RequestT, ResponseT> directCallable,
+      UnaryCallable<RequestT, ResponseT> transportCallable,
       BatchingCallSettings<RequestT, ResponseT> batchingCallSettings,
       ClientContext clientContext) {
     UnaryCallable<RequestT, ResponseT> callable =
-        createBaseCallable(directCallable, batchingCallSettings, clientContext);
+        createBaseCallable(transportCallable, batchingCallSettings, clientContext);
     BatcherFactory<RequestT, ResponseT> batcherFactory =
         new BatcherFactory<>(
             batchingCallSettings.getBatchingDescriptor(),
@@ -209,7 +206,7 @@ public class CallableFactory {
    * Creates a callable object that represents a long-running operation. Designed for use by
    * generated code.
    *
-   * @param directCallable the callable that directly issues the call to the underlying API
+   * @param transportCallable the callable that directly issues the call to the underlying API
    * @param operationCallSettings {@link OperationCallSettings} to configure the method-level
    *     settings with.
    * @param clientContext {@link ClientContext} to use to connect to the service.
@@ -217,12 +214,12 @@ public class CallableFactory {
    * @return {@link OperationCallable} callable object.
    */
   public <RequestT, ResponseT, MetadataT> OperationCallable<RequestT, ResponseT, MetadataT> create(
-      UnaryCallable<RequestT, OperationSnapshot> directCallable,
+      UnaryCallable<RequestT, OperationSnapshot> transportCallable,
       OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings,
       ClientContext clientContext,
       LongRunningClient longRunningClient) {
     OperationCallable<RequestT, ResponseT, MetadataT> callableImpl =
-        createImpl(directCallable, operationCallSettings, clientContext, longRunningClient);
+        createImpl(transportCallable, operationCallSettings, clientContext, longRunningClient);
     return new EntryPointOperationCallable<>(
         callableImpl,
         transportDescriptor.createDefaultCallContext(),
@@ -230,14 +227,14 @@ public class CallableFactory {
   }
 
   <RequestT, ResponseT, MetadataT> OperationCallableImpl<RequestT, ResponseT, MetadataT> createImpl(
-      UnaryCallable<RequestT, OperationSnapshot> directCallable,
+      UnaryCallable<RequestT, OperationSnapshot> transportCallable,
       OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings,
       ClientContext clientContext,
       LongRunningClient longRunningClient) {
 
     UnaryCallable<RequestT, OperationSnapshot> initialCallable =
         createBaseCallable(
-            directCallable, operationCallSettings.getInitialCallSettings(), clientContext);
+            transportCallable, operationCallSettings.getInitialCallSettings(), clientContext);
 
     RetryAlgorithm<OperationSnapshot> pollingAlgorithm =
         new RetryAlgorithm<>(
@@ -253,18 +250,18 @@ public class CallableFactory {
    * Create a callable object that represents a bidirectional streaming API method. Designed for use
    * by generated code.
    *
-   * @param directCallable the callable that directly issues the call to the underlying API
+   * @param transportCallable the callable that directly issues the call to the underlying API
    * @param streamingCallSettings {@link StreamingCallSettings} to configure the method-level
    *     settings with.
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link BidiStreamingCallable} callable object.
    */
   public <RequestT, ResponseT> BidiStreamingCallable<RequestT, ResponseT> create(
-      BidiStreamingCallable<RequestT, ResponseT> directCallable,
+      BidiStreamingCallable<RequestT, ResponseT> transportCallable,
       StreamingCallSettings<RequestT, ResponseT> streamingCallSettings,
       ClientContext clientContext) {
     return new EntryPointBidiStreamingCallable<>(
-        directCallable,
+        transportCallable,
         transportDescriptor.createDefaultCallContext(),
         getCallContextEnhancers(clientContext));
   }
@@ -273,18 +270,18 @@ public class CallableFactory {
    * Create a callable object that represents a server streaming API method. Designed for use by
    * generated code.
    *
-   * @param directCallable the callable that directly issues the call to the underlying API
+   * @param transportCallable the callable that directly issues the call to the underlying API
    * @param streamingCallSettings {@link StreamingCallSettings} to configure the method-level
    *     settings with.
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link ServerStreamingCallable} callable object.
    */
   public <RequestT, ResponseT> ServerStreamingCallable<RequestT, ResponseT> create(
-      ServerStreamingCallable<RequestT, ResponseT> directCallable,
+      ServerStreamingCallable<RequestT, ResponseT> transportCallable,
       StreamingCallSettings<RequestT, ResponseT> streamingCallSettings,
       ClientContext clientContext) {
     return new EntryPointServerStreamingCallable<>(
-        directCallable,
+        transportCallable,
         transportDescriptor.createDefaultCallContext(),
         getCallContextEnhancers(clientContext));
   }
@@ -293,18 +290,18 @@ public class CallableFactory {
    * Create a callable object that represents a client streaming API method. Designed for use by
    * generated code.
    *
-   * @param directCallable the callable that directly issues the call to the underlying API
+   * @param transportCallable the callable that directly issues the call to the underlying API
    * @param streamingCallSettings {@link StreamingCallSettings} to configure the method-level
    *     settings with.
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link ClientStreamingCallable} callable object.
    */
   public <RequestT, ResponseT> ClientStreamingCallable<RequestT, ResponseT> create(
-      ClientStreamingCallable<RequestT, ResponseT> directCallable,
+      ClientStreamingCallable<RequestT, ResponseT> transportCallable,
       StreamingCallSettings<RequestT, ResponseT> streamingCallSettings,
       ClientContext clientContext) {
     return new EntryPointClientStreamingCallable<>(
-        directCallable,
+        transportCallable,
         transportDescriptor.createDefaultCallContext(),
         getCallContextEnhancers(clientContext));
   }

--- a/gax/src/main/java/com/google/api/gax/rpc/TransportDescriptor.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/TransportDescriptor.java
@@ -31,7 +31,6 @@ package com.google.api.gax.rpc;
 
 import com.google.api.core.BetaApi;
 import com.google.auth.Credentials;
-import org.threeten.bp.Duration;
 
 /**
  * A TransportDescriptor contains transport-specific logic necessary to build callables and issue
@@ -39,11 +38,6 @@ import org.threeten.bp.Duration;
  */
 @BetaApi
 public abstract class TransportDescriptor {
-
-  public void translateException(TranslateExceptionParameters build) {
-    throw new UnsupportedOperationException(
-        "TransportDescriptor.translateException not implemented");
-  }
 
   public ApiCallContext createDefaultCallContext() {
     throw new UnsupportedOperationException(
@@ -53,11 +47,6 @@ public abstract class TransportDescriptor {
   public ApiCallContext getCallContextWithDefault(ApiCallContext inputContext) {
     throw new UnsupportedOperationException(
         "TransportDescriptor.getCallContextWithDefault not implemented");
-  }
-
-  public ApiCallContext getCallContextWithTimeout(ApiCallContext callContext, Duration rpcTimeout) {
-    throw new UnsupportedOperationException(
-        "TransportDescriptor.getCallContextWithTimeout not implemented");
   }
 
   public ApiCallContextEnhancer getAuthCallContextEnhancer(Credentials credentials) {

--- a/gax/src/test/java/com/google/api/gax/rpc/BatchingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/BatchingCallableTest.java
@@ -34,6 +34,7 @@ import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.batching.FlowController;
 import com.google.api.gax.batching.FlowController.LimitExceededBehavior;
+import com.google.api.gax.rpc.testing.FakeApiCallContext;
 import com.google.api.gax.rpc.testing.FakeBatchableApi;
 import com.google.api.gax.rpc.testing.FakeBatchableApi.LabeledIntList;
 import com.google.api.gax.rpc.testing.FakeBatchableApi.SquarerBatchingDescriptor;
@@ -88,13 +89,13 @@ public class BatchingCallableTest {
 
     LabeledIntList request1 = new LabeledIntList("label", 2);
     ApiFuture<List<Integer>> future1 =
-        batchingCallable.futureCall(request1, new ApiCallContext() {});
+        batchingCallable.futureCall(request1, FakeApiCallContext.of());
     // Assume it won't take 10 seconds (the batching delay threshold) to check the first future
     Truth.assertThat(future1.isDone()).isFalse();
 
     LabeledIntList request2 = new LabeledIntList("label", 3);
     ApiFuture<List<Integer>> future2 =
-        batchingCallable.futureCall(request2, new ApiCallContext() {});
+        batchingCallable.futureCall(request2, FakeApiCallContext.of());
 
     List<Integer> response1 = future1.get();
     List<Integer> response2 = future2.get();
@@ -127,7 +128,7 @@ public class BatchingCallableTest {
 
     LabeledIntList request1 = new LabeledIntList("label", 2);
     ApiFuture<List<Integer>> future1 =
-        batchingCallable.futureCall(request1, new ApiCallContext() {});
+        batchingCallable.futureCall(request1, FakeApiCallContext.of());
     List<Integer> response1 = future1.get();
 
     Truth.assertThat(response1.size()).isEqualTo(1);

--- a/gax/src/test/java/com/google/api/gax/rpc/EntryPointOperationCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/EntryPointOperationCallableTest.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.api.gax.rpc.testing.FakeApiCallContext;
 import com.google.api.gax.rpc.testing.FakeOperationApi.OperationStashCallable;
 import com.google.common.truth.Truth;
 import java.util.Collections;
@@ -43,7 +44,7 @@ public class EntryPointOperationCallableTest {
 
   @Test
   public void call() throws Exception {
-    ApiCallContext defaultCallContext = new ApiCallContext() {};
+    ApiCallContext defaultCallContext = FakeApiCallContext.of();
     OperationStashCallable stashCallable = new OperationStashCallable();
     OperationCallable<Integer, String, Long> callable =
         new EntryPointOperationCallable<>(stashCallable, defaultCallContext);
@@ -58,7 +59,7 @@ public class EntryPointOperationCallableTest {
     ApiCallContext context = Mockito.mock(ApiCallContext.class);
     OperationStashCallable stashCallable = new OperationStashCallable();
     OperationCallable<Integer, String, Long> callable =
-        new EntryPointOperationCallable<>(stashCallable, new ApiCallContext() {});
+        new EntryPointOperationCallable<>(stashCallable, FakeApiCallContext.of());
 
     String response = callable.call(2, context);
     Truth.assertThat(response).isEqualTo("2");
@@ -78,7 +79,7 @@ public class EntryPointOperationCallableTest {
     OperationStashCallable stashCallable = new OperationStashCallable();
     OperationCallable<Integer, String, Long> callable =
         new EntryPointOperationCallable<>(
-            stashCallable, new ApiCallContext() {}, Collections.singletonList(enhancer));
+            stashCallable, FakeApiCallContext.of(), Collections.singletonList(enhancer));
 
     String response = callable.call(3);
     Truth.assertThat(response).isEqualTo("3");
@@ -87,7 +88,7 @@ public class EntryPointOperationCallableTest {
 
   @Test
   public void callResume() throws Exception {
-    ApiCallContext defaultCallContext = new ApiCallContext() {};
+    ApiCallContext defaultCallContext = FakeApiCallContext.of();
     OperationStashCallable stashCallable = new OperationStashCallable();
     OperationCallable<Integer, String, Long> callable =
         new EntryPointOperationCallable<>(stashCallable, defaultCallContext);
@@ -104,7 +105,7 @@ public class EntryPointOperationCallableTest {
     ApiCallContext context = Mockito.mock(ApiCallContext.class);
     OperationStashCallable stashCallable = new OperationStashCallable();
     OperationCallable<Integer, String, Long> callable =
-        new EntryPointOperationCallable<>(stashCallable, new ApiCallContext() {});
+        new EntryPointOperationCallable<>(stashCallable, FakeApiCallContext.of());
 
     OperationFuture<String, Long> operationFuture = callable.futureCall(45);
 
@@ -126,7 +127,7 @@ public class EntryPointOperationCallableTest {
     OperationStashCallable stashCallable = new OperationStashCallable();
     OperationCallable<Integer, String, Long> callable =
         new EntryPointOperationCallable<>(
-            stashCallable, new ApiCallContext() {}, Collections.singletonList(enhancer));
+            stashCallable, FakeApiCallContext.of(), Collections.singletonList(enhancer));
 
     OperationFuture<String, Long> operationFuture = callable.futureCall(45);
 
@@ -137,7 +138,7 @@ public class EntryPointOperationCallableTest {
 
   @Test
   public void callCancel() throws Exception {
-    ApiCallContext defaultCallContext = new ApiCallContext() {};
+    ApiCallContext defaultCallContext = FakeApiCallContext.of();
     OperationStashCallable stashCallable = new OperationStashCallable();
     OperationCallable<Integer, String, Long> callable =
         new EntryPointOperationCallable<>(stashCallable, defaultCallContext);
@@ -154,7 +155,7 @@ public class EntryPointOperationCallableTest {
     ApiCallContext context = Mockito.mock(ApiCallContext.class);
     OperationStashCallable stashCallable = new OperationStashCallable();
     OperationCallable<Integer, String, Long> callable =
-        new EntryPointOperationCallable<>(stashCallable, new ApiCallContext() {});
+        new EntryPointOperationCallable<>(stashCallable, FakeApiCallContext.of());
 
     OperationFuture<String, Long> operationFuture = callable.futureCall(45);
 
@@ -176,7 +177,7 @@ public class EntryPointOperationCallableTest {
     OperationStashCallable stashCallable = new OperationStashCallable();
     OperationCallable<Integer, String, Long> callable =
         new EntryPointOperationCallable<>(
-            stashCallable, new ApiCallContext() {}, Collections.singletonList(enhancer));
+            stashCallable, FakeApiCallContext.of(), Collections.singletonList(enhancer));
 
     OperationFuture<String, Long> operationFuture = callable.futureCall(45);
 

--- a/gax/src/test/java/com/google/api/gax/rpc/EntryPointStreamingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/EntryPointStreamingCallableTest.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.rpc;
 
+import com.google.api.gax.rpc.testing.FakeApiCallContext;
 import com.google.api.gax.rpc.testing.FakeStreamingApi.BidiStreamingStashCallable;
 import com.google.api.gax.rpc.testing.FakeStreamingApi.ClientStreamingStashCallable;
 import com.google.api.gax.rpc.testing.FakeStreamingApi.ServerStreamingStashCallable;
@@ -44,7 +45,7 @@ public class EntryPointStreamingCallableTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testBidiStreamingCall() {
-    ApiCallContext defaultCallContext = new ApiCallContext() {};
+    ApiCallContext defaultCallContext = FakeApiCallContext.of();
     BidiStreamingStashCallable<Integer, Integer> stashCallable = new BidiStreamingStashCallable<>();
     BidiStreamingCallable<Integer, Integer> callable =
         new EntryPointBidiStreamingCallable<>(stashCallable, defaultCallContext);
@@ -60,7 +61,7 @@ public class EntryPointStreamingCallableTest {
     ApiCallContext context = Mockito.mock(ApiCallContext.class);
     BidiStreamingStashCallable<Integer, Integer> stashCallable = new BidiStreamingStashCallable<>();
     BidiStreamingCallable<Integer, Integer> callable =
-        new EntryPointBidiStreamingCallable<>(stashCallable, new ApiCallContext() {});
+        new EntryPointBidiStreamingCallable<>(stashCallable, FakeApiCallContext.of());
     ApiStreamObserver<Integer> observer = Mockito.mock(ApiStreamObserver.class);
     callable.bidiStreamingCall(observer, context);
     Truth.assertThat(stashCallable.getActualObserver()).isSameAs(observer);
@@ -81,7 +82,7 @@ public class EntryPointStreamingCallableTest {
     BidiStreamingStashCallable<Integer, Integer> stashCallable = new BidiStreamingStashCallable<>();
     BidiStreamingCallable<Integer, Integer> callable =
         new EntryPointBidiStreamingCallable<>(
-            stashCallable, new ApiCallContext() {}, Collections.singletonList(enhancer));
+            stashCallable, FakeApiCallContext.of(), Collections.singletonList(enhancer));
     ApiStreamObserver<Integer> observer = Mockito.mock(ApiStreamObserver.class);
     callable.bidiStreamingCall(observer);
     Truth.assertThat(stashCallable.getActualObserver()).isSameAs(observer);
@@ -91,7 +92,7 @@ public class EntryPointStreamingCallableTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testClientStreamingCall() {
-    ApiCallContext defaultCallContext = new ApiCallContext() {};
+    ApiCallContext defaultCallContext = FakeApiCallContext.of();
     ClientStreamingStashCallable<Integer, Integer> stashCallable =
         new ClientStreamingStashCallable<>();
     ApiStreamObserver<Integer> observer = Mockito.mock(ApiStreamObserver.class);
@@ -110,7 +111,7 @@ public class EntryPointStreamingCallableTest {
         new ClientStreamingStashCallable<>();
     ApiStreamObserver<Integer> observer = Mockito.mock(ApiStreamObserver.class);
     ClientStreamingCallable<Integer, Integer> callable =
-        new EntryPointClientStreamingCallable<>(stashCallable, new ApiCallContext() {});
+        new EntryPointClientStreamingCallable<>(stashCallable, FakeApiCallContext.of());
     callable.clientStreamingCall(observer, context);
     Truth.assertThat(stashCallable.getActualObserver()).isSameAs(observer);
     Truth.assertThat(stashCallable.getContext()).isSameAs(context);
@@ -131,7 +132,7 @@ public class EntryPointStreamingCallableTest {
         new ClientStreamingStashCallable<>();
     ClientStreamingCallable<Integer, Integer> callable =
         new EntryPointClientStreamingCallable<>(
-            stashCallable, new ApiCallContext() {}, Collections.singletonList(enhancer));
+            stashCallable, FakeApiCallContext.of(), Collections.singletonList(enhancer));
     ApiStreamObserver<Integer> observer = Mockito.mock(ApiStreamObserver.class);
     callable.clientStreamingCall(observer);
     Truth.assertThat(stashCallable.getActualObserver()).isSameAs(observer);
@@ -141,7 +142,7 @@ public class EntryPointStreamingCallableTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testServerStreamingCall() {
-    ApiCallContext defaultCallContext = new ApiCallContext() {};
+    ApiCallContext defaultCallContext = FakeApiCallContext.of();
     ServerStreamingStashCallable<Integer, Integer> stashCallable =
         new ServerStreamingStashCallable<>();
     ServerStreamingCallable<Integer, Integer> callable =
@@ -161,7 +162,7 @@ public class EntryPointStreamingCallableTest {
     ServerStreamingStashCallable<Integer, Integer> stashCallable =
         new ServerStreamingStashCallable<>();
     ServerStreamingCallable<Integer, Integer> callable =
-        new EntryPointServerStreamingCallable<>(stashCallable, new ApiCallContext() {});
+        new EntryPointServerStreamingCallable<>(stashCallable, FakeApiCallContext.of());
     ApiStreamObserver<Integer> observer = Mockito.mock(ApiStreamObserver.class);
     Integer request = 1;
     callable.serverStreamingCall(request, observer, context);
@@ -185,7 +186,7 @@ public class EntryPointStreamingCallableTest {
         new ServerStreamingStashCallable<>();
     ServerStreamingCallable<Integer, Integer> callable =
         new EntryPointServerStreamingCallable<>(
-            stashCallable, new ApiCallContext() {}, Collections.singletonList(enhancer));
+            stashCallable, FakeApiCallContext.of(), Collections.singletonList(enhancer));
     ApiStreamObserver<Integer> observer = Mockito.mock(ApiStreamObserver.class);
     Integer request = 1;
     callable.serverStreamingCall(request, observer);
@@ -197,7 +198,7 @@ public class EntryPointStreamingCallableTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testIteratedServerStreamingCall() {
-    ApiCallContext defaultCallContext = new ApiCallContext() {};
+    ApiCallContext defaultCallContext = FakeApiCallContext.of();
     ServerStreamingStashCallable<Integer, Integer> stashCallable =
         new ServerStreamingStashCallable<>();
     ServerStreamingCallable<Integer, Integer> callable =
@@ -215,7 +216,7 @@ public class EntryPointStreamingCallableTest {
     ServerStreamingStashCallable<Integer, Integer> stashCallable =
         new ServerStreamingStashCallable<>();
     ServerStreamingCallable<Integer, Integer> callable =
-        new EntryPointServerStreamingCallable<>(stashCallable, new ApiCallContext() {});
+        new EntryPointServerStreamingCallable<>(stashCallable, FakeApiCallContext.of());
     Integer request = 1;
     callable.blockingServerStreamingCall(request, context);
     Truth.assertThat(stashCallable.getActualRequest()).isSameAs(request);
@@ -237,7 +238,7 @@ public class EntryPointStreamingCallableTest {
         new ServerStreamingStashCallable<>();
     ServerStreamingCallable<Integer, Integer> callable =
         new EntryPointServerStreamingCallable<>(
-            stashCallable, new ApiCallContext() {}, Collections.singletonList(enhancer));
+            stashCallable, FakeApiCallContext.of(), Collections.singletonList(enhancer));
     Integer request = 1;
     callable.blockingServerStreamingCall(request);
     Truth.assertThat(stashCallable.getActualRequest()).isSameAs(request);

--- a/gax/src/test/java/com/google/api/gax/rpc/EntryPointUnaryCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/EntryPointUnaryCallableTest.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.rpc;
 
+import com.google.api.gax.rpc.testing.FakeApiCallContext;
 import com.google.api.gax.rpc.testing.FakeSimpleApi.StashCallable;
 import com.google.common.truth.Truth;
 import java.util.Collections;
@@ -42,7 +43,7 @@ public class EntryPointUnaryCallableTest {
 
   @Test
   public void call() throws Exception {
-    ApiCallContext defaultCallContext = new ApiCallContext() {};
+    ApiCallContext defaultCallContext = FakeApiCallContext.of();
     StashCallable<Integer, Integer> stashCallable = new StashCallable<>(1);
     UnaryCallable<Integer, Integer> callable =
         new EntryPointUnaryCallable<>(stashCallable, defaultCallContext);
@@ -58,7 +59,7 @@ public class EntryPointUnaryCallableTest {
     ApiCallContext context = Mockito.mock(ApiCallContext.class);
     StashCallable<Integer, Integer> stashCallable = new StashCallable<>(1);
     UnaryCallable<Integer, Integer> callable =
-        new EntryPointUnaryCallable<>(stashCallable, new ApiCallContext() {});
+        new EntryPointUnaryCallable<>(stashCallable, FakeApiCallContext.of());
 
     Integer response = callable.call(2, context);
     Truth.assertThat(response).isEqualTo(Integer.valueOf(1));
@@ -78,7 +79,7 @@ public class EntryPointUnaryCallableTest {
     StashCallable<Integer, Integer> stashCallable = new StashCallable<>(1);
     UnaryCallable<Integer, Integer> callable =
         new EntryPointUnaryCallable<>(
-            stashCallable, new ApiCallContext() {}, Collections.singletonList(enhancer));
+            stashCallable, FakeApiCallContext.of(), Collections.singletonList(enhancer));
 
     Integer response = callable.call(2);
     Truth.assertThat(response).isEqualTo(Integer.valueOf(1));

--- a/gax/src/test/java/com/google/api/gax/rpc/PagedCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/PagedCallableTest.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.rpc;
 
+import com.google.api.gax.rpc.testing.FakeApiCallContext;
 import com.google.api.gax.rpc.testing.FakePagedApi.ListIntegersPagedResponse;
 import com.google.api.gax.rpc.testing.FakePagedApi.ListIntegersPagedResponseFactory;
 import com.google.api.gax.rpc.testing.FakePagedApi.PagedStashCallable;
@@ -54,7 +55,7 @@ public class PagedCallableTest {
         new PagedCallable<>(callable, new ListIntegersPagedResponseFactory());
 
     Truth.assertThat(
-            ImmutableList.copyOf(pagedCallable.call(0, new ApiCallContext() {}).iterateAll()))
+            ImmutableList.copyOf(pagedCallable.call(0, FakeApiCallContext.of()).iterateAll()))
         .containsExactly(0, 1, 2, 3, 4)
         .inOrder();
   }

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeApiCallContext.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeApiCallContext.java
@@ -32,6 +32,7 @@ package com.google.api.gax.rpc.testing;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.auth.Credentials;
+import org.threeten.bp.Duration;
 
 @InternalApi("for testing")
 public class FakeApiCallContext implements ApiCallContext {
@@ -60,6 +61,11 @@ public class FakeApiCallContext implements ApiCallContext {
       fakeCallContext = (FakeApiCallContext) inputContext;
     }
     return fakeCallContext;
+  }
+
+  @Override
+  public ApiCallContext withTimeout(Duration rpcTimeout) {
+    return this;
   }
 
   public Credentials getCredentials() {

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeExceptionCallable.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeExceptionCallable.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc.testing;
+
+import com.google.api.core.AbstractApiFuture;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.ApiExceptionFactory;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+
+/**
+ * Transforms all {@code Throwable}s thrown during a call into an instance of {@link ApiException}.
+ *
+ * <p>Package-private for internal use.
+ */
+class FakeExceptionCallable<RequestT, ResponseT> extends UnaryCallable<RequestT, ResponseT> {
+  private final UnaryCallable<RequestT, ResponseT> callable;
+  private final ImmutableSet<Code> retryableCodes;
+
+  FakeExceptionCallable(UnaryCallable<RequestT, ResponseT> callable, Set<Code> retryableCodes) {
+    this.callable = Preconditions.checkNotNull(callable);
+    this.retryableCodes = ImmutableSet.copyOf(retryableCodes);
+  }
+
+  @Override
+  public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext inputContext) {
+    FakeApiCallContext context =
+        FakeApiCallContext.getAsFakeApiCallContextWithDefault(inputContext);
+    ApiFuture<ResponseT> innerCallFuture = callable.futureCall(request, context);
+    ExceptionTransformingFuture transformingFuture =
+        new ExceptionTransformingFuture(innerCallFuture);
+    ApiFutures.addCallback(innerCallFuture, transformingFuture);
+    return transformingFuture;
+  }
+
+  private class ExceptionTransformingFuture extends AbstractApiFuture<ResponseT>
+      implements ApiFutureCallback<ResponseT> {
+    private ApiFuture<ResponseT> innerCallFuture;
+    private volatile boolean cancelled = false;
+
+    public ExceptionTransformingFuture(ApiFuture<ResponseT> innerCallFuture) {
+      this.innerCallFuture = innerCallFuture;
+    }
+
+    @Override
+    protected void interruptTask() {
+      cancelled = true;
+      innerCallFuture.cancel(true);
+    }
+
+    @Override
+    public void onSuccess(ResponseT r) {
+      super.set(r);
+    }
+
+    @Override
+    public void onFailure(Throwable throwable) {
+      StatusCode.Code statusCode = StatusCode.Code.UNKNOWN;
+      boolean canRetry = false;
+      boolean rethrow = false;
+      if (throwable instanceof FakeStatusException) {
+        FakeStatusException e = (FakeStatusException) throwable;
+        statusCode = e.getStatusCode().getCode();
+        canRetry = retryableCodes.contains(e.getStatusCode().getCode());
+      } else if (throwable instanceof CancellationException && cancelled) {
+        // this just circled around, so ignore.
+        return;
+      } else if (throwable instanceof ApiException) {
+        rethrow = true;
+      } else {
+        // Do not retry on unknown throwable, even when UNKNOWN is in retryableCodes
+        statusCode = StatusCode.Code.UNKNOWN;
+        canRetry = false;
+      }
+      if (rethrow) {
+        super.setException(throwable);
+      } else {
+        super.setException(
+            ApiExceptionFactory.createException(
+                throwable, FakeStatusCode.of(statusCode), canRetry));
+      }
+    }
+  }
+}


### PR DESCRIPTION
* timeout calculation is moved into ApiCallContext
* exception translation is moved back to transport-specific code
* introducing a GrpcCallSettings concept, which is passed into GrpcCallableFactory (we can add header processing config to this)
* Moving off of deprecated MethodDescriptor.create() method in grpc
