### PR TITLE
properly format error string

### DIFF
--- a/gax/src/main/java/com/google/api/gax/core/PropertiesProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/PropertiesProvider.java
@@ -113,7 +113,7 @@ public class PropertiesProvider {
   private static void logMissingProperties(Class<?> loadedClass, String propertyFilePath) {
     logger.log(
         Level.WARNING,
-        "Warning: Failed to open properties resource at '%s' of the given class '%s'\n",
+        "Warning: Failed to open properties resource at '{0}' of the given class '{1}'",
         new Object[] {propertyFilePath, loadedClass.getName()});
   }
 }


### PR DESCRIPTION
Logger uses braces for placeholders, not %s.