### PR TITLE
Removing BetaApi from ClientSettings

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/ClientSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientSettings.java
@@ -53,7 +53,6 @@ import java.io.IOException;
  * <p>If no ExecutorProvider is set, then InstantiatingExecutorProvider will be used, which creates
  * a default executor.
  */
-@BetaApi
 public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>> {
 
   private final ExecutorProvider executorProvider;


### PR DESCRIPTION
This should have been removed in the last pass of removing `@BetaApi`
tags, but it was somehow overlooked.