### PR TITLE
Fixing DEADLINE_EXCEEDED for long-running calls

### DIFF
--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -31,6 +31,7 @@ package com.google.api.gax.grpc;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.api.gax.rpc.DeadlineExceededException;
 import com.google.api.gax.rpc.testing.FakeCallContext;
 import com.google.api.gax.rpc.testing.FakeChannel;
 import com.google.api.gax.rpc.testing.FakeTransportChannel;
@@ -44,6 +45,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
+import org.threeten.bp.Duration;
 
 public class GrpcCallContextTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
@@ -95,5 +97,22 @@ public class GrpcCallContextTest {
 
     assertEquals(
         ImmutableMap.of(CallOptionsUtil.REQUEST_PARAMS_HEADER_KEY, encodedRequestParams), headers);
+  }
+
+  @Test
+  public void testWithTimeout() {
+    Truth.assertThat(GrpcCallContext.createDefault().withTimeout(null).getDeadline()).isNull();
+  }
+
+  @Test
+  public void testWithNegativeTimeout() {
+    thrown.expect(DeadlineExceededException.class);
+    GrpcCallContext.createDefault().withTimeout(Duration.ofSeconds(-1L));
+  }
+
+  @Test
+  public void testWithZeroTimeout() {
+    thrown.expect(DeadlineExceededException.class);
+    GrpcCallContext.createDefault().withTimeout(Duration.ofSeconds(0L));
   }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/AttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/AttemptCallable.java
@@ -34,6 +34,7 @@ import com.google.api.core.ApiFutures;
 import com.google.api.gax.retrying.NonCancellableFuture;
 import com.google.api.gax.retrying.RetryingFuture;
 import java.util.concurrent.Callable;
+import org.threeten.bp.Duration;
 
 /**
  * A callable representing a retriable grpc call. This class is used from {@link RetryingCallable}.
@@ -64,8 +65,9 @@ class AttemptCallable<RequestT, ResponseT> implements Callable<ResponseT> {
   @Override
   public ResponseT call() {
     try {
-      if (callContext != null) {
-        callContext = callContext.withTimeout(externalFuture.getAttemptSettings().getRpcTimeout());
+      Duration rpcTimeout = externalFuture.getAttemptSettings().getRpcTimeout();
+      if (callContext != null && !rpcTimeout.isZero()) {
+        callContext = callContext.withTimeout(rpcTimeout);
       }
       externalFuture.setAttemptFuture(new NonCancellableFuture<ResponseT>());
       if (externalFuture.isDone()) {

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -169,10 +169,6 @@ public class Callables {
         new ScheduledRetryingExecutor<>(pollingAlgorithm, clientContext.getExecutor());
 
     return new OperationCallableImpl<>(
-        clientContext.getDefaultCallContext(),
-        initialCallable,
-        scheduler,
-        longRunningClient,
-        operationCallSettings);
+        initialCallable, scheduler, longRunningClient, operationCallSettings);
   }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/OperationCallableImpl.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/OperationCallableImpl.java
@@ -49,7 +49,6 @@ import com.google.api.gax.retrying.RetryingFuture;
 class OperationCallableImpl<RequestT, ResponseT, MetadataT>
     extends OperationCallable<RequestT, ResponseT, MetadataT> {
 
-  private final ApiCallContext callContextPrototype;
   private final UnaryCallable<RequestT, OperationSnapshot> initialCallable;
   private final RetryingExecutor<OperationSnapshot> executor;
   private final LongRunningClient longRunningClient;
@@ -57,12 +56,10 @@ class OperationCallableImpl<RequestT, ResponseT, MetadataT>
   private final ApiFunction<OperationSnapshot, MetadataT> metadataTransformer;
 
   OperationCallableImpl(
-      ApiCallContext callContextPrototype,
       UnaryCallable<RequestT, OperationSnapshot> initialCallable,
       RetryingExecutor<OperationSnapshot> executor,
       LongRunningClient longRunningClient,
       OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings) {
-    this.callContextPrototype = checkNotNull(callContextPrototype);
     this.initialCallable = checkNotNull(initialCallable);
     this.executor = checkNotNull(executor);
     this.longRunningClient = checkNotNull(longRunningClient);

--- a/gax/src/main/java/com/google/api/gax/rpc/OperationCallableImpl.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/OperationCallableImpl.java
@@ -86,11 +86,9 @@ class OperationCallableImpl<RequestT, ResponseT, MetadataT>
   }
 
   OperationFutureImpl<ResponseT, MetadataT> futureCall(ApiFuture<OperationSnapshot> initialFuture) {
-    RetryingCallable<RequestT, OperationSnapshot> callable =
-        new RetryingCallable<RequestT, OperationSnapshot>(
-            callContextPrototype,
-            new OperationCheckingCallable<RequestT>(longRunningClient, initialFuture),
-            executor);
+    RecheckingCallable<RequestT, OperationSnapshot> callable =
+        new RecheckingCallable<>(
+            new OperationCheckingCallable<RequestT>(longRunningClient, initialFuture), executor);
 
     RetryingFuture<OperationSnapshot> pollingFuture = callable.futureCall(null, null);
     return new OperationFutureImpl<>(

--- a/gax/src/main/java/com/google/api/gax/rpc/OperationCheckingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/OperationCheckingCallable.java
@@ -76,9 +76,12 @@ class OperationCheckingCallable<RequestT> extends UnaryCallable<RequestT, Operat
         return initialFuture;
       }
 
+      // The timeout of the operation-checking context is set to a junk value, so don't want
+      // to propagate it
+      ApiCallContext innerCallContext = context.withTimeout(null);
       return longRunningClient
           .getOperationCallable()
-          .futureCall(initialOperation.getName(), context);
+          .futureCall(initialOperation.getName(), innerCallContext);
     } catch (ExecutionException e) {
       return ApiFutures.immediateFailedFuture(e.getCause());
     } catch (InterruptedException e) {

--- a/gax/src/main/java/com/google/api/gax/rpc/OperationCheckingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/OperationCheckingCallable.java
@@ -76,12 +76,7 @@ class OperationCheckingCallable<RequestT> extends UnaryCallable<RequestT, Operat
         return initialFuture;
       }
 
-      // The timeout of the operation-checking context is set to a junk value, so don't want
-      // to propagate it
-      ApiCallContext innerCallContext = context.withTimeout(null);
-      return longRunningClient
-          .getOperationCallable()
-          .futureCall(initialOperation.getName(), innerCallContext);
+      return longRunningClient.getOperationCallable().futureCall(initialOperation.getName(), null);
     } catch (ExecutionException e) {
       return ApiFutures.immediateFailedFuture(e.getCause());
     } catch (InterruptedException e) {

--- a/gax/src/main/java/com/google/api/gax/rpc/RecheckingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/RecheckingCallable.java
@@ -29,55 +29,42 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.ApiFuture;
-import com.google.api.core.ApiFutures;
-import com.google.api.gax.retrying.NonCancellableFuture;
+import com.google.api.gax.retrying.RetryingExecutor;
 import com.google.api.gax.retrying.RetryingFuture;
-import java.util.concurrent.Callable;
+import com.google.common.base.Preconditions;
 
 /**
- * A callable representing an attempt to make an RPC call. This class is used from {@link
- * RetryingCallable}.
+ * A UnaryCallable that will keep issuing calls to an inner callable until a terminal condition is
+ * met.
+ *
+ * <p>Note: Any request or context passed to this class is ignored.
  *
  * <p>Package-private for internal use.
- *
- * @param <RequestT> request type
- * @param <ResponseT> response type
  */
-class AttemptCallable<RequestT, ResponseT> implements Callable<ResponseT> {
+class RecheckingCallable<RequestT, ResponseT> extends UnaryCallable<RequestT, ResponseT> {
   private final UnaryCallable<RequestT, ResponseT> callable;
-  private final RequestT request;
+  private final RetryingExecutor<ResponseT> executor;
 
-  private volatile RetryingFuture<ResponseT> externalFuture;
-  private volatile ApiCallContext callContext;
-
-  AttemptCallable(
-      UnaryCallable<RequestT, ResponseT> callable, RequestT request, ApiCallContext callContext) {
-    this.callable = callable;
-    this.request = request;
-    this.callContext = callContext;
-  }
-
-  public void setExternalFuture(RetryingFuture<ResponseT> externalFuture) {
-    this.externalFuture = externalFuture;
+  RecheckingCallable(
+      UnaryCallable<RequestT, ResponseT> callable, RetryingExecutor<ResponseT> executor) {
+    this.callable = Preconditions.checkNotNull(callable);
+    this.executor = Preconditions.checkNotNull(executor);
   }
 
   @Override
-  public ResponseT call() {
-    try {
-      if (callContext != null) {
-        callContext = callContext.withTimeout(externalFuture.getAttemptSettings().getRpcTimeout());
-      }
-      externalFuture.setAttemptFuture(new NonCancellableFuture<ResponseT>());
-      if (externalFuture.isDone()) {
-        return null;
-      }
-      ApiFuture<ResponseT> internalFuture = callable.futureCall(request, callContext);
-      externalFuture.setAttemptFuture(internalFuture);
-    } catch (Throwable e) {
-      externalFuture.setAttemptFuture(ApiFutures.<ResponseT>immediateFailedFuture(e));
-    }
+  public RetryingFuture<ResponseT> futureCall(RequestT request, ApiCallContext inputContext) {
+    CheckingAttemptCallable<RequestT, ResponseT> checkingAttemptCallable =
+        new CheckingAttemptCallable<>(callable);
 
-    return null;
+    RetryingFuture<ResponseT> retryingFuture = executor.createFuture(checkingAttemptCallable);
+    checkingAttemptCallable.setExternalFuture(retryingFuture);
+    checkingAttemptCallable.call();
+
+    return retryingFuture;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("retrying(%s)", callable);
   }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/RecheckingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/RecheckingCallable.java
@@ -65,6 +65,6 @@ class RecheckingCallable<RequestT, ResponseT> extends UnaryCallable<RequestT, Re
 
   @Override
   public String toString() {
-    return String.format("retrying(%s)", callable);
+    return String.format("rechecking(%s)", callable);
   }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/RetryingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/RetryingCallable.java
@@ -29,15 +29,12 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.retrying.RetryingExecutor;
 import com.google.api.gax.retrying.RetryingFuture;
 import com.google.common.base.Preconditions;
 
 /**
- * Implements retry and timeout functionality.
- *
- * <p>The behavior is controlled by the given {@link RetrySettings}.
+ * A UnaryCallable that will keep issuing calls to an inner callable until it succeeds or times out.
  *
  * <p>Package-private for internal use.
  */

--- a/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
@@ -76,14 +76,25 @@ public class OperationCallableImplTest {
 
   private static final RetrySettings FAST_RETRY_SETTINGS =
       RetrySettings.newBuilder()
+          .setInitialRetryDelay(Duration.ofMillis(2L))
+          .setRetryDelayMultiplier(1)
+          .setMaxRetryDelay(Duration.ofMillis(2L))
+          .setInitialRpcTimeout(Duration.ofMillis(2L))
+          .setRpcTimeoutMultiplier(1)
+          .setMaxRpcTimeout(Duration.ofMillis(2L))
+          .setTotalTimeout(Duration.ofMillis(10L))
+          .build();
+
+  private static final RetrySettings FAST_POLLING_RETRYING_SETTINGS =
+      RetrySettings.newBuilder()
           .setInitialRetryDelay(Duration.ofMillis(1L))
           .setRetryDelayMultiplier(1)
           .setMaxRetryDelay(Duration.ofMillis(1L))
-          .setInitialRpcTimeout(Duration.ofMillis(1L))
+          .setInitialRpcTimeout(Duration.ZERO) // supposed to be ignored
           .setMaxAttempts(0)
           .setJittered(false)
-          .setRpcTimeoutMultiplier(1)
-          .setMaxRpcTimeout(Duration.ofMillis(1L))
+          .setRpcTimeoutMultiplier(1) // supposed to be ignored
+          .setMaxRpcTimeout(Duration.ZERO) // supposed to be ignored
           .setTotalTimeout(Duration.ofMillis(5L))
           .build();
 
@@ -105,7 +116,7 @@ public class OperationCallableImplTest {
 
     clock = new FakeApiClock(0L);
     executor = RecordingScheduler.create(clock);
-    pollingAlgorithm = OperationTimedPollAlgorithm.create(FAST_RETRY_SETTINGS, clock);
+    pollingAlgorithm = OperationTimedPollAlgorithm.create(FAST_POLLING_RETRYING_SETTINGS, clock);
 
     UnaryCallSettings<Integer, OperationSnapshot> initialCallSettings =
         UnaryCallSettings.<Integer, OperationSnapshot>newUnaryCallSettingsBuilder()
@@ -458,7 +469,7 @@ public class OperationCallableImplTest {
 
     pollingAlgorithm =
         OperationTimedPollAlgorithm.create(
-            FAST_RETRY_SETTINGS
+            FAST_POLLING_RETRYING_SETTINGS
                 .toBuilder()
                 .setTotalTimeout(Duration.ofMillis(iterationsCount))
                 .build(),
@@ -558,7 +569,10 @@ public class OperationCallableImplTest {
 
     pollingAlgorithm =
         OperationTimedPollAlgorithm.create(
-            FAST_RETRY_SETTINGS.toBuilder().setTotalTimeout(Duration.ofMillis(1000L)).build(),
+            FAST_POLLING_RETRYING_SETTINGS
+                .toBuilder()
+                .setTotalTimeout(Duration.ofMillis(1000L))
+                .build(),
             clock);
     callSettings = callSettings.toBuilder().setPollingAlgorithm(pollingAlgorithm).build();
 
@@ -985,6 +999,14 @@ public class OperationCallableImplTest {
 
       @Override
       public ApiFuture<OperationSnapshot> futureCall(RequestT request, ApiCallContext context) {
+        FakeCallContext fakeCallContext = (FakeCallContext) context;
+        if (fakeCallContext.getTimeout() != null && fakeCallContext.getTimeout().isZero()) {
+          throw new DeadlineExceededException(
+              "Invalid timeout of 0 s",
+              null,
+              FakeStatusCode.of(StatusCode.Code.DEADLINE_EXCEEDED),
+              true);
+        }
         OperationSnapshot response = results[index];
         if (index < results.length - 1) {
           index += 1;

--- a/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
@@ -1000,7 +1000,9 @@ public class OperationCallableImplTest {
       @Override
       public ApiFuture<OperationSnapshot> futureCall(RequestT request, ApiCallContext context) {
         FakeCallContext fakeCallContext = (FakeCallContext) context;
-        if (fakeCallContext.getTimeout() != null && fakeCallContext.getTimeout().isZero()) {
+        if (fakeCallContext != null
+            && fakeCallContext.getTimeout() != null
+            && fakeCallContext.getTimeout().isZero()) {
           throw new DeadlineExceededException(
               "Invalid timeout of 0 s",
               null,

--- a/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
@@ -85,7 +85,7 @@ public class OperationCallableImplTest {
           .setTotalTimeout(Duration.ofMillis(10L))
           .build();
 
-  private static final RetrySettings FAST_POLLING_RETRYING_SETTINGS =
+  private static final RetrySettings FAST_RECHECKING_SETTINGS =
       RetrySettings.newBuilder()
           .setInitialRetryDelay(Duration.ofMillis(1L))
           .setRetryDelayMultiplier(1)
@@ -116,7 +116,7 @@ public class OperationCallableImplTest {
 
     clock = new FakeApiClock(0L);
     executor = RecordingScheduler.create(clock);
-    pollingAlgorithm = OperationTimedPollAlgorithm.create(FAST_POLLING_RETRYING_SETTINGS, clock);
+    pollingAlgorithm = OperationTimedPollAlgorithm.create(FAST_RECHECKING_SETTINGS, clock);
 
     UnaryCallSettings<Integer, OperationSnapshot> initialCallSettings =
         UnaryCallSettings.<Integer, OperationSnapshot>newUnaryCallSettingsBuilder()
@@ -469,7 +469,7 @@ public class OperationCallableImplTest {
 
     pollingAlgorithm =
         OperationTimedPollAlgorithm.create(
-            FAST_POLLING_RETRYING_SETTINGS
+            FAST_RECHECKING_SETTINGS
                 .toBuilder()
                 .setTotalTimeout(Duration.ofMillis(iterationsCount))
                 .build(),
@@ -569,10 +569,7 @@ public class OperationCallableImplTest {
 
     pollingAlgorithm =
         OperationTimedPollAlgorithm.create(
-            FAST_POLLING_RETRYING_SETTINGS
-                .toBuilder()
-                .setTotalTimeout(Duration.ofMillis(1000L))
-                .build(),
+            FAST_RECHECKING_SETTINGS.toBuilder().setTotalTimeout(Duration.ofMillis(1000L)).build(),
             clock);
     callSettings = callSettings.toBuilder().setPollingAlgorithm(pollingAlgorithm).build();
 

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
@@ -41,14 +41,16 @@ import org.threeten.bp.Duration;
 public class FakeCallContext implements ApiCallContext {
   private final Credentials credentials;
   private final FakeChannel channel;
+  private final Duration timeout;
 
-  private FakeCallContext(Credentials credentials, FakeChannel channel) {
+  private FakeCallContext(Credentials credentials, FakeChannel channel, Duration timeout) {
     this.credentials = credentials;
     this.channel = channel;
+    this.timeout = timeout;
   }
 
   public static FakeCallContext createDefault() {
-    return new FakeCallContext(null, null);
+    return new FakeCallContext(null, null, null);
   }
 
   @Override
@@ -65,11 +67,6 @@ public class FakeCallContext implements ApiCallContext {
       fakeCallContext = (FakeCallContext) inputContext;
     }
     return fakeCallContext;
-  }
-
-  @Override
-  public ApiCallContext withTimeout(Duration rpcTimeout) {
-    return this;
   }
 
   @Override
@@ -94,7 +91,12 @@ public class FakeCallContext implements ApiCallContext {
       newCallCredentials = credentials;
     }
 
-    return new FakeCallContext(newCallCredentials, newChannel);
+    Duration newTimeout = fakeCallContext.timeout;
+    if (newTimeout == null) {
+      newTimeout = timeout;
+    }
+
+    return new FakeCallContext(newCallCredentials, newChannel, newTimeout);
   }
 
   public Credentials getCredentials() {
@@ -105,9 +107,13 @@ public class FakeCallContext implements ApiCallContext {
     return channel;
   }
 
+  public Duration getTimeout() {
+    return timeout;
+  }
+
   @Override
   public FakeCallContext withCredentials(Credentials credentials) {
-    return new FakeCallContext(credentials, this.channel);
+    return new FakeCallContext(credentials, this.channel, this.timeout);
   }
 
   @Override
@@ -122,7 +128,12 @@ public class FakeCallContext implements ApiCallContext {
   }
 
   public FakeCallContext withChannel(FakeChannel channel) {
-    return new FakeCallContext(this.credentials, channel);
+    return new FakeCallContext(this.credentials, channel, this.timeout);
+  }
+
+  @Override
+  public FakeCallContext withTimeout(Duration timeout) {
+    return new FakeCallContext(this.credentials, this.channel, timeout);
   }
 
   public static FakeCallContext create(ClientContext clientContext) {


### PR DESCRIPTION
Updates https://github.com/GoogleCloudPlatform/google-cloud-java/issues/2609 .

**Problem**: When the large GAX refactoring was released in google-cloud-java recently (0.27.0), it was discovered that long-running operation calls would throw DEADLINE_EXCEEDED (Includes calls to Speech and DLP)

**Proximate cause**: A negative deadline is being sent to the server. 

**Bug**: `OperationCheckingCallable` is passing the context (and thus the RPC timeout) from the operation's RetrySettings to the inner callable, and thus the operation's RPC timeout is used for the RPC call itself. This is wrong because the operation's RPC timeout is set to 0 because it's theoretically not supposed to be used.

**How the bug was introduced**: It was introduced at some point in the large GAX refactoring, and probably has to do with more correct context propagation - this context data was probably being dropped previously, accidentally resulting in correct overall behavior. This is just a guess, but I don't think it's worth finding out for sure.

**The fix**: I am fixing this at several levels, just to make really sure it doesn't crop up again.
- `OperationCheckingCallable`: When propagating the context, setting the timeout to null for the RPC call.
- `AttemptCallable`: If the RPC timeout is zero, don't set the context's timeout at all (leave it null). This is correct for LRO because the RPC timeout there is not used; it is correct for RPC calls because a 0 timeout would otherwise be a guarantee of failure. We have to allow 0 here because `AttemptCallable` is used for both cases.
- `GrpcCallContext`: Throw a `DeadlineExceededException` if the RPC timeout is negative or zero, because the server would throw this anyway, and it's better to fail fast. 
