### PR TITLE
don't force-shutdown executor on exit

### DIFF
--- a/gax/src/main/java/com/google/api/gax/core/InstantiatingExecutorProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/InstantiatingExecutorProvider.java
@@ -30,9 +30,9 @@
 package com.google.api.gax.core;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
 
 /**
  * InstantiatingChannelProvider is an ExecutorProvider which constructs a new
@@ -48,8 +48,16 @@ public abstract class InstantiatingExecutorProvider implements ExecutorProvider 
 
   @Override
   public ScheduledExecutorService getExecutor() {
-    return MoreExecutors.getExitingScheduledExecutorService(
-        new ScheduledThreadPoolExecutor(getExecutorThreadCount()));
+    return new ScheduledThreadPoolExecutor(
+        getExecutorThreadCount(),
+        new ThreadFactory() {
+          @Override
+          public Thread newThread(Runnable r) {
+            Thread t = new Thread(r);
+            t.setDaemon(true);
+            return t;
+          }
+        });
   }
 
   @Override


### PR DESCRIPTION
Fixes GoogleCloudPlatform/google-cloud-java#2588 .

Background
==========

We previously decided that executors created from
InstantiatingExecutorProvider should not block JVM from exiting
if user forgets to call shutdown().

To implement this, we used Guava's
MoreExecutors.getExitingScheduledExecutorService.
It works by
1. making all executor threads daemon; the JVM exits after the last
non-daemon thread exits, so these threads don't block termination
2. adding a shutdown hook; when shutting down, we create one
*non-daemon* thread. This thread shuts down the executor, preventing
more jobs from being added, then wait for the maximum of 2 minutes
for existing jobs to complete. In either case, the
thread simply exits. Since (hopefully) there are no non-daemon threads
left, the JVM exits due to (1).

Problem
=======

Frameworks, like Spring, use shutdown hooks to gracefully exit.
However, JVM runs shutdown hooks in unspecified order.
The executor's shutdown might run first and shuts down the executor.
Then, the graceful-exit logic might try to execute more tasks,
causing RejectedExecutionExceptions
and making graceful-exit not very graceful.

This problem isn't isolated to shutdown hooks.
For example, if we create two non-daemon threads A and B;
A calls System.exit();
and B calls executor.execute();
B might also get the exception.

Proposed Solution
=================

This PR implements (1) but not (2).
On exit, we'd no longer shuts down the executor.
User code may still use executor to perform any shutdown logic it needs.
However, when all user threads exit, executor threads will abruptly terminate
with no grace period.