### PR TITLE
Stability annotation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,36 @@ additional qualifications:
    public for technical reasons, because of the limitations of Java's access
    modifiers. For the purposes of semver, they should be considered private.
 
-It is currently in major version zero (``0.y.z``), which means that anything
-may change at any time and the public API should not be considered
-stable.
+1. Components marked with `@InternalExtensionOnly` are stable for usage, but
+   not for extension. Thus, methods will not be removed from interfaces marked
+   with this annotation, but methods can be added, thus breaking any
+   code implementing the interface. See the javadocs for more details on other
+   consequences of this annotation.
+
+### Submodule notes
+
+- `gax` is stable (> 1.0.0), so anything not marked `@BetaApi`, `@InternalApi`,
+or `@InternalExtensionOnly` won't break between minor releases. Anything marked
+`@InternalExtensionOnly` can only break extensions between minor releases.
+- `gax-grpc` is beta (0.x.y), so anything may change at any time and the public
+API should not be considered stable. There is no difference whether a class is
+marked `@BetaApi` or not; that annotation is only present as a reminder. There is
+also no difference whether a class is marked `@InternalExtensionOnly` or not; that
+only implies that the annotation will still be present in 1.0.0.
+- `gax-httpjson` is beta (0.x.y), so anything may change at any time and the public
+API should not be considered stable. There is no difference whether a class is
+marked `@BetaApi` or not; that annotation is only present as a reminder. There is
+also no difference whether a class is marked `@InternalExtensionOnly` or not; that
+only implies that the annotation will still be present in 1.0.0.
+
+### Feature notes
+
+- **Long Running Operations** - This feature is not yet considered stable.
+- **Streaming** - Streaming features are not yet considered stable.
+- **Batching** - Batching features are not yet considered stable.
+- **Generated Code Support** - Features to support generated code is not yet
+  considered stable.
+- **Testing** - There are no plans to consider any code in the testlib jar to be stable.
 
 Repository Structure
 --------------------

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GaxGrpcProperties.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GaxGrpcProperties.java
@@ -29,12 +29,12 @@
  */
 package com.google.api.gax.grpc;
 
-import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
 import com.google.api.gax.core.PropertiesProvider;
 import java.util.Properties;
 
 /** Provides properties of the GAX-GRPC library. */
-@BetaApi
+@InternalApi
 public class GaxGrpcProperties {
   private static final Properties gaxProperties = new Properties();
   private static final String GAX_PROPERTY_FILE = "/com/google/api/gax/grpc/project.properties";

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.grpc;
 
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.auth.Credentials;
@@ -52,6 +53,7 @@ import org.threeten.bp.Duration;
  * and thread safety of the arguments solely depends on the arguments themselves.
  */
 @BetaApi("Reference ApiCallContext instead - this class is likely to experience breaking changes")
+@InternalExtensionOnly
 public final class GrpcCallContext implements ApiCallContext {
   private final Channel channel;
   private final CallOptions callOptions;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallSettings.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallSettings.java
@@ -34,7 +34,7 @@ import com.google.api.gax.rpc.RequestParamsExtractor;
 import io.grpc.MethodDescriptor;
 
 /** Grpc-specific settings for creating callables. */
-@BetaApi
+@BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
 public class GrpcCallSettings<RequestT, ResponseT> {
   private final MethodDescriptor<RequestT, ResponseT> methodDescriptor;
   private final RequestParamsExtractor<RequestT> paramsExtractor;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -48,7 +48,7 @@ import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 
 /** Class with utility methods to create grpc-based direct callables. */
-@BetaApi
+@BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
 public class GrpcCallableFactory {
   private GrpcCallableFactory() {}
 
@@ -112,6 +112,7 @@ public class GrpcCallableFactory {
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link UnaryCallable} callable object.
    */
+  @BetaApi("The surface for batching is not stable yet and may change in the future.")
   public static <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createBatchingCallable(
       GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
       BatchingCallSettings<RequestT, ResponseT> batchingCallSettings,
@@ -133,6 +134,8 @@ public class GrpcCallableFactory {
    * @param operationsStub {@link OperationsStub} to use to poll for updates on the Operation.
    * @return {@link com.google.api.gax.rpc.OperationCallable} callable object.
    */
+  @BetaApi(
+      "The surface for long-running operations is not stable yet and may change in the future.")
   public static <RequestT, ResponseT, MetadataT>
       OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
           GrpcCallSettings<RequestT, Operation> grpcCallSettings,
@@ -161,7 +164,7 @@ public class GrpcCallableFactory {
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link BidiStreamingCallable} callable object.
    */
-  @BetaApi
+  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   public static <RequestT, ResponseT>
       BidiStreamingCallable<RequestT, ResponseT> createBidiStreamingCallable(
           GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
@@ -181,7 +184,7 @@ public class GrpcCallableFactory {
    *     settings with.
    * @param clientContext {@link ClientContext} to use to connect to the service.
    */
-  @BetaApi
+  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   public static <RequestT, ResponseT>
       ServerStreamingCallable<RequestT, ResponseT> createServerStreamingCallable(
           GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
@@ -207,7 +210,7 @@ public class GrpcCallableFactory {
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link ClientStreamingCallable} callable object.
    */
-  @BetaApi
+  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   public static <RequestT, ResponseT>
       ClientStreamingCallable<RequestT, ResponseT> createClientStreamingCallable(
           GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcStatusCode.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcStatusCode.java
@@ -29,14 +29,14 @@
  */
 package com.google.api.gax.grpc;
 
-import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.common.base.Preconditions;
 import io.grpc.Status;
 import java.util.Objects;
 
 /** A failure code specific to a gRPC call. */
-@BetaApi
+@InternalExtensionOnly
 public class GrpcStatusCode implements StatusCode {
   private final Status.Code grpcCode;
   private final StatusCode.Code statusCode;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcTransportChannel.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcTransportChannel.java
@@ -29,7 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
-import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.auto.value.AutoValue;
 import io.grpc.Channel;
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 
 /** Implementation of TransportChannel based on gRPC. */
 @AutoValue
-@BetaApi
+@InternalExtensionOnly
 public abstract class GrpcTransportChannel implements TransportChannel {
 
   /** The name of the Grpc transport. */

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.grpc;
 
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.core.FixedExecutorProvider;
 import com.google.api.gax.rpc.FixedHeaderProvider;
@@ -59,7 +60,7 @@ import org.threeten.bp.Duration;
  * <p>The client lib header and generator header values are used to form a value that goes into the
  * http header of requests to the service.
  */
-@BetaApi
+@InternalExtensionOnly
 public final class InstantiatingGrpcChannelProvider implements TransportChannelProvider {
   private final ExecutorProvider executorProvider;
   private final HeaderProvider headerProvider;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ProtoOperationTransformers.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ProtoOperationTransformers.java
@@ -39,7 +39,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 
 /** Public for technical reasons; intended for use by generated code. */
-@BetaApi
+@BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
 public class ProtoOperationTransformers {
   private ProtoOperationTransformers() {}
 

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/MockOperationsEx.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/MockOperationsEx.java
@@ -29,13 +29,14 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.grpc.testing.MockGrpcService;
 import com.google.protobuf.GeneratedMessageV3;
 import io.grpc.ServerServiceDefinition;
 import java.util.List;
 
 /** A MockGrpcService for OperationsApi which uses MockOperationsExImpl. */
-@javax.annotation.Generated("by GAPIC")
+@BetaApi
 public class MockOperationsEx implements MockGrpcService {
   private final MockOperationsExImpl serviceImpl;
 

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/MockOperationsExImpl.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/MockOperationsExImpl.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.core.BetaApi;
 import com.google.longrunning.CancelOperationRequest;
 import com.google.longrunning.DeleteOperationRequest;
 import com.google.longrunning.GetOperationRequest;
@@ -45,7 +46,7 @@ import java.util.List;
 import java.util.Queue;
 
 /** A custom mock Operations service implementation which only mocks responses for GetOperation. */
-@javax.annotation.Generated("by GAPIC")
+@BetaApi
 public class MockOperationsExImpl extends OperationsImplBase {
   private ArrayList<GeneratedMessageV3> requests;
   private Queue<Object> getOperationResponses;

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/testing/LocalChannelProvider.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/testing/LocalChannelProvider.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc.testing;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.api.gax.rpc.TransportChannelProvider;
@@ -43,6 +44,7 @@ import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 
 /** LocalChannelProvider creates channels for in-memory gRPC services. */
+@BetaApi
 public class LocalChannelProvider implements TransportChannelProvider {
   private final SocketAddress address;
 

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.httpjson;
 
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.auth.Credentials;
@@ -47,6 +48,7 @@ import org.threeten.bp.Instant;
  * arguments solely depends on the arguments themselves.
  */
 @BetaApi
+@InternalExtensionOnly
 public final class HttpJsonCallContext implements ApiCallContext {
   private final HttpJsonChannel channel;
   private final Instant deadline;

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStatusCode.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStatusCode.java
@@ -30,12 +30,14 @@
 package com.google.api.gax.httpjson;
 
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.common.base.Strings;
 import java.util.Objects;
 
 /** A failure code specific to an HTTP call. */
 @BetaApi
+@InternalExtensionOnly
 public class HttpJsonStatusCode implements StatusCode {
   static final String FAILED_PRECONDITION = "FAILED_PRECONDITION";
   static final String OUT_OF_RANGE = "OUT_OF_RANGE";

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonTransportChannel.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonTransportChannel.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.httpjson;
 
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.auto.value.AutoValue;
 import java.util.concurrent.TimeUnit;
@@ -37,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 /** Implementation of TransportChannel based on http/json. */
 @AutoValue
 @BetaApi
+@InternalExtensionOnly
 public abstract class HttpJsonTransportChannel implements TransportChannel {
 
   /** The name of the Http-JSON transport. */

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/InstantiatingHttpJsonChannelProvider.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/InstantiatingHttpJsonChannelProvider.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.httpjson;
 
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.core.FixedExecutorProvider;
 import com.google.api.gax.rpc.FixedHeaderProvider;
@@ -55,6 +56,7 @@ import java.util.concurrent.ScheduledExecutorService;
  * http header of requests to the service.
  */
 @BetaApi
+@InternalExtensionOnly
 public final class InstantiatingHttpJsonChannelProvider implements TransportChannelProvider {
   private final ExecutorProvider executorProvider;
   private final HeaderProvider headerProvider;

--- a/gax/src/main/java/com/google/api/gax/batching/AccumulatingBatchReceiver.java
+++ b/gax/src/main/java/com/google/api/gax/batching/AccumulatingBatchReceiver.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /** A simple ThresholdBatchReceiver that just accumulates batches. Not thread-safe. */
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public final class AccumulatingBatchReceiver<T> implements ThresholdBatchReceiver<T> {
   private final List<T> batches = new ArrayList<>();
 

--- a/gax/src/main/java/com/google/api/gax/batching/BatchMerger.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchMerger.java
@@ -31,7 +31,7 @@ package com.google.api.gax.batching;
 
 import com.google.api.core.BetaApi;
 
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public interface BatchMerger<B> {
   void merge(B batch, B newBatch);
 }

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingFlowController.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingFlowController.java
@@ -35,7 +35,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
 
 /** Wraps a {@link FlowController} for use by batching. */
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public class BatchingFlowController<T> {
 
   private final FlowController flowController;

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingSettings.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingSettings.java
@@ -87,7 +87,7 @@ import org.threeten.bp.Duration;
  * can occur if messages are created and added to batching faster than they can be processed. The
  * flow control behavior is controlled using FlowControlSettings.
  */
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 @AutoValue
 public abstract class BatchingSettings {
   /** Get the element count threshold to use for batching. */

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingThreshold.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingThreshold.java
@@ -35,7 +35,7 @@ import com.google.api.core.BetaApi;
  * The interface representing a threshold to be used in ThresholdBatcher. Thresholds do not need to
  * be thread-safe if they are only used inside ThresholdBatcher.
  */
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public interface BatchingThreshold<E> {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingThresholds.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingThresholds.java
@@ -34,7 +34,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 /** Factory methods for general-purpose batching thresholds. */
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public final class BatchingThresholds {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/batching/ElementCounter.java
+++ b/gax/src/main/java/com/google/api/gax/batching/ElementCounter.java
@@ -35,7 +35,7 @@ import com.google.api.core.BetaApi;
  * Interface representing an object that provides a numerical count given an object of the
  * parameterized type.
  */
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public interface ElementCounter<E> {
   /** Provides the numerical count associated with the given object. */
   public long count(E element);

--- a/gax/src/main/java/com/google/api/gax/batching/FlowControlSettings.java
+++ b/gax/src/main/java/com/google/api/gax/batching/FlowControlSettings.java
@@ -37,7 +37,7 @@ import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
 
 /** Settings for {@link FlowController}. */
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 @AutoValue
 public abstract class FlowControlSettings {
   public static FlowControlSettings getDefaultInstance() {

--- a/gax/src/main/java/com/google/api/gax/batching/FlowController.java
+++ b/gax/src/main/java/com/google/api/gax/batching/FlowController.java
@@ -34,7 +34,7 @@ import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
 
 /** Provides flow control capability. */
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public class FlowController {
   /** Base exception that signals a flow control state. */
   public abstract static class FlowControlException extends Exception {

--- a/gax/src/main/java/com/google/api/gax/batching/NumericThreshold.java
+++ b/gax/src/main/java/com/google/api/gax/batching/NumericThreshold.java
@@ -33,7 +33,7 @@ import com.google.api.core.BetaApi;
 import com.google.common.base.Preconditions;
 
 /** A threshold which accumulates a count based on the provided ElementCounter. */
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public final class NumericThreshold<E> implements BatchingThreshold<E> {
   private final long threshold;
   private final ElementCounter<E> extractor;

--- a/gax/src/main/java/com/google/api/gax/batching/PartitionKey.java
+++ b/gax/src/main/java/com/google/api/gax/batching/PartitionKey.java
@@ -33,7 +33,7 @@ package com.google.api.gax.batching;
 import com.google.api.core.BetaApi;
 import com.google.common.collect.ImmutableList;
 
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public final class PartitionKey {
   private final ImmutableList<Object> keys;
   private final int hash;

--- a/gax/src/main/java/com/google/api/gax/batching/RequestBuilder.java
+++ b/gax/src/main/java/com/google/api/gax/batching/RequestBuilder.java
@@ -31,7 +31,7 @@ package com.google.api.gax.batching;
 
 import com.google.api.core.BetaApi;
 
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public interface RequestBuilder<RequestT> {
   void appendRequest(RequestT request);
 

--- a/gax/src/main/java/com/google/api/gax/batching/ThresholdBatchReceiver.java
+++ b/gax/src/main/java/com/google/api/gax/batching/ThresholdBatchReceiver.java
@@ -36,7 +36,7 @@ import com.google.api.core.BetaApi;
  * Interface representing an object that receives batches from a ThresholdBatcher and takes action
  * on them. Implementations of ThresholdBatchReceiver should be thread-safe.
  */
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public interface ThresholdBatchReceiver<BatchT> {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/batching/ThresholdBatcher.java
+++ b/gax/src/main/java/com/google/api/gax/batching/ThresholdBatcher.java
@@ -48,7 +48,7 @@ import org.threeten.bp.Duration;
  * Queues up elements until either a duration of time has passed or any threshold in a given set of
  * thresholds is breached, and then delivers the elements in a batch to the consumer.
  */
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public final class ThresholdBatcher<E> {
 
   private class ReleaseResourcesFunction<T> implements ApiFunction<T, Void> {

--- a/gax/src/main/java/com/google/api/gax/core/BackgroundResource.java
+++ b/gax/src/main/java/com/google/api/gax/core/BackgroundResource.java
@@ -29,14 +29,12 @@
  */
 package com.google.api.gax.core;
 
-import com.google.api.core.BetaApi;
 import java.util.concurrent.TimeUnit;
 
 /**
  * Represents a resource running in the background that needs to be shut down for resources to be
  * released.
  */
-@BetaApi
 public interface BackgroundResource extends AutoCloseable {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/core/BackgroundResourceAggregation.java
+++ b/gax/src/main/java/com/google/api/gax/core/BackgroundResourceAggregation.java
@@ -29,12 +29,10 @@
  */
 package com.google.api.gax.core;
 
-import com.google.api.core.BetaApi;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /** Treats a collection of background resources as a single background resource. */
-@BetaApi
 public class BackgroundResourceAggregation implements BackgroundResource {
 
   private final List<BackgroundResource> resources;

--- a/gax/src/main/java/com/google/api/gax/core/BaseBackgroundResource.java
+++ b/gax/src/main/java/com/google/api/gax/core/BaseBackgroundResource.java
@@ -29,11 +29,9 @@
  */
 package com.google.api.gax.core;
 
-import com.google.api.core.BetaApi;
 import java.util.concurrent.TimeUnit;
 
 /** A Background resource that does nothing. */
-@BetaApi
 public class BaseBackgroundResource implements BackgroundResource {
 
   @Override

--- a/gax/src/main/java/com/google/api/gax/core/CredentialsProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/CredentialsProvider.java
@@ -29,14 +29,12 @@
  */
 package com.google.api.gax.core;
 
-import com.google.api.core.BetaApi;
 import com.google.auth.Credentials;
 import java.io.IOException;
 
 /**
  * Provides an interface to hold and acquire the credentials that will be used to call the service.
  */
-@BetaApi
 public interface CredentialsProvider {
   /**
    * Gets the credentials which will be used to call the service. If the credentials have not been

--- a/gax/src/main/java/com/google/api/gax/core/ExecutorAsBackgroundResource.java
+++ b/gax/src/main/java/com/google/api/gax/core/ExecutorAsBackgroundResource.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.core;
 
-import com.google.api.core.BetaApi;
 import com.google.common.base.Preconditions;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -38,7 +37,6 @@ import java.util.concurrent.TimeUnit;
  * ExecutorAsBackgroundResource wraps an {@link ExecutorService} so that it can be used as a {@link
  * BackgroundResource}.
  */
-@BetaApi
 public class ExecutorAsBackgroundResource implements BackgroundResource {
 
   private final ExecutorService executor;

--- a/gax/src/main/java/com/google/api/gax/core/ExecutorProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/ExecutorProvider.java
@@ -29,14 +29,12 @@
  */
 package com.google.api.gax.core;
 
-import com.google.api.core.BetaApi;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Provides an interface to either build a ScheduledExecutorService or provide a fixed
  * ScheduledExecutorService that will be used to make calls to a service.
  */
-@BetaApi
 public interface ExecutorProvider {
   /** Indicates whether the executor should be closed by the containing client class. */
   boolean shouldAutoClose();

--- a/gax/src/main/java/com/google/api/gax/core/FixedCredentialsProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/FixedCredentialsProvider.java
@@ -29,13 +29,11 @@
  */
 package com.google.api.gax.core;
 
-import com.google.api.core.BetaApi;
 import com.google.auth.Credentials;
 import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
 
 /** FixedCredentialsProvider is a CredentialsProvider which always provides the same credentials. */
-@BetaApi
 @AutoValue
 public abstract class FixedCredentialsProvider implements CredentialsProvider {
 

--- a/gax/src/main/java/com/google/api/gax/core/FixedExecutorProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/FixedExecutorProvider.java
@@ -29,11 +29,9 @@
  */
 package com.google.api.gax.core;
 
-import com.google.api.core.BetaApi;
 import java.util.concurrent.ScheduledExecutorService;
 
 /** FixedExecutorProvider is an ExecutorProvider which always returns the same executor. */
-@BetaApi
 public final class FixedExecutorProvider implements ExecutorProvider {
 
   private final ScheduledExecutorService executor;

--- a/gax/src/main/java/com/google/api/gax/core/GaxProperties.java
+++ b/gax/src/main/java/com/google/api/gax/core/GaxProperties.java
@@ -29,11 +29,11 @@
  */
 package com.google.api.gax.core;
 
-import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
 import java.util.Properties;
 
 /** Provides properties of the GAX library. */
-@BetaApi
+@InternalApi
 public class GaxProperties {
   private static final Properties gaxProperties = new Properties();
   private static final String GAX_PROPERTY_FILE = "/com/google/api/gax/project.properties";

--- a/gax/src/main/java/com/google/api/gax/core/GoogleCredentialsProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/GoogleCredentialsProvider.java
@@ -43,7 +43,6 @@ import java.util.List;
  * href="https://developers.google.com/identity/protocols/application-default-credentials">
  * https://developers.google.com/identity/protocols/application-default-credentials</a>.
  */
-@BetaApi
 @AutoValue
 public abstract class GoogleCredentialsProvider implements CredentialsProvider {
 

--- a/gax/src/main/java/com/google/api/gax/core/InstantiatingExecutorProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/InstantiatingExecutorProvider.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.core;
 
-import com.google.api.core.BetaApi;
 import com.google.auto.value.AutoValue;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -39,7 +38,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
  * InstantiatingChannelProvider is an ExecutorProvider which constructs a new
  * ScheduledExecutorService every time getExecutor() is called.
  */
-@BetaApi
 @AutoValue
 public abstract class InstantiatingExecutorProvider implements ExecutorProvider {
   // The number of threads to use with the default executor.

--- a/gax/src/main/java/com/google/api/gax/core/NoCredentialsProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/NoCredentialsProvider.java
@@ -29,11 +29,9 @@
  */
 package com.google.api.gax.core;
 
-import com.google.api.core.BetaApi;
 import com.google.auth.Credentials;
 
 /** NoCredentialsProvider is a CredentialsProvider which always returns null. */
-@BetaApi
 public final class NoCredentialsProvider implements CredentialsProvider {
   @Override
   public Credentials getCredentials() {

--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationFuture.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationFuture.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ExecutionException;
  *
  * <p>Implementations are expected to be thread-safe.
  */
-@BetaApi
+@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public interface OperationFuture<ResponseT, MetadataT> extends ApiFuture<ResponseT> {
   /**
    * Returns the value of the name of the operation from the initial operation object returned from

--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationFutureImpl.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationFutureImpl.java
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeoutException;
  *
  * <p>This class is thread-safe.
  */
-@BetaApi
+@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public final class OperationFutureImpl<ResponseT, MetadataT> extends AbstractApiFuture<ResponseT>
     implements OperationFuture<ResponseT, MetadataT> {
   private final Object lock = new Object();

--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationResponsePollAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationResponsePollAlgorithm.java
@@ -37,7 +37,7 @@ import com.google.api.gax.retrying.TimedAttemptSettings;
  * Operation polling algorithm, which keeps retrying until {@link OperationSnapshot#isDone()} is
  * true.
  */
-@BetaApi
+@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public class OperationResponsePollAlgorithm implements ResultRetryAlgorithm<OperationSnapshot> {
   @Override
   public TimedAttemptSettings createNextAttempt(

--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationSnapshot.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationSnapshot.java
@@ -38,7 +38,7 @@ import com.google.api.gax.rpc.StatusCode;
  * <p>The metadata and response will have a structure defined by the particular long-running
  * operation that was initiated.
  */
-@BetaApi
+@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public interface OperationSnapshot {
 
   /** The name of the operation. This is used for identifying the operation on the server. */

--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
@@ -42,7 +42,7 @@ import java.util.concurrent.CancellationException;
  * next polling operation should be executed. If the polling exceeds the total timeout this
  * algorithm cancels polling.
  */
-@BetaApi
+@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public class OperationTimedPollAlgorithm extends ExponentialRetryAlgorithm {
   /**
    * Creates the polling algorithm, using the default {@code NanoClock} for time computations.

--- a/gax/src/main/java/com/google/api/gax/paging/AbstractFixedSizeCollection.java
+++ b/gax/src/main/java/com/google/api/gax/paging/AbstractFixedSizeCollection.java
@@ -36,11 +36,7 @@ import com.google.common.collect.AbstractIterator;
 import java.util.Iterator;
 import java.util.List;
 
-/**
- * Partial implementation of {@link FixedSizeCollection}.
- *
- * <p>This is public only for technical reasons, for advanced usage.
- */
+/** Partial implementation of {@link FixedSizeCollection}. */
 public abstract class AbstractFixedSizeCollection<
         RequestT,
         ResponseT,

--- a/gax/src/main/java/com/google/api/gax/paging/AbstractFixedSizeCollection.java
+++ b/gax/src/main/java/com/google/api/gax/paging/AbstractFixedSizeCollection.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.paging;
 
 import com.google.api.client.util.Lists;
-import com.google.api.core.BetaApi;
 import com.google.api.pathtemplate.ValidationException;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.AbstractIterator;
@@ -42,7 +41,6 @@ import java.util.List;
  *
  * <p>This is public only for technical reasons, for advanced usage.
  */
-@BetaApi
 public abstract class AbstractFixedSizeCollection<
         RequestT,
         ResponseT,

--- a/gax/src/main/java/com/google/api/gax/paging/AbstractPage.java
+++ b/gax/src/main/java/com/google/api/gax/paging/AbstractPage.java
@@ -32,7 +32,6 @@ package com.google.api.gax.paging;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.rpc.ApiExceptions;
 import com.google.api.gax.rpc.PageContext;
@@ -46,7 +45,6 @@ import java.util.Iterator;
  *
  * <p>This is public only for technical reasons, for advanced usage.
  */
-@BetaApi
 public abstract class AbstractPage<
         RequestT,
         ResponseT,

--- a/gax/src/main/java/com/google/api/gax/paging/AbstractPage.java
+++ b/gax/src/main/java/com/google/api/gax/paging/AbstractPage.java
@@ -40,11 +40,7 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterables;
 import java.util.Iterator;
 
-/**
- * Partial implementation of {@link AsyncPage}.
- *
- * <p>This is public only for technical reasons, for advanced usage.
- */
+/** Partial implementation of {@link AsyncPage}. */
 public abstract class AbstractPage<
         RequestT,
         ResponseT,

--- a/gax/src/main/java/com/google/api/gax/paging/AbstractPagedListResponse.java
+++ b/gax/src/main/java/com/google/api/gax/paging/AbstractPagedListResponse.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.paging;
 
-import com.google.api.core.BetaApi;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.AbstractIterator;
 import java.util.Iterator;
@@ -40,7 +39,6 @@ import java.util.List;
  *
  * <p>This is public only for technical reasons, for advanced usage.
  */
-@BetaApi
 public abstract class AbstractPagedListResponse<
         RequestT,
         ResponseT,

--- a/gax/src/main/java/com/google/api/gax/paging/AbstractPagedListResponse.java
+++ b/gax/src/main/java/com/google/api/gax/paging/AbstractPagedListResponse.java
@@ -34,11 +34,7 @@ import com.google.common.collect.AbstractIterator;
 import java.util.Iterator;
 import java.util.List;
 
-/**
- * Partial implementation of {@link com.google.api.gax.paging.PagedListResponse}.
- *
- * <p>This is public only for technical reasons, for advanced usage.
- */
+/** Partial implementation of {@link com.google.api.gax.paging.PagedListResponse}. */
 public abstract class AbstractPagedListResponse<
         RequestT,
         ResponseT,

--- a/gax/src/main/java/com/google/api/gax/paging/FixedSizeCollection.java
+++ b/gax/src/main/java/com/google/api/gax/paging/FixedSizeCollection.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.paging;
 
-import com.google.api.core.BetaApi;
-
 /**
  * A FixedSizeCollection object wraps multiple API list method responses into a single collection
  * with a fixed number of elements.
@@ -40,7 +38,6 @@ import com.google.api.core.BetaApi;
  * passed to expandPage(), unless the API has no more elements to return. The FixedSizeCollection
  * object also provides methods to retrieve additional FixedSizeCollections using the page token.
  */
-@BetaApi
 public interface FixedSizeCollection<ResourceT> {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/paging/PagedListResponse.java
+++ b/gax/src/main/java/com/google/api/gax/paging/PagedListResponse.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.paging;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Response for paged results from a list API method
  *
@@ -38,7 +36,6 @@ import com.google.api.core.BetaApi;
  * tokens can be handled automatically, or by the caller. Results can be accessed on a per-element
  * or per-page basis.
  */
-@BetaApi
 public interface PagedListResponse<ResourceT> {
   /**
    * Returns an iterable over the full list of elements. Elements of the list are retrieved lazily

--- a/gax/src/main/java/com/google/api/gax/retrying/BasicResultRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/BasicResultRetryAlgorithm.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.retrying;
 
-import com.google.api.core.BetaApi;
-
 /**
  * A basic implementation of {@link ResultRetryAlgorithm}. Using this implementation would mean that
  * all exceptions should be retried, all responses should be accepted (including {@code null}) and
@@ -38,7 +36,6 @@ import com.google.api.core.BetaApi;
  *
  * @param <ResponseT> attempt response type
  */
-@BetaApi
 public class BasicResultRetryAlgorithm<ResponseT> implements ResultRetryAlgorithm<ResponseT> {
   /**
    * Always returns null, indicating that this algorithm does not provide any specific settings for

--- a/gax/src/main/java/com/google/api/gax/retrying/DirectRetryingExecutor.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/DirectRetryingExecutor.java
@@ -33,7 +33,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
-import com.google.api.core.BetaApi;
 import java.io.InterruptedIOException;
 import java.nio.channels.ClosedByInterruptException;
 import java.util.concurrent.Callable;
@@ -47,7 +46,6 @@ import org.threeten.bp.Duration;
  *
  * @param <ResponseT> response type
  */
-@BetaApi
 public class DirectRetryingExecutor<ResponseT> implements RetryingExecutor<ResponseT> {
 
   private final RetryAlgorithm<ResponseT> retryAlgorithm;

--- a/gax/src/main/java/com/google/api/gax/retrying/ExponentialPollAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/ExponentialPollAlgorithm.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.retrying;
 
 import com.google.api.core.ApiClock;
-import com.google.api.core.BetaApi;
 
 /**
  * The timed poll algorithm which uses jittered exponential backoff factor for calculating the next
@@ -39,7 +38,6 @@ import com.google.api.core.BetaApi;
  *
  * <p>This class is thread-safe.
  */
-@BetaApi
 public class ExponentialPollAlgorithm extends ExponentialRetryAlgorithm {
   /**
    * Creates a new exponential poll algorithm instance.

--- a/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
@@ -32,7 +32,6 @@ package com.google.api.gax.retrying;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.core.ApiClock;
-import com.google.api.core.BetaApi;
 import java.util.concurrent.ThreadLocalRandom;
 import org.threeten.bp.Duration;
 
@@ -42,7 +41,6 @@ import org.threeten.bp.Duration;
  *
  * <p>This class is thread-safe.
  */
-@BetaApi
 public class ExponentialRetryAlgorithm implements TimedRetryAlgorithm {
 
   private final RetrySettings globalSettings;

--- a/gax/src/main/java/com/google/api/gax/retrying/NonCancellableFuture.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/NonCancellableFuture.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.retrying;
 
 import com.google.api.core.AbstractApiFuture;
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 
 /**
@@ -41,7 +40,6 @@ import com.google.api.core.InternalApi;
  * @param <ResponseT> future response type
  */
 @InternalApi
-@BetaApi
 public final class NonCancellableFuture<ResponseT> extends AbstractApiFuture<ResponseT> {
   @Override
   public boolean cancel(boolean mayInterruptIfRunning) {

--- a/gax/src/main/java/com/google/api/gax/retrying/PollException.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/PollException.java
@@ -29,13 +29,10 @@
  */
 package com.google.api.gax.retrying;
 
-import com.google.api.core.BetaApi;
-
 /**
  * {@code PollException} is thrown when polling algorithm exceeds total timeout or total number of
  * attempts.
  */
-@BetaApi
 public class PollException extends RuntimeException {
 
   private static final long serialVersionUID = -3666617975087303999L;

--- a/gax/src/main/java/com/google/api/gax/retrying/ResultRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/ResultRetryAlgorithm.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.retrying;
 
-import com.google.api.core.BetaApi;
 import java.util.concurrent.CancellationException;
 
 /**
@@ -47,7 +46,6 @@ import java.util.concurrent.CancellationException;
  *
  * @param <ResponseT> response type
  */
-@BetaApi
 public interface ResultRetryAlgorithm<ResponseT> {
   /**
    * Creates a next attempt {@link TimedAttemptSettings}.

--- a/gax/src/main/java/com/google/api/gax/retrying/RetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetryAlgorithm.java
@@ -31,7 +31,6 @@ package com.google.api.gax.retrying;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.api.core.BetaApi;
 import java.util.concurrent.CancellationException;
 
 /**
@@ -42,7 +41,6 @@ import java.util.concurrent.CancellationException;
  *
  * @param <ResponseT> response type
  */
-@BetaApi
 public class RetryAlgorithm<ResponseT> {
   private final ResultRetryAlgorithm<ResponseT> resultAlgorithm;
   private final TimedRetryAlgorithm timedAlgorithm;

--- a/gax/src/main/java/com/google/api/gax/retrying/RetryingExecutor.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetryingExecutor.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.retrying;
 
 import com.google.api.core.ApiFuture;
-import com.google.api.core.BetaApi;
 import java.util.concurrent.Callable;
 
 /**
@@ -46,7 +45,6 @@ import java.util.concurrent.Callable;
  *
  * @param <ResponseT> response type
  */
-@BetaApi
 public interface RetryingExecutor<ResponseT> {
   /**
    * Creates the {@link RetryingFuture}, which is a facade, returned to the client code to wait for

--- a/gax/src/main/java/com/google/api/gax/retrying/RetryingFuture.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetryingFuture.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.retrying;
 
 import com.google.api.core.ApiFuture;
-import com.google.api.core.BetaApi;
 import java.util.concurrent.Callable;
 
 /**
@@ -41,7 +40,6 @@ import java.util.concurrent.Callable;
  *
  * @param <ResponseT> response type
  */
-@BetaApi
 public interface RetryingFuture<ResponseT> extends ApiFuture<ResponseT> {
   /**
    * Sets the attempt in a form of a future. This future represents a concrete retry attempt,

--- a/gax/src/main/java/com/google/api/gax/retrying/ScheduledRetryingExecutor.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/ScheduledRetryingExecutor.java
@@ -31,7 +31,6 @@ package com.google.api.gax.retrying;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
-import com.google.api.core.BetaApi;
 import com.google.api.core.ListenableFutureToApiFuture;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
@@ -54,7 +53,6 @@ import java.util.concurrent.TimeUnit;
  *
  * @param <ResponseT> response type
  */
-@BetaApi
 public class ScheduledRetryingExecutor<ResponseT> implements RetryingExecutor<ResponseT> {
 
   private final RetryAlgorithm<ResponseT> retryAlgorithm;

--- a/gax/src/main/java/com/google/api/gax/retrying/TimedRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/TimedRetryAlgorithm.java
@@ -30,7 +30,6 @@
 
 package com.google.api.gax.retrying;
 
-import com.google.api.core.BetaApi;
 import java.util.concurrent.CancellationException;
 
 /**
@@ -47,7 +46,6 @@ import java.util.concurrent.CancellationException;
  *
  * Implementations of this interface must be be thread-save.
  */
-@BetaApi
 public interface TimedRetryAlgorithm {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/rpc/AbortedException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/AbortedException.java
@@ -29,20 +29,15 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Exception thrown when the operation was aborted, typically due to a concurrency issue like
  * sequencer check failures, transaction aborts, etc.
  */
-@BetaApi
 public class AbortedException extends ApiException {
-  @BetaApi
   public AbortedException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause, statusCode, retryable);
   }
 
-  @BetaApi
   public AbortedException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause, statusCode, retryable);

--- a/gax/src/main/java/com/google/api/gax/rpc/AlreadyExistsException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/AlreadyExistsException.java
@@ -29,20 +29,15 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Exception thrown when some entity that we attempted to create (e.g., file or directory) already
  * exists.
  */
-@BetaApi
 public class AlreadyExistsException extends ApiException {
-  @BetaApi
   public AlreadyExistsException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause, statusCode, retryable);
   }
 
-  @BetaApi
   public AlreadyExistsException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause, statusCode, retryable);

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -29,7 +29,7 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.auth.Credentials;
 import org.threeten.bp.Duration;
 
@@ -40,7 +40,7 @@ import org.threeten.bp.Duration;
  *
  * <p>This is transport specific and each transport has an implementation with its own options.
  */
-@BetaApi
+@InternalExtensionOnly
 public interface ApiCallContext {
 
   /** Returns a new ApiCallContext with the given credentials set. */

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiException.java
@@ -29,25 +29,21 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import com.google.common.base.Preconditions;
 
 /** Represents an exception thrown during an RPC call. */
-@BetaApi
 public class ApiException extends RuntimeException {
   private static final long serialVersionUID = -4375114339928877996L;
 
   private final StatusCode statusCode;
   private final boolean retryable;
 
-  @BetaApi
   public ApiException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause);
     this.statusCode = Preconditions.checkNotNull(statusCode);
     this.retryable = retryable;
   }
 
-  @BetaApi
   public ApiException(String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause);
     this.statusCode = Preconditions.checkNotNull(statusCode);

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiExceptionFactory.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiExceptionFactory.java
@@ -29,17 +29,13 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * A factory class that returns the corresponding type of exception class from the given status
  * code.
  */
-@BetaApi
 public class ApiExceptionFactory {
   private ApiExceptionFactory() {}
 
-  @BetaApi
   public static ApiException createException(
       Throwable cause, StatusCode statusCode, boolean retryable) {
     switch (statusCode.getCode()) {
@@ -81,7 +77,6 @@ public class ApiExceptionFactory {
     }
   }
 
-  @BetaApi
   public static ApiException createException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     switch (statusCode.getCode()) {

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiExceptions.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiExceptions.java
@@ -30,13 +30,11 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.ApiFuture;
-import com.google.api.core.BetaApi;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
 /** A utility class for working with {@link ApiException}. */
-@BetaApi
 public class ApiExceptions {
   private ApiExceptions() {}
 

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiStreamObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiStreamObserver.java
@@ -52,7 +52,7 @@ import com.google.api.core.BetaApi;
  * <p>This interface is a fork of io.grpc.stub.StreamObserver to enable shadowing of Guava, and also
  * to allow for a transport-agnostic interface that doesn't depend on gRPC.
  */
-@BetaApi
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public interface ApiStreamObserver<V> {
   /**
    * Receives a value from the stream.

--- a/gax/src/main/java/com/google/api/gax/rpc/BatchedRequestIssuer.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/BatchedRequestIssuer.java
@@ -38,7 +38,7 @@ import com.google.common.base.Preconditions;
  *
  * <p>This class is designed to be used by generated code.
  */
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public final class BatchedRequestIssuer<ResponseT> {
   private final BatchedFuture<ResponseT> batchedFuture;
   private final long messageCount;

--- a/gax/src/main/java/com/google/api/gax/rpc/BatchingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/BatchingCallSettings.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowController;
 import com.google.api.gax.retrying.RetrySettings;
@@ -40,7 +41,8 @@ import java.util.Set;
  * A settings class to configure a {@link UnaryCallable} for calls to an API method that supports
  * batching. The settings are provided using an instance of {@link BatchingSettings}.
  */
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
+@InternalExtensionOnly
 public final class BatchingCallSettings<RequestT, ResponseT>
     extends UnaryCallSettings<RequestT, ResponseT> {
   private final BatchingDescriptor<RequestT, ResponseT> batchingDescriptor;

--- a/gax/src/main/java/com/google/api/gax/rpc/BatchingDescriptor.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/BatchingDescriptor.java
@@ -43,7 +43,7 @@ import java.util.Collection;
  *
  * <p>This class is designed to be used by generated code.
  */
-@BetaApi
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public interface BatchingDescriptor<RequestT, ResponseT> {
 
   /** Returns the value of the partition key for the given request. */

--- a/gax/src/main/java/com/google/api/gax/rpc/BidiStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/BidiStreamingCallable.java
@@ -39,7 +39,7 @@ import com.google.api.core.BetaApi;
  * class is intended to be created by a generated client class, and configured by instances of
  * StreamingCallSettings.Builder which are exposed through the client settings class.
  */
-@BetaApi
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public abstract class BidiStreamingCallable<RequestT, ResponseT> {
 
   protected BidiStreamingCallable() {}

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -75,7 +75,7 @@ public class Callables {
    * @param context {@link ClientContext} to use to connect to the service.
    * @return {@link UnaryCallable} callable object.
    */
-  @BetaApi
+  @BetaApi("The surface for batching is not stable yet and may change in the future.")
   public static <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> batching(
       UnaryCallable<RequestT, ResponseT> innerCallable,
       BatchingCallSettings<RequestT, ResponseT> batchingCallSettings,

--- a/gax/src/main/java/com/google/api/gax/rpc/CancelledException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/CancelledException.java
@@ -29,17 +29,12 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /** The exception thrown when the operation was cancelled (typically by the caller). */
-@BetaApi
 public class CancelledException extends ApiException {
-  @BetaApi
   public CancelledException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause, statusCode, retryable);
   }
 
-  @BetaApi
   public CancelledException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause, statusCode, retryable);

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -53,7 +53,6 @@ import javax.annotation.Nullable;
  * <p>Unlike {@link ClientSettings} which allows users to configure the client, {@code
  * ClientContext} is intended to be used in generated code. Most users will not need to use it.
  */
-@BetaApi
 @AutoValue
 public abstract class ClientContext {
 

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientStreamingCallable.java
@@ -39,7 +39,7 @@ import com.google.api.core.BetaApi;
  * This class is intended to be created by a generated client class, and configured by instances of
  * StreamingCallSettings.Builder which are exposed through the client settings class.
  */
-@BetaApi
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public abstract class ClientStreamingCallable<RequestT, ResponseT> {
 
   protected ClientStreamingCallable() {}

--- a/gax/src/main/java/com/google/api/gax/rpc/DataLossException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/DataLossException.java
@@ -29,17 +29,12 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /** Exception thrown due to unrecoverable data loss or corruption. */
-@BetaApi
 public class DataLossException extends ApiException {
-  @BetaApi
   public DataLossException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause, statusCode, retryable);
   }
 
-  @BetaApi
   public DataLossException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause, statusCode, retryable);

--- a/gax/src/main/java/com/google/api/gax/rpc/DeadlineExceededException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/DeadlineExceededException.java
@@ -29,22 +29,17 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Exception thrown when deadline expired before operation could complete. For operations that
  * change the state of the system, this error may be returned even if the operation has completed
  * successfully. For example, a successful response from a server could have been delayed long
  * enough for the deadline to expire.
  */
-@BetaApi
 public class DeadlineExceededException extends ApiException {
-  @BetaApi
   public DeadlineExceededException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause, statusCode, retryable);
   }
 
-  @BetaApi
   public DeadlineExceededException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause, statusCode, retryable);

--- a/gax/src/main/java/com/google/api/gax/rpc/FailedPreconditionException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FailedPreconditionException.java
@@ -29,21 +29,16 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Exception thrown when the operation was rejected because the system is not in a state required
  * for the operation's execution. For example, directory to be deleted may be non-empty, an rmdir
  * operation is applied to a non-directory, etc.
  */
-@BetaApi
 public class FailedPreconditionException extends ApiException {
-  @BetaApi
   public FailedPreconditionException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause, statusCode, retryable);
   }
 
-  @BetaApi
   public FailedPreconditionException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause, statusCode, retryable);

--- a/gax/src/main/java/com/google/api/gax/rpc/FixedTransportChannelProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FixedTransportChannelProvider.java
@@ -30,13 +30,14 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 
 /** An instance of TransportChannelProvider that always provides the same TransportChannel. */
-@BetaApi
+@InternalExtensionOnly
 public class FixedTransportChannelProvider implements TransportChannelProvider {
 
   private final TransportChannel transportChannel;

--- a/gax/src/main/java/com/google/api/gax/rpc/InternalException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/InternalException.java
@@ -29,20 +29,15 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Exception thrown due to internal errors. Means some invariants expected by underlying system has
  * been broken. If you see one of these errors, something is very broken.
  */
-@BetaApi
 public class InternalException extends ApiException {
-  @BetaApi
   public InternalException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause, statusCode, retryable);
   }
 
-  @BetaApi
   public InternalException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause, statusCode, retryable);

--- a/gax/src/main/java/com/google/api/gax/rpc/InvalidArgumentException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/InvalidArgumentException.java
@@ -29,21 +29,16 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Exception thrown when client specified an invalid argument. Note that this differs from {@link
  * FailedPreconditionException}. This exception indicates arguments that are problematic regardless
  * of the state of the system (e.g., a malformed file name).
  */
-@BetaApi
 public class InvalidArgumentException extends ApiException {
-  @BetaApi
   public InvalidArgumentException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause, statusCode, retryable);
   }
 
-  @BetaApi
   public InvalidArgumentException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause, statusCode, retryable);

--- a/gax/src/main/java/com/google/api/gax/rpc/LongRunningClient.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/LongRunningClient.java
@@ -33,7 +33,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.longrunning.OperationSnapshot;
 
 /** Implementation-agnostic interface for managing long-running operations. */
-@BetaApi
+@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public interface LongRunningClient {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/rpc/NotFoundException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/NotFoundException.java
@@ -29,16 +29,12 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /** Exception thrown when some requested entity (e.g., file or directory) was not found. */
-@BetaApi
 public class NotFoundException extends ApiException {
   public NotFoundException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause, statusCode, retryable);
   }
 
-  @BetaApi
   public NotFoundException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause, statusCode, retryable);

--- a/gax/src/main/java/com/google/api/gax/rpc/OperationCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/OperationCallSettings.java
@@ -40,7 +40,7 @@ import com.google.api.gax.retrying.TimedRetryAlgorithm;
  * A settings class to configure an {@link OperationCallable} for calls to initiate, resume, and
  * cancel a long-running operation.
  */
-@BetaApi
+@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public final class OperationCallSettings<RequestT, ResponseT, MetadataT> {
   private final UnaryCallSettings<RequestT, OperationSnapshot> initialCallSettings;
   private final TimedRetryAlgorithm pollingAlgorithm;

--- a/gax/src/main/java/com/google/api/gax/rpc/OperationCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/OperationCallable.java
@@ -42,7 +42,7 @@ import com.google.api.gax.longrunning.OperationFuture;
  * class is intended to be created by a generated client class, and configured by instances of
  * OperationCallSettings.Builder which are exposed through the client settings class.
  */
-@BetaApi
+@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public abstract class OperationCallable<RequestT, ResponseT, MetadataT> {
 
   protected OperationCallable() {}

--- a/gax/src/main/java/com/google/api/gax/rpc/OperationCallableImpl.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/OperationCallableImpl.java
@@ -33,7 +33,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
-import com.google.api.core.InternalApi;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.longrunning.OperationFutureImpl;
 import com.google.api.gax.longrunning.OperationSnapshot;
@@ -47,7 +46,6 @@ import com.google.api.gax.retrying.RetryingFuture;
  *
  * <p>Package-private for internal use.
  */
-@InternalApi
 class OperationCallableImpl<RequestT, ResponseT, MetadataT>
     extends OperationCallable<RequestT, ResponseT, MetadataT> {
 

--- a/gax/src/main/java/com/google/api/gax/rpc/OutOfRangeException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/OutOfRangeException.java
@@ -29,20 +29,15 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Exception thrown when the operation was attempted past the valid range. E.g., seeking or reading
  * past end of file.
  */
-@BetaApi
 public class OutOfRangeException extends ApiException {
-  @BetaApi
   public OutOfRangeException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause, statusCode, retryable);
   }
 
-  @BetaApi
   public OutOfRangeException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause, statusCode, retryable);

--- a/gax/src/main/java/com/google/api/gax/rpc/PageContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/PageContext.java
@@ -29,11 +29,9 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import com.google.auto.value.AutoValue;
 
 /** The context for a page call. */
-@BetaApi
 @AutoValue
 public abstract class PageContext<RequestT, ResponseT, ResourceT> {
 

--- a/gax/src/main/java/com/google/api/gax/rpc/PagedCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/PagedCallSettings.java
@@ -29,7 +29,7 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.retrying.RetrySettings;
 import java.util.Set;
 
@@ -37,7 +37,7 @@ import java.util.Set;
  * A settings class to configure a {@link UnaryCallable} for calls to an API method that supports
  * page streaming.
  */
-@BetaApi
+@InternalExtensionOnly
 public final class PagedCallSettings<RequestT, ResponseT, PagedListResponseT>
     extends UnaryCallSettings<RequestT, ResponseT> {
   private final PagedListResponseFactory<RequestT, ResponseT, PagedListResponseT>

--- a/gax/src/main/java/com/google/api/gax/rpc/PagedListDescriptor.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/PagedListDescriptor.java
@@ -29,15 +29,12 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * An interface which provides the functionality to extract data from requests and inject data into
  * requests for the purposes of page streaming.
  *
  * <p>This class is designed to be used by generated code.
  */
-@BetaApi
 public interface PagedListDescriptor<RequestT, ResponseT, ResourceT> {
 
   /** Delivers the empty page token. */

--- a/gax/src/main/java/com/google/api/gax/rpc/PagedListResponseFactory.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/PagedListResponseFactory.java
@@ -30,14 +30,12 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.ApiFuture;
-import com.google.api.core.BetaApi;
 
 /**
  * Interface for constructing futures which return PagedListResponse objects.
  *
  * <p>This class is designed to be used by generated code.
  */
-@BetaApi
 public interface PagedListResponseFactory<RequestT, ResponseT, PagedListResponseT> {
 
   ApiFuture<PagedListResponseT> getFuturePagedResponse(

--- a/gax/src/main/java/com/google/api/gax/rpc/PermissionDeniedException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/PermissionDeniedException.java
@@ -29,17 +29,12 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /** Exception thrown when the caller does not have permission to execute the specified operation. */
-@BetaApi
 public class PermissionDeniedException extends ApiException {
-  @BetaApi
   public PermissionDeniedException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause, statusCode, retryable);
   }
 
-  @BetaApi
   public PermissionDeniedException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause, statusCode, retryable);

--- a/gax/src/main/java/com/google/api/gax/rpc/RequestParamsEncoder.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/RequestParamsEncoder.java
@@ -29,7 +29,7 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
 
 /**
  * A request params encoder takes a {@code request} object and encodes some (or all) of its
@@ -38,7 +38,7 @@ import com.google.api.core.BetaApi;
  *
  * @param <RequestT> request message type
  */
-@BetaApi
+@InternalApi("For use by transport-specific implementations")
 public interface RequestParamsEncoder<RequestT> {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/rpc/RequestParamsExtractor.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/RequestParamsExtractor.java
@@ -29,7 +29,7 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
 import java.util.Map;
 
 /**
@@ -43,7 +43,7 @@ import java.util.Map;
  *
  * @param <RequestT> request message type
  */
-@BetaApi
+@InternalApi("For use by transport-specific implementations")
 public interface RequestParamsExtractor<RequestT> {
   /**
    * Extracts specific fields from the {@code request} and returns them in a form of key-value

--- a/gax/src/main/java/com/google/api/gax/rpc/RequestUrlParamsEncoder.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/RequestUrlParamsEncoder.java
@@ -31,7 +31,7 @@ package com.google.api.gax.rpc;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -45,7 +45,7 @@ import java.util.Map;
  *
  * @param <RequestT> request message type
  */
-@BetaApi
+@InternalApi("For use by transport-specific implementations")
 public class RequestUrlParamsEncoder<RequestT> implements RequestParamsEncoder<RequestT> {
   private static final String STR_ENCODING = "UTF-8";
 

--- a/gax/src/main/java/com/google/api/gax/rpc/ResourceExhaustedException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ResourceExhaustedException.java
@@ -29,20 +29,15 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Exception thrown when some resource has been exhausted, perhaps a per-user quota, or perhaps the
  * entire file system is out of space.
  */
-@BetaApi
 public class ResourceExhaustedException extends ApiException {
-  @BetaApi
   public ResourceExhaustedException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause, statusCode, retryable);
   }
 
-  @BetaApi
   public ResourceExhaustedException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause, statusCode, retryable);

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
@@ -40,7 +40,7 @@ import java.util.Iterator;
  * This class is intended to be created by a generated client class, and configured by instances of
  * StreamingCallSettings.Builder which are exposed through the client settings class.
  */
-@BetaApi
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public abstract class ServerStreamingCallable<RequestT, ResponseT> {
 
   protected ServerStreamingCallable() {}

--- a/gax/src/main/java/com/google/api/gax/rpc/StatusCode.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StatusCode.java
@@ -29,7 +29,7 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 
 /**
  * Transport-specific status code.
@@ -38,7 +38,7 @@ import com.google.api.core.BetaApi;
  * status codes, see
  * https://github.com/grpc/grpc-java/blob/master/core/src/main/java/io/grpc/Status.java
  */
-@BetaApi
+@InternalExtensionOnly
 public interface StatusCode {
 
   enum Code {

--- a/gax/src/main/java/com/google/api/gax/rpc/StreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StreamingCallSettings.java
@@ -30,11 +30,13 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 
 /**
  * A settings class to configure a streaming callable object for calls to a streaming API method.
  */
-@BetaApi
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
+@InternalExtensionOnly
 public final class StreamingCallSettings<RequestT, ResponseT> {
 
   public static <RequestT, ResponseT> Builder<RequestT, ResponseT> newBuilder() {

--- a/gax/src/main/java/com/google/api/gax/rpc/TranslatingUnaryCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/TranslatingUnaryCallable.java
@@ -32,12 +32,10 @@ package com.google.api.gax.rpc;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
-import com.google.api.core.BetaApi;
 
 /**
  * A UnaryCallable that translates request types and response types using the given transformers.
  */
-@BetaApi
 public class TranslatingUnaryCallable<InnerRequestT, InnerResponseT, OuterRequestT, OuterResponseT>
     extends UnaryCallable<OuterRequestT, OuterResponseT> {
   private final UnaryCallable<InnerRequestT, InnerResponseT> innerUnaryCallable;

--- a/gax/src/main/java/com/google/api/gax/rpc/TransportChannel.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/TransportChannel.java
@@ -29,11 +29,11 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.core.BackgroundResource;
 
 /** Class whose instances can issue RPCs on a particular transport. */
-@BetaApi
+@InternalExtensionOnly
 public interface TransportChannel extends BackgroundResource {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/rpc/TransportChannelProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/TransportChannelProvider.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
@@ -55,7 +56,7 @@ import java.util.concurrent.ScheduledExecutorService;
  * TransportChannel transportChannel = transportChannelProvider.getTransportChannel();
  * </code></pre>
  */
-@BetaApi
+@InternalExtensionOnly
 public interface TransportChannelProvider {
   /** Indicates whether the TransportChannel should be closed by the containing client class. */
   boolean shouldAutoClose();

--- a/gax/src/main/java/com/google/api/gax/rpc/UnaryCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/UnaryCallSettings.java
@@ -29,7 +29,7 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
@@ -53,7 +53,7 @@ import org.threeten.bp.Duration;
  * builder class cannot be used to create an instance of UnaryCallSettings, because
  * UnaryCallSettings is an abstract class.
  */
-@BetaApi
+@InternalExtensionOnly
 public class UnaryCallSettings<RequestT, ResponseT> {
 
   private final ImmutableSet<StatusCode.Code> retryableCodes;

--- a/gax/src/main/java/com/google/api/gax/rpc/UnaryCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/UnaryCallable.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.ApiFuture;
-import com.google.api.core.BetaApi;
 
 /**
  * A UnaryCallable is an immutable object which is capable of making RPC calls to non-streaming API
@@ -66,7 +65,6 @@ import com.google.api.core.BetaApi;
  * intended to be created by a generated client class, and configured by instances of
  * UnaryCallSettings.Builder which are exposed through the client settings class.
  */
-@BetaApi
 public abstract class UnaryCallable<RequestT, ResponseT> {
 
   protected UnaryCallable() {}

--- a/gax/src/main/java/com/google/api/gax/rpc/UnauthenticatedException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/UnauthenticatedException.java
@@ -29,20 +29,15 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Exception thrown when the request does not have valid authentication credentials for the
  * operation.
  */
-@BetaApi
 public class UnauthenticatedException extends ApiException {
-  @BetaApi
   public UnauthenticatedException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause, statusCode, retryable);
   }
 
-  @BetaApi
   public UnauthenticatedException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause, statusCode, retryable);

--- a/gax/src/main/java/com/google/api/gax/rpc/UnavailableException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/UnavailableException.java
@@ -29,20 +29,15 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Exception thrown when the service is currently unavailable. This is a most likely a transient
  * condition and may be corrected by retrying with a backoff.
  */
-@BetaApi
 public class UnavailableException extends ApiException {
-  @BetaApi
   public UnavailableException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause, statusCode, retryable);
   }
 
-  @BetaApi
   public UnavailableException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause, statusCode, retryable);

--- a/gax/src/main/java/com/google/api/gax/rpc/UnimplementedException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/UnimplementedException.java
@@ -29,19 +29,14 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Exception thrown when the operation is not implemented or not supported/enabled in this service.
  */
-@BetaApi
 public class UnimplementedException extends ApiException {
-  @BetaApi
   public UnimplementedException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause, statusCode, retryable);
   }
 
-  @BetaApi
   public UnimplementedException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause, statusCode, retryable);

--- a/gax/src/main/java/com/google/api/gax/rpc/UnknownException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/UnknownException.java
@@ -29,22 +29,17 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Exception thrown due to an unknown error. An example of where this error may be returned is if a
  * Status value received from another address space belongs to an error-space that is not known in
  * this address space. Also errors raised by APIs that do not return enough error information may be
  * converted to this error.
  */
-@BetaApi
 public class UnknownException extends ApiException {
-  @BetaApi
   public UnknownException(Throwable cause, StatusCode statusCode, boolean retryable) {
     super(cause, statusCode, retryable);
   }
 
-  @BetaApi
   public UnknownException(
       String message, Throwable cause, StatusCode statusCode, boolean retryable) {
     super(message, cause, statusCode, retryable);


### PR DESCRIPTION
- Removing `@BetaApi` from various classes
- Adding explanations to some usages of `@BetaApi`
- Introducing usage of `@InternalExtensionOnly`
- Updating readme with stability explanations