### PR TITLE
ApiFuture classes: overriding set/setException

### DIFF
--- a/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
@@ -196,13 +196,13 @@ class BasicRetryingFuture<ResponseT> extends AbstractFuture<ResponseT>
         latestCompletedAttemptResult = ApiFutures.immediateFailedFuture(throwable);
         attemptResult = shouldRetry ? null : latestCompletedAttemptResult;
         if (prevAttemptResult instanceof NonCancellableFuture) {
-          ((NonCancellableFuture<ResponseT>) prevAttemptResult).setException(throwable);
+          ((NonCancellableFuture<ResponseT>) prevAttemptResult).setExceptionPrivately(throwable);
         }
       } else {
         latestCompletedAttemptResult = ApiFutures.immediateFuture(response);
         attemptResult = shouldRetry ? null : latestCompletedAttemptResult;
         if (prevAttemptResult instanceof NonCancellableFuture) {
-          ((NonCancellableFuture<ResponseT>) prevAttemptResult).set(response);
+          ((NonCancellableFuture<ResponseT>) prevAttemptResult).setPrivately(response);
         }
       }
     } catch (Exception e) {

--- a/gax/src/main/java/com/google/api/gax/retrying/NonCancellableFuture.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/NonCancellableFuture.java
@@ -48,17 +48,33 @@ public final class NonCancellableFuture<ResponseT> extends AbstractApiFuture<Res
     return false;
   }
 
+  /**
+   * Note: Once AbstractApiFuture.set(ResponseT) is updated from public to protected, this should be
+   * removed.
+   */
+  @Override
+  public boolean set(ResponseT value) {
+    return false;
+  }
+
+  /**
+   * Note: Once AbstractApiFuture.set(ResponseT) is updated from public to protected, this should be
+   * removed.
+   */
+  @Override
+  public boolean setException(Throwable throwable) {
+    return false;
+  }
+
   void cancelPrivately() {
     super.cancel(false);
   }
 
-  @Override
-  public boolean set(ResponseT value) {
+  boolean setPrivately(ResponseT value) {
     return super.set(value);
   }
 
-  @Override
-  public boolean setException(Throwable throwable) {
+  boolean setExceptionPrivately(Throwable throwable) {
     return super.setException(throwable);
   }
 }

--- a/gax/src/main/java/com/google/api/gax/retrying/NonCancellableFuture.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/NonCancellableFuture.java
@@ -51,4 +51,14 @@ public final class NonCancellableFuture<ResponseT> extends AbstractApiFuture<Res
   void cancelPrivately() {
     super.cancel(false);
   }
+
+  @Override
+  public boolean set(ResponseT value) {
+    return super.set(value);
+  }
+
+  @Override
+  public boolean setException(Throwable throwable) {
+    return super.setException(throwable);
+  }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/BatchedFuture.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/BatchedFuture.java
@@ -44,4 +44,14 @@ public class BatchedFuture<ResponseT> extends AbstractApiFuture<ResponseT> {
   public static <T> BatchedFuture<T> create() {
     return new BatchedFuture<>();
   }
+
+  @Override
+  public boolean set(ResponseT value) {
+    return super.set(value);
+  }
+
+  @Override
+  public boolean setException(Throwable throwable) {
+    return super.setException(throwable);
+  }
 }


### PR DESCRIPTION
This is to make gax forward compatible with a future release of
api-common which makes the parent methods protected.