### PR TITLE
Server streaming callable improvements

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -231,10 +231,16 @@ public class GrpcCallableFactory {
               callable, grpcCallSettings.getParamsExtractor());
     }
     callable =
-        new GrpcExceptionServerStreamingCallable<>(callable, ImmutableSet.<StatusCode.Code>of());
+        new GrpcExceptionServerStreamingCallable<>(
+            callable, streamingCallSettings.getRetryableCodes());
 
     if (!streamingCallSettings.getCheckInterval().isZero()) {
       callable = Callables.antiIdle(callable, streamingCallSettings, clientContext);
+    }
+
+    if (!streamingCallSettings.getRetryableCodes().isEmpty()
+        && streamingCallSettings.getRetrySettings().getMaxAttempts() > 1) {
+      callable = Callables.retrying(callable, streamingCallSettings, clientContext);
     }
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
   }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -233,6 +233,9 @@ public class GrpcCallableFactory {
     callable =
         new GrpcExceptionServerStreamingCallable<>(callable, ImmutableSet.<StatusCode.Code>of());
 
+    if (!streamingCallSettings.getCheckInterval().isZero()) {
+      callable = Callables.antiIdle(callable, streamingCallSettings, clientContext);
+    }
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
   }
 

--- a/gax/src/main/java/com/google/api/gax/retrying/RestartingStreamingTrackerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RestartingStreamingTrackerFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.retrying;
+
+import com.google.api.core.BetaApi;
+
+/**
+ * Simplest implementation of a {@link StreamTracker.Factory} which simply restarts the stream from
+ * the beginning.
+ */
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
+public final class RestartingStreamingTrackerFactory<ReqT, RespT>
+    implements StreamTracker.Factory<ReqT, RespT> {
+  @Override
+  public StreamTracker<ReqT, RespT> create() {
+    return new StreamTracker<ReqT, RespT>() {
+      @Override
+      public ReqT getResumeRequest(ReqT originalRequest) {
+        return originalRequest;
+      }
+
+      @Override
+      public void onProgress(RespT response) {
+        // noop
+      }
+    };
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/retrying/RetryingServerStream.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetryingServerStream.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.retrying;
+
+import com.google.api.core.InternalApi;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.ResponseObserver;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StreamController;
+import com.google.common.base.Preconditions;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The core logic for ServerStreaming retries.
+ *
+ * <p>Wraps a request, a {@link ResponseObserver} and an inner {@link ServerStreamingCallable} and
+ * coordinates retries between them. When inner callable throws an error, this class will schedule
+ * retries using the configured {@link RetryAlgorithm}. The {@link RetryAlgorithm} behaves slightly
+ * differently for streaming: the attempts are reset as soon as a response is received and rpc
+ * timeouts are ignored.
+ *
+ * <p>Streams can be resumed using a {@link StreamTracker}. The {@link StreamTracker} is notified of
+ * incoming responses is expected to track the progress of the stream. Upon receiving an error, the
+ * {@link StreamTracker} is asked to modify the original request to resume the stream.
+ */
+@InternalApi("For internal use only")
+public class RetryingServerStream<RequestT, ResponseT> {
+  private final Object lock = new Object();
+
+  private final ScheduledExecutorService executor;
+  private final ServerStreamingCallable<RequestT, ResponseT> innerCallable;
+  private final TimedRetryAlgorithm retryAlgorithm;
+
+  private final StreamTracker<RequestT, ResponseT> streamTracker;
+  private final RequestT initialRequest;
+  private final ApiCallContext context;
+
+  private final ResponseObserver<ResponseT> outerObserver;
+
+  // Start state
+  private boolean autoFlowControl = true;
+  private boolean isStarted;
+
+  // Outer state
+  private volatile Throwable cancellationCause;
+  private int pendingRequests;
+
+  // Internal retry state
+  private StreamController currentInnerController;
+  private TimedAttemptSettings timedAttemptSettings;
+  private boolean seenSuccessSinceLastError;
+
+  public RetryingServerStream(
+      ScheduledExecutorService executor,
+      ServerStreamingCallable<RequestT, ResponseT> innerCallable,
+      TimedRetryAlgorithm retryAlgorithm,
+      StreamTracker<RequestT, ResponseT> streamTracker,
+      RequestT initialRequest,
+      ApiCallContext context,
+      ResponseObserver<ResponseT> outerObserver) {
+    this.executor = executor;
+    this.innerCallable = innerCallable;
+    this.retryAlgorithm = retryAlgorithm;
+
+    this.initialRequest = initialRequest;
+    this.context = context;
+    this.outerObserver = outerObserver;
+    this.streamTracker = streamTracker;
+  }
+
+  /**
+   * Starts the initial call. The call is attempted on the caller's thread. Further call attempts
+   * will be made by the executor.
+   */
+  public void start() {
+    Preconditions.checkState(!isStarted, "Already started");
+
+    // Initialize the outer observer
+    outerObserver.onStart(
+        new StreamController() {
+          @Override
+          public void disableAutoInboundFlowControl() {
+            Preconditions.checkState(
+                !isStarted, "Can't disable auto flow control once the stream is started");
+            autoFlowControl = false;
+          }
+
+          @Override
+          public void request(int count) {
+            onRequest(count);
+          }
+
+          @Override
+          public void cancel() {
+            onCancel();
+          }
+        });
+    isStarted = true;
+    if (autoFlowControl) {
+      pendingRequests = Integer.MAX_VALUE;
+    }
+    timedAttemptSettings = retryAlgorithm.createFirstAttempt();
+
+    // Call the inner callable
+    callNextAttempt();
+  }
+
+  /**
+   * Called when the outer {@link ResponseObserver} is ready for more data.
+   *
+   * @see StreamController#request(int)
+   */
+  private void onRequest(int count) {
+    Preconditions.checkState(!autoFlowControl, "Automatic flow control is enabled");
+    Preconditions.checkArgument(count > 0, "Count must be > 0");
+
+    final StreamController currentUpstreamController;
+
+    synchronized (lock) {
+      int maxInc = Integer.MAX_VALUE - pendingRequests;
+      count = Math.min(maxInc, count);
+
+      pendingRequests += count;
+      currentUpstreamController = this.currentInnerController;
+    }
+
+    // Note: there is a race condition here where the count might go to the previous attempt's
+    // StreamController after it failed. But it doesn't matter, because the controller will just
+    // ignore it and the current controller will pick it up onStart.
+    if (currentUpstreamController != null) {
+      currentUpstreamController.request(count);
+    }
+  }
+
+  /**
+   * Called when the outer {@link ResponseObserver} wants to prematurely cancel the stream.
+   *
+   * @see StreamController#cancel()
+   */
+  private void onCancel() {
+    StreamController upstreamController;
+
+    synchronized (lock) {
+      if (cancellationCause != null) {
+        return;
+      }
+      cancellationCause = new CancellationException("User cancelled stream");
+      upstreamController = currentInnerController;
+    }
+
+    if (upstreamController != null) {
+      upstreamController.cancel();
+    }
+  }
+
+  /**
+   * Called by the inner {@link ServerStreamingCallable} when the call is about to start. This will
+   * transfer unfinished state from the previous attempt.
+   *
+   * @see ResponseObserver#onStart(StreamController)
+   */
+  private void onAttemptStart(StreamController controller) {
+    if (!autoFlowControl) {
+      controller.disableAutoInboundFlowControl();
+    }
+
+    Throwable cancellationRequest;
+    int numToRequest = 0;
+
+    synchronized (lock) {
+      currentInnerController = controller;
+
+      cancellationRequest = this.cancellationCause;
+
+      if (!autoFlowControl) {
+        numToRequest = pendingRequests;
+      }
+    }
+
+    if (cancellationRequest != null) {
+      controller.cancel();
+    } else if (numToRequest > 0) {
+      controller.request(numToRequest);
+    }
+  }
+
+  /**
+   * Called by the inner {@link ServerStreamingCallable} when it received data. This will notify the
+   * {@link StreamTracker} and the outer {@link ResponseObserver}.
+   *
+   * @see ResponseObserver#onResponse(Object)
+   */
+  private void onAttemptResponse(ResponseT response) {
+    synchronized (lock) {
+      if (!autoFlowControl) {
+        pendingRequests--;
+      }
+    }
+
+    streamTracker.onProgress(response);
+    seenSuccessSinceLastError = true;
+    outerObserver.onResponse(response);
+  }
+
+  /**
+   * Called by the inner {@link ServerStreamingCallable} when an error is encountered. This method
+   * try to schedule a new attempt using executor.
+   *
+   * @see ResponseObserver#onError(Throwable)
+   */
+  private void onAttemptError(Throwable t) {
+    final boolean shouldResetAttempts = seenSuccessSinceLastError;
+    seenSuccessSinceLastError = false;
+
+    boolean shouldRetry = true;
+
+    // cancellations should not be retried
+    synchronized (lock) {
+      if (cancellationCause != null) {
+        shouldRetry = false;
+        t = cancellationCause;
+      }
+    }
+
+    if (shouldRetry && isRetryable(t)) {
+      // If the error is retryable, update timing settings
+      timedAttemptSettings = nextAttemptSettings(shouldResetAttempts);
+    } else {
+      shouldRetry = false;
+    }
+
+    // make sure that none of retry limits have been exhausted
+    shouldRetry = shouldRetry && retryAlgorithm.shouldRetry(timedAttemptSettings);
+
+    if (shouldRetry) {
+      executor.schedule(
+          new Runnable() {
+            @Override
+            public void run() {
+              callNextAttempt();
+            }
+          },
+          timedAttemptSettings.getRandomizedRetryDelay().getNano(),
+          TimeUnit.NANOSECONDS);
+    } else {
+      outerObserver.onError(t);
+    }
+  }
+
+  /**
+   * Called by the inner {@link ServerStreamingCallable} when the stream is complete. The outer
+   * {@link ResponseObserver} is notified.
+   */
+  private void onAttemptComplete() {
+    outerObserver.onComplete();
+  }
+
+  /** Schedules the next call attmept. */
+  private void callNextAttempt() {
+    RequestT resumeRequest = streamTracker.getResumeRequest(initialRequest);
+
+    innerCallable.call(
+        resumeRequest,
+        new ResponseObserver<ResponseT>() {
+          @Override
+          public void onStart(StreamController controller) {
+            onAttemptStart(controller);
+          }
+
+          @Override
+          public void onResponse(ResponseT response) {
+            onAttemptResponse(response);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            onAttemptError(t);
+          }
+
+          @Override
+          public void onComplete() {
+            onAttemptComplete();
+          }
+        },
+        context);
+  }
+
+  /**
+   * Creates a next attempt {@link TimedAttemptSettings} using the retryAlgorithm. When reset is
+   * true, all properties (except the start time) be reset as if this is first retry attempt (ie.
+   * second request).
+   */
+  private TimedAttemptSettings nextAttemptSettings(boolean reset) {
+    TimedAttemptSettings currentAttemptSettings = timedAttemptSettings;
+
+    if (reset) {
+      TimedAttemptSettings firstAttempt = retryAlgorithm.createFirstAttempt();
+
+      currentAttemptSettings =
+          firstAttempt
+              .toBuilder()
+              .setFirstAttemptStartTimeNanos(currentAttemptSettings.getFirstAttemptStartTimeNanos())
+              .build();
+    }
+
+    return retryAlgorithm.createNextAttempt(currentAttemptSettings);
+  }
+
+  private boolean isRetryable(Throwable t) {
+    return t instanceof ApiException && ((ApiException) t).isRetryable();
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/retrying/StreamTracker.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/StreamTracker.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.retrying;
+
+import com.google.api.core.BetaApi;
+
+/**
+ * This is part of the server streaming retry api. It's implementors are responsible for tracking
+ * the progress of the stream and calculating a request to resume it in case of an error.
+ *
+ * <p>Implementations don't have to be threadsafe because all of the calls will be serialized.
+ */
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
+public interface StreamTracker<RequestT, ResponseT> {
+  /**
+   * Called by the {@link RetryingServerStream} to notify of a successfully received response.
+   *
+   * @param response
+   */
+  void onProgress(ResponseT response);
+
+  /**
+   * Called when a stream needs to be restarted, the implementation should generate a request that
+   * will yield a stream whose first response would come right after the last response in
+   * onProgress.
+   */
+  RequestT getResumeRequest(RequestT originalRequest);
+
+  /**
+   * Stateless factory to create new {@link StreamTracker}s to use new calls in
+   * RetryingServerStreamingCallable.
+   */
+  interface Factory<RequestT, ResponseT> {
+    StreamTracker<RequestT, ResponseT> create();
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/AntiIdleStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/AntiIdleStreamingCallable.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.ApiClock;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.lang.ref.WeakReference;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.concurrent.GuardedBy;
+import org.threeten.bp.Duration;
+
+/**
+ * Prevents the streams from hanging indefinitely. This middleware garbage collects idle streams in
+ * case the user forgot to close a ServerStream or if a connection is reset and GRPC does not get
+ * notified.
+ *
+ * <p>Every {@code checkInterval} this middleware checks two thresholds:
+ *
+ * <ul>
+ *   <li>waitingTimeout: the amount of time to wait for a response (after the caller signaled
+ *       demand) before forcefully closing the stream.
+ *   <li>idleTimeout: the amount of time to wait before assuming that the caller forgot to close the
+ *       stream and forcefully closing the stream. This is measured from the last time the caller
+ *       had no outstanding demand.
+ * </ul>
+ *
+ * <p>Package-private for internal use.
+ *
+ * @param <RequestT> The type of the request.
+ * @param <ResponseT> The type of the response.
+ */
+final class AntiIdleStreamingCallable<RequestT, ResponseT>
+    extends ServerStreamingCallable<RequestT, ResponseT> {
+
+  // Dummy value to convert the ConcurrentHashMap into a Set
+  private static Object VALUE_MARKER = new Object();
+  private final ConcurrentHashMap<Stream, Object> openStreams = new ConcurrentHashMap<>();
+
+  private final ServerStreamingCallable<RequestT, ResponseT> upstream;
+  private final ScheduledExecutorService executor;
+  private final ApiClock clock;
+
+  private final Duration checkInterval;
+  private final Duration waitingTimeout;
+  private final Duration idleTimeout;
+
+  AntiIdleStreamingCallable(
+      ServerStreamingCallable<RequestT, ResponseT> upstream,
+      ScheduledExecutorService executor,
+      ApiClock clock,
+      Duration waitingTimeout,
+      Duration idleTimeout,
+      Duration checkInterval) {
+
+    Preconditions.checkNotNull(upstream, "upstream can't be null");
+
+    Preconditions.checkNotNull(executor, "executor can't be null");
+    Preconditions.checkNotNull(clock, "clock can't be null");
+
+    Preconditions.checkNotNull(checkInterval, "checkInterval can't be null");
+    Preconditions.checkNotNull(waitingTimeout, "waitingTimeout can't be null");
+    Preconditions.checkNotNull(idleTimeout, "idleTimeout can't be null");
+
+    Preconditions.checkArgument(
+        Duration.ZERO.compareTo(checkInterval) < 0, "checkInterval must be a positive duration");
+
+    Preconditions.checkArgument(
+        checkInterval.compareTo(waitingTimeout) <= 0,
+        "waitingTimeout must be greater than the checkInterval");
+
+    Preconditions.checkArgument(
+        checkInterval.compareTo(idleTimeout) <= 0,
+        "idleTimeout must be greater than the checkInterval");
+
+    this.upstream = upstream;
+    this.executor = executor;
+    this.clock = clock;
+    this.waitingTimeout = waitingTimeout;
+    this.idleTimeout = idleTimeout;
+    this.checkInterval = checkInterval;
+  }
+
+  /** Schedules the timeout check thread. */
+  void start() {
+    Runner runner = new Runner(this);
+    ScheduledFuture<?> scheduledFuture =
+        executor.scheduleAtFixedRate(
+            runner, checkInterval.toMillis(), checkInterval.toMillis(), TimeUnit.MILLISECONDS);
+    runner.setScheduledFuture(scheduledFuture);
+  }
+
+  @Override
+  public void call(
+      RequestT request, ResponseObserver<ResponseT> responseObserver, ApiCallContext context) {
+    Stream stream = new Stream(responseObserver);
+    openStreams.put(stream, VALUE_MARKER);
+    upstream.call(request, stream, context);
+  }
+
+  @VisibleForTesting
+  void checkAll() {
+    Iterator<Entry<Stream, Object>> it = openStreams.entrySet().iterator();
+
+    while (it.hasNext()) {
+      Stream stream = it.next().getKey();
+      if (stream.cancelIfStale()) {
+        it.remove();
+      }
+    }
+  }
+
+  /** Wrap the scheduled check in a {@link WeakReference} to allow it to be garbage collected. */
+  private static class Runner implements Runnable {
+    private final WeakReference<AntiIdleStreamingCallable<?, ?>> callable;
+    private ScheduledFuture<?> scheduledFuture;
+
+    private Runner(AntiIdleStreamingCallable<?, ?> callable) {
+      this.callable = new WeakReference<AntiIdleStreamingCallable<?, ?>>(callable);
+    }
+
+    private void setScheduledFuture(ScheduledFuture<?> future) {
+      this.scheduledFuture = future;
+    }
+
+    @Override
+    public void run() {
+      AntiIdleStreamingCallable<?, ?> callable = this.callable.get();
+
+      if (callable != null) {
+        callable.checkAll();
+      } else if (scheduledFuture != null) {
+        scheduledFuture.cancel(false);
+      }
+    }
+  }
+
+  enum State {
+    /** Stream has been started, but doesn't have any outstanding requests. */
+    IDLE,
+    /** Stream is awaiting a response from upstream. */
+    WAITING,
+    /**
+     * Stream received a response from upstream, and is awaiting outerResponseObserver processing.
+     */
+    DELIVERING
+  }
+
+  class Stream implements ResponseObserver<ResponseT> {
+    private final Object lock = new Object();
+    private boolean hasStarted;
+    private boolean autoAutoFlowControl = true;
+
+    private final ResponseObserver<ResponseT> outerResponseObserver;
+    private StreamController innerController;
+
+    @GuardedBy("lock")
+    private State state = State.IDLE;
+
+    @GuardedBy("lock")
+    private int pendingCount = 0;
+
+    @GuardedBy("lock")
+    private long lastActivityAt;
+
+    private volatile Throwable error;
+
+    Stream(ResponseObserver<ResponseT> responseObserver) {
+      this.outerResponseObserver = responseObserver;
+      lastActivityAt = clock.millisTime();
+    }
+
+    @Override
+    public void onStart(StreamController controller) {
+      Preconditions.checkState(!hasStarted, "Already started");
+
+      this.innerController = controller;
+      outerResponseObserver.onStart(
+          new StreamController() {
+            @Override
+            public void disableAutoInboundFlowControl() {
+              Preconditions.checkState(
+                  !hasStarted, "Can't disable automatic flow control after the stream has started");
+              autoAutoFlowControl = false;
+              innerController.disableAutoInboundFlowControl();
+            }
+
+            @Override
+            public void request(int count) {
+              Stream.this.onRequest(count);
+            }
+
+            @Override
+            public void cancel() {
+              Stream.this.onCancel();
+            }
+          });
+
+      hasStarted = true;
+    }
+
+    private void onRequest(int count) {
+      Preconditions.checkArgument(count > 0, "count must be > 0");
+      Preconditions.checkState(!autoAutoFlowControl, "Auto flow control is enabled");
+
+      // Only reset the request water mark if there is no outstanding requests.
+      synchronized (lock) {
+        if (state == State.IDLE) {
+          state = State.WAITING;
+          lastActivityAt = clock.millisTime();
+        }
+
+        // Increment the request count without overflow
+        int maxIncrement = Integer.MAX_VALUE - pendingCount;
+        count = Math.min(maxIncrement, count);
+        pendingCount += count;
+      }
+      innerController.request(count);
+    }
+
+    private void onCancel() {
+      error = new CancellationException("User cancelled stream");
+      innerController.cancel();
+    }
+
+    @Override
+    public void onResponse(ResponseT response) {
+      synchronized (lock) {
+        state = State.DELIVERING;
+      }
+
+      outerResponseObserver.onResponse(response);
+
+      synchronized (lock) {
+        pendingCount--;
+        lastActivityAt = clock.millisTime();
+
+        if (autoAutoFlowControl || pendingCount > 0) {
+          state = State.WAITING;
+        } else {
+          state = State.IDLE;
+        }
+      }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      // Overlay the cancellation errors (either user or idle)
+      if (this.error != null) {
+        t = this.error;
+      }
+      openStreams.remove(this);
+      outerResponseObserver.onError(t);
+    }
+
+    @Override
+    public void onComplete() {
+      openStreams.remove(this);
+      outerResponseObserver.onComplete();
+    }
+
+    /**
+     * Checks if this stream has over run any of its timeouts and cancels it if it does.
+     *
+     * @return True if the stream was canceled.
+     */
+    boolean cancelIfStale() {
+      Throwable myError = null;
+
+      synchronized (lock) {
+        long waitTime = clock.millisTime() - lastActivityAt;
+
+        switch (this.state) {
+          case IDLE:
+            if (waitTime >= idleTimeout.toMillis()) {
+              myError = new IdleConnectionException("Canceled due to idle connection", false);
+            }
+            break;
+          case WAITING:
+            if (waitTime >= waitingTimeout.toMillis()) {
+              myError =
+                  new IdleConnectionException(
+                      "Canceled due to timeout waiting for next response", true);
+            }
+            break;
+        }
+      }
+
+      if (myError != null) {
+        this.error = myError;
+        innerController.cancel();
+        return true;
+      }
+      return false;
+    }
+  }
+
+  // TODO: figure out proper exception to signal idle disconnect
+  /**
+   * The marker exception thrown when a timeout is exceeded in a {@link AntiIdleStreamingCallable}.
+   */
+  public static class IdleConnectionException extends ApiException {
+    IdleConnectionException(String message, boolean retry) {
+      super(message, null, LOCAL_ABORTED_STATUS_CODE, retry);
+    }
+  }
+
+  public static final StatusCode LOCAL_ABORTED_STATUS_CODE =
+      new StatusCode() {
+        @Override
+        public Code getCode() {
+          return Code.ABORTED;
+        }
+
+        @Override
+        public Object getTransportCode() {
+          return null;
+        }
+      };
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -171,4 +171,31 @@ public class Callables {
     return new OperationCallableImpl<>(
         initialCallable, scheduler, longRunningClient, operationCallSettings);
   }
+
+  /**
+   * Create a callable object that will periodically check for idle calls and cancel them.
+   *
+   * @param innerCallable the callable to issue calls
+   * @param settings {@link ServerStreamingCallSettings} to configure the timing
+   * @param context {@link ClientContext} to use to connect to the service.
+   * @return {@link UnaryCallable} callable object.
+   */
+  public static <RequestT, ResponseT> ServerStreamingCallable<RequestT, ResponseT> antiIdle(
+      ServerStreamingCallable<RequestT, ResponseT> innerCallable,
+      ServerStreamingCallSettings<RequestT, ResponseT> settings,
+      ClientContext context) {
+
+    AntiIdleStreamingCallable<RequestT, ResponseT> callable =
+        new AntiIdleStreamingCallable<>(
+            innerCallable,
+            context.getExecutor(),
+            context.getClock(),
+            settings.getWaitTimeout(),
+            settings.getIdleTimeout(),
+            settings.getCheckInterval());
+
+    callable.start();
+
+    return callable;
+  }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -37,6 +37,7 @@ import com.google.api.gax.retrying.ExponentialRetryAlgorithm;
 import com.google.api.gax.retrying.RetryAlgorithm;
 import com.google.api.gax.retrying.RetryingExecutor;
 import com.google.api.gax.retrying.ScheduledRetryingExecutor;
+import com.google.api.gax.retrying.TimedRetryAlgorithm;
 
 /**
  * Class with utility methods to create callable objects using provided settings.
@@ -63,6 +64,22 @@ public class Callables {
         new ScheduledRetryingExecutor<>(retryAlgorithm, clientContext.getExecutor());
     return new RetryingCallable<>(
         clientContext.getDefaultCallContext(), innerCallable, retryingExecutor);
+  }
+
+  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+  public static <RequestT, ResponseT> ServerStreamingCallable<RequestT, ResponseT> retrying(
+      ServerStreamingCallable<RequestT, ResponseT> innerCallable,
+      ServerStreamingCallSettings<RequestT, ResponseT> callSettings,
+      ClientContext clientContext) {
+
+    TimedRetryAlgorithm retryAlgorithm =
+        new ExponentialRetryAlgorithm(callSettings.getRetrySettings(), clientContext.getClock());
+
+    return new RetryingServerStreamingCallable<>(
+        innerCallable,
+        clientContext.getExecutor(),
+        retryAlgorithm,
+        callSettings.getStreamTrackerFactory());
   }
 
   /**

--- a/gax/src/main/java/com/google/api/gax/rpc/RetryingServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/RetryingServerStreamingCallable.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.gax.retrying.RetryingServerStream;
+import com.google.api.gax.retrying.StreamTracker;
+import com.google.api.gax.retrying.TimedRetryAlgorithm;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * A ServerStreamingCallable that will keep issuing calls to an inner callable until it succeeds or
+ * times out. On error, the stream can be resumed from where it left off via a {@link
+ * StreamTracker}.
+ *
+ * <p>Package-private for internal use.
+ */
+class RetryingServerStreamingCallable<RequestT, ResponseT>
+    extends ServerStreamingCallable<RequestT, ResponseT> {
+  private final ServerStreamingCallable<RequestT, ResponseT> innerCallable;
+  private final ScheduledExecutorService executor;
+  private final TimedRetryAlgorithm retryAlgorithm;
+  private final StreamTracker.Factory<RequestT, ResponseT> streamTrackerFactory;
+
+  public RetryingServerStreamingCallable(
+      ServerStreamingCallable<RequestT, ResponseT> innerCallable,
+      ScheduledExecutorService executor,
+      TimedRetryAlgorithm retryAlgorithm,
+      StreamTracker.Factory<RequestT, ResponseT> streamTrackerFactory) {
+    this.innerCallable = innerCallable;
+    this.executor = executor;
+    this.retryAlgorithm = retryAlgorithm;
+    this.streamTrackerFactory = streamTrackerFactory;
+  }
+
+  @Override
+  public void call(
+      RequestT request, ResponseObserver<ResponseT> responseObserver, ApiCallContext context) {
+
+    StreamTracker<RequestT, ResponseT> streamTracker = streamTrackerFactory.create();
+
+    RetryingServerStream<RequestT, ResponseT> retryer =
+        new RetryingServerStream<>(
+            executor,
+            innerCallable,
+            retryAlgorithm,
+            streamTracker,
+            request,
+            context,
+            responseObserver);
+
+    retryer.start();
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -30,17 +30,60 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.BetaApi;
+import org.threeten.bp.Duration;
 
 /**
  * A settings class to configure a {@link ServerStreamingCallable}.
  *
- * <p>This class includes settings that are applicable to all server streaming calls
+ * <p>This class includes settings that are applicable to all server streaming calls, which
+ * currently is watchdog settings.
+ *
+ * <p>Watchdog configuration prevents server streams from getting stale in case the caller forgets
+ * to close the stream or if the stream was reset but GRPC was not properly notified. There are 3
+ * settings:
+ *
+ * <ul>
+ *   <li>waitTimeout: how long to wait for a server response
+ *   <li>idleTimeout: how long to wait for a client to request the next response
+ *   <li>checkInterval: how often to check that active streams have not passed those thresholds.
+ * </ul>
  */
 @BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public final class ServerStreamingCallSettings<RequestT, ResponseT>
     extends StreamingCallSettings<RequestT, ResponseT> {
+  private final Duration checkInterval;
+  private final Duration waitTimeout;
+  private final Duration idleTimeout;
 
-  private ServerStreamingCallSettings(Builder<RequestT, ResponseT> builder) {}
+  private ServerStreamingCallSettings(Builder<RequestT, ResponseT> builder) {
+    this.checkInterval = builder.checkInterval;
+    this.waitTimeout = builder.waitTimeout;
+    this.idleTimeout = builder.idleTimeout;
+  }
+
+  /**
+   * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
+   * checkInterval does.
+   */
+  public Duration getCheckInterval() {
+    return checkInterval;
+  }
+
+  /**
+   * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
+   * waitTimeout does.
+   */
+  public Duration getWaitTimeout() {
+    return waitTimeout;
+  }
+
+  /**
+   * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
+   * idleTimeout does.
+   */
+  public Duration getIdleTimeout() {
+    return idleTimeout;
+  }
 
   public Builder<RequestT, ResponseT> toBuilder() {
     return new Builder<>(this);
@@ -52,11 +95,60 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
 
   public static class Builder<RequestT, ResponseT>
       extends StreamingCallSettings.Builder<RequestT, ResponseT> {
+    private Duration checkInterval;
+    private Duration waitTimeout;
+    private Duration idleTimeout;
 
-    private Builder() {}
+    private Builder() {
+      this.checkInterval = Duration.ZERO;
+      this.waitTimeout = Duration.ofDays(1);
+      this.idleTimeout = Duration.ofDays(1);
+    }
 
     private Builder(ServerStreamingCallSettings<RequestT, ResponseT> settings) {
       super(settings);
+      this.checkInterval = settings.checkInterval;
+      this.waitTimeout = settings.waitTimeout;
+      this.idleTimeout = settings.idleTimeout;
+    }
+
+    /**
+     * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
+     * checkInterval does.
+     */
+    public Builder<RequestT, ResponseT> setCheckInterval(Duration checkInterval) {
+      this.checkInterval = checkInterval;
+      return this;
+    }
+
+    public Duration getCheckInterval() {
+      return checkInterval;
+    }
+
+    /**
+     * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
+     * waitTimeout does.
+     */
+    public Builder<RequestT, ResponseT> setWaitTimeout(Duration waitTimeout) {
+      this.waitTimeout = waitTimeout;
+      return this;
+    }
+
+    public Duration getWaitTimeout() {
+      return waitTimeout;
+    }
+
+    /**
+     * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
+     * idleTimeout does.
+     */
+    public Builder<RequestT, ResponseT> setIdleTimeout(Duration idleTimeout) {
+      this.idleTimeout = idleTimeout;
+      return this;
+    }
+
+    public Duration getIdleTimeout() {
+      return idleTimeout;
     }
 
     @Override

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -30,13 +30,20 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.retrying.RestartingStreamingTrackerFactory;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.retrying.StreamTracker;
+import com.google.api.gax.retrying.StreamTracker.Factory;
+import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
 import org.threeten.bp.Duration;
 
 /**
  * A settings class to configure a {@link ServerStreamingCallable}.
  *
  * <p>This class includes settings that are applicable to all server streaming calls, which
- * currently is watchdog settings.
+ * currently is watchdog settings and retries.
  *
  * <p>Watchdog configuration prevents server streams from getting stale in case the caller forgets
  * to close the stream or if the stream was reset but GRPC was not properly notified. There are 3
@@ -47,6 +54,12 @@ import org.threeten.bp.Duration;
  *   <li>idleTimeout: how long to wait for a client to request the next response
  *   <li>checkInterval: how often to check that active streams have not passed those thresholds.
  * </ul>
+ *
+ * <p>Retry configuration allows for the stream to be restarted and resumed. it is composed of 3
+ * parts: the retryable codes, the retry settings and the stream tracker. The retryable codes
+ * indicate which codes cause a retry to occur, the retry settings configure the retry logic when
+ * the retry needs to happen and the stream tracker composes the request to resume the stream. To
+ * turn off retries, set the retryable codes needs to be set to the empty set.
  */
 @BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public final class ServerStreamingCallSettings<RequestT, ResponseT>
@@ -55,10 +68,18 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
   private final Duration waitTimeout;
   private final Duration idleTimeout;
 
+  private final StreamTracker.Factory<RequestT, ResponseT> streamTrackerFactory;
+  private final RetrySettings retrySettings;
+  private final Set<StatusCode.Code> retryableCodes;
+
   private ServerStreamingCallSettings(Builder<RequestT, ResponseT> builder) {
     this.checkInterval = builder.checkInterval;
     this.waitTimeout = builder.waitTimeout;
     this.idleTimeout = builder.idleTimeout;
+
+    this.streamTrackerFactory = builder.streamTrackerFactory;
+    this.retrySettings = builder.retrySettings;
+    this.retryableCodes = ImmutableSet.copyOf(builder.retryableCodes);
   }
 
   /**
@@ -85,6 +106,30 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
     return idleTimeout;
   }
 
+  /**
+   * See the class documentation of {@link ServerStreamingCallSettings} and {@link StreamTracker}
+   * for a description of what streamTrackerFactory does.
+   */
+  public StreamTracker.Factory<RequestT, ResponseT> getStreamTrackerFactory() {
+    return streamTrackerFactory;
+  }
+
+  /**
+   * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
+   * retrySettings do.
+   */
+  public RetrySettings getRetrySettings() {
+    return retrySettings;
+  }
+
+  /**
+   * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
+   * retryableCodes do.
+   */
+  public Set<Code> getRetryableCodes() {
+    return retryableCodes;
+  }
+
   public Builder<RequestT, ResponseT> toBuilder() {
     return new Builder<>(this);
   }
@@ -98,11 +143,25 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
     private Duration checkInterval;
     private Duration waitTimeout;
     private Duration idleTimeout;
+    private RetrySettings retrySettings;
+    private StreamTracker.Factory<RequestT, ResponseT> streamTrackerFactory;
+    private Set<StatusCode.Code> retryableCodes;
 
     private Builder() {
       this.checkInterval = Duration.ZERO;
       this.waitTimeout = Duration.ofDays(1);
       this.idleTimeout = Duration.ofDays(1);
+      this.retrySettings =
+          RetrySettings.newBuilder()
+              // Disable retries by default
+              .setMaxAttempts(1)
+              // RPC timeouts are ignored
+              .setInitialRpcTimeout(Duration.ofMillis(Long.MAX_VALUE))
+              .setRpcTimeoutMultiplier(1)
+              .setMaxRpcTimeout(Duration.ofMillis(Long.MAX_VALUE))
+              .build();
+      this.streamTrackerFactory = new RestartingStreamingTrackerFactory<>();
+      this.retryableCodes = ImmutableSet.of();
     }
 
     private Builder(ServerStreamingCallSettings<RequestT, ResponseT> settings) {
@@ -110,6 +169,9 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
       this.checkInterval = settings.checkInterval;
       this.waitTimeout = settings.waitTimeout;
       this.idleTimeout = settings.idleTimeout;
+      this.retrySettings = settings.retrySettings;
+      this.streamTrackerFactory = settings.streamTrackerFactory;
+      this.retryableCodes = settings.retryableCodes;
     }
 
     /**
@@ -149,6 +211,45 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
 
     public Duration getIdleTimeout() {
       return idleTimeout;
+    }
+
+    /**
+     * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
+     * retrySettings do.
+     */
+    public void setRetrySettings(RetrySettings retrySettings) {
+      this.retrySettings = retrySettings;
+    }
+
+    public RetrySettings getRetrySettings() {
+      return retrySettings;
+    }
+
+    /**
+     * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
+     * streamTrackerFactory does.
+     */
+    public Builder<RequestT, ResponseT> setStreamTrackerFactory(
+        Factory<RequestT, ResponseT> streamTrackerFactory) {
+      this.streamTrackerFactory = streamTrackerFactory;
+      return this;
+    }
+
+    public StreamTracker.Factory<RequestT, ResponseT> getStreamTrackerFactory() {
+      return streamTrackerFactory;
+    }
+
+    /**
+     * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
+     * retryableCodes do.
+     */
+    public Builder<RequestT, ResponseT> setRetryableCodes(Set<Code> retryableCodes) {
+      this.retryableCodes = retryableCodes;
+      return this;
+    }
+
+    public Set<Code> getRetryableCodes() {
+      return retryableCodes;
     }
 
     @Override

--- a/gax/src/test/java/com/google/api/gax/retrying/RetryingServerStreamTest.java
+++ b/gax/src/test/java/com/google/api/gax/retrying/RetryingServerStreamTest.java
@@ -1,0 +1,412 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.retrying;
+
+import com.google.api.gax.core.FakeApiClock;
+import com.google.api.gax.core.RecordingScheduler;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ResponseObserver;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.api.gax.rpc.StreamController;
+import com.google.api.gax.rpc.testing.FakeApiException;
+import com.google.api.gax.rpc.testing.FakeCallContext;
+import com.google.common.collect.Queues;
+import com.google.common.truth.Truth;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.threeten.bp.Duration;
+
+@RunWith(JUnit4.class)
+public class RetryingServerStreamTest {
+
+  private FakeApiClock clock;
+  private RecordingScheduler executor;
+  private AccumulatingCallable innerCallable;
+  private TimedRetryAlgorithm retryAlgorithm;
+  private MyStreamTracker streamTracker;
+  private ApiCallContext context;
+  private MyObserver observer;
+
+  @Before
+  public void setUp() {
+    clock = new FakeApiClock(0);
+    executor = RecordingScheduler.create(clock);
+    innerCallable = new AccumulatingCallable();
+    retryAlgorithm =
+        new RetryAlgorithm(
+            RetrySettings.newBuilder()
+                .setInitialRetryDelay(Duration.ofMillis(2))
+                .setRetryDelayMultiplier(2)
+                .setMaxRetryDelay(Duration.ofSeconds(1))
+                .setTotalTimeout(Duration.ofMinutes(1))
+                .build());
+    streamTracker = new MyStreamTracker("request");
+    context = FakeCallContext.createDefault();
+    observer = new MyObserver(true);
+  }
+
+  @Test
+  public void testNoErrorsAutoFlow() throws Exception {
+    String request = "request";
+    RetryingServerStream<String, String> stream =
+        new RetryingServerStream<>(
+            executor, innerCallable, retryAlgorithm, streamTracker, request, context, observer);
+    stream.start();
+
+    // Should notify outer observer
+    Truth.assertThat(observer.controller).isNotNull();
+
+    Controller controller = innerCallable.popNextCall();
+    Truth.assertThat(controller).isNotNull();
+    Truth.assertThat(controller.autoFlowControl).isTrue();
+
+    // send a response in auto flow mode
+    controller.responseObserver.onResponse("response1");
+    controller.responseObserver.onResponse("response2");
+    controller.responseObserver.onComplete();
+
+    // Make sure the responses are received
+    Truth.assertThat(observer.complete).isTrue();
+    Truth.assertThat(observer.responses).containsExactly("response1", "response2").inOrder();
+  }
+
+  @Test
+  public void testNoErrorsManualFlow() throws Exception {
+    String request = "request";
+
+    observer = new MyObserver(false);
+    RetryingServerStream<String, String> stream =
+        new RetryingServerStream<>(
+            executor, innerCallable, retryAlgorithm, streamTracker, request, context, observer);
+    stream.start();
+
+    // Should notify outer observer
+    Truth.assertThat(observer.controller).isNotNull();
+
+    Controller controller = innerCallable.popNextCall();
+    Truth.assertThat(controller).isNotNull();
+    Truth.assertThat(controller.autoFlowControl).isFalse();
+
+    // Request & send message 1
+    observer.controller.request(1);
+    Truth.assertThat(controller.popNextPull()).isEqualTo(1);
+    controller.responseObserver.onResponse("response1");
+
+    // Request & send message 1
+    observer.controller.request(1);
+    Truth.assertThat(controller.popNextPull()).isEqualTo(1);
+    controller.responseObserver.onResponse("response2");
+
+    controller.responseObserver.onComplete();
+
+    // Make sure the responses are received
+    Truth.assertThat(observer.complete).isTrue();
+    Truth.assertThat(observer.responses).containsExactly("response1", "response2").inOrder();
+  }
+
+  @Test
+  public void testInitialRetry() throws Exception {
+    String request = "request";
+    RetryingServerStream<String, String> stream =
+        new RetryingServerStream<>(
+            executor, innerCallable, retryAlgorithm, streamTracker, request, context, observer);
+    stream.start();
+
+    // Should notify outer observer
+    Truth.assertThat(observer.controller).isNotNull();
+
+    Controller controller = innerCallable.popNextCall();
+    Truth.assertThat(controller).isNotNull();
+    Truth.assertThat(controller.autoFlowControl).isTrue();
+
+    // Send error
+    controller.responseObserver.onError(new FakeApiException(null, Code.UNAVAILABLE, true));
+
+    // After a delay the call was retried
+    Truth.assertThat(clock.millisTime())
+        .isAtLeast(retryAlgorithm.createFirstAttempt().getRetryDelay().toMillis());
+    Truth.assertThat(executor.getIterationsCount()).isEqualTo(1);
+    controller = innerCallable.popNextCall();
+
+    controller.responseObserver.onResponse("response");
+    Truth.assertThat(observer.responses).containsExactly("response");
+  }
+
+  @Test
+  public void testMidRetry() throws Exception {
+    String request = "request";
+    RetryingServerStream<String, String> stream =
+        new RetryingServerStream<>(
+            executor, innerCallable, retryAlgorithm, streamTracker, request, context, observer);
+    stream.start();
+
+    // Should notify outer observer
+    Truth.assertThat(observer.controller).isNotNull();
+
+    Controller controller = innerCallable.popNextCall();
+    Truth.assertThat(controller).isNotNull();
+    Truth.assertThat(controller.autoFlowControl).isTrue();
+
+    controller.responseObserver.onResponse("response1");
+    controller.responseObserver.onResponse("response2");
+    controller.responseObserver.onError(new FakeApiException(null, Code.UNAVAILABLE, true));
+
+    Truth.assertThat(executor.getIterationsCount()).isEqualTo(1);
+    controller = innerCallable.popNextCall();
+
+    controller.responseObserver.onResponse("response3");
+    Truth.assertThat(observer.responses)
+        .containsExactly("response1", "response2", "response3")
+        .inOrder();
+  }
+
+  @Test
+  public void testMultipleRetry() throws Exception {
+    String request = "request";
+    RetryingServerStream<String, String> stream =
+        new RetryingServerStream<>(
+            executor, innerCallable, retryAlgorithm, streamTracker, request, context, observer);
+    stream.start();
+
+    Controller controller;
+    // Fake 3 errors: the initial call + scheduled retries
+    for (int i = 0; i < 3; i++) {
+      controller = innerCallable.popNextCall();
+      Truth.assertThat(controller).isNotNull();
+      Truth.assertThat(controller.autoFlowControl).isTrue();
+      controller.responseObserver.onError(new FakeApiException(null, Code.UNAVAILABLE, true));
+    }
+    // 2 scheduled retries that failed + 1 outstanding
+    Truth.assertThat(executor.getIterationsCount()).isEqualTo(3);
+
+    // simulate a success
+    controller = innerCallable.popNextCall();
+    controller.responseObserver.onResponse("response1");
+    Truth.assertThat(observer.responses).containsExactly("response1").inOrder();
+  }
+
+  @Test
+  public void testRequestCountIsPreserved() throws Exception {
+    String request = "request";
+    observer = new MyObserver(false);
+    RetryingServerStream<String, String> stream =
+        new RetryingServerStream<>(
+            executor, innerCallable, retryAlgorithm, streamTracker, request, context, observer);
+    stream.start();
+    observer.controller.request(5);
+
+    Truth.assertThat(observer.controller).isNotNull();
+    Controller controller = innerCallable.popNextCall();
+    Truth.assertThat(controller).isNotNull();
+    Truth.assertThat(controller.autoFlowControl).isFalse();
+
+    Truth.assertThat(controller.popNextPull()).isEqualTo(5);
+    // decrement
+    controller.responseObserver.onResponse("response");
+    // and then error
+    controller.responseObserver.onError(new FakeApiException(null, Code.UNAUTHENTICATED, true));
+
+    controller = innerCallable.popNextCall();
+    Truth.assertThat(controller.popNextPull()).isEqualTo(4);
+  }
+
+  @Test
+  public void testCancel() throws Exception {
+    String request = "request";
+    observer = new MyObserver(false);
+    RetryingServerStream<String, String> stream =
+        new RetryingServerStream<>(
+            executor, innerCallable, retryAlgorithm, streamTracker, request, context, observer);
+    stream.start();
+    observer.controller.request(1);
+
+    Truth.assertThat(observer.controller).isNotNull();
+    Controller controller = innerCallable.popNextCall();
+    Truth.assertThat(controller).isNotNull();
+    Truth.assertThat(controller.autoFlowControl).isFalse();
+
+    observer.controller.cancel();
+
+    // Check upstream is cancelled
+    Truth.assertThat(controller.cancelled).isTrue();
+
+    // and after upstream cancellation is processed, downstream is cancelled, but the cause is replaced
+    controller.responseObserver.onError(new RuntimeException("Some external cancellation cause"));
+    Truth.assertThat(observer.error).isInstanceOf(CancellationException.class);
+  }
+
+  static class AccumulatingCallable extends ServerStreamingCallable<String, String> {
+    final BlockingDeque<Controller> controllers = Queues.newLinkedBlockingDeque();
+
+    @Override
+    public void call(
+        String request, ResponseObserver<String> responseObserver, ApiCallContext context) {
+      Controller controller = new Controller(request, responseObserver, context);
+      controllers.add(controller);
+      responseObserver.onStart(controller);
+    }
+
+    Controller popNextCall() throws InterruptedException {
+      return controllers.poll(1, TimeUnit.SECONDS);
+    }
+  }
+
+  static class Controller implements StreamController {
+    final String request;
+    final ResponseObserver<String> responseObserver;
+    final ApiCallContext context;
+
+    boolean cancelled;
+    boolean autoFlowControl = true;
+    final BlockingQueue<Integer> pulls = Queues.newLinkedBlockingQueue();
+
+    Controller(String request, ResponseObserver<String> responseObserver, ApiCallContext context) {
+      this.request = request;
+      this.responseObserver = responseObserver;
+      this.context = context;
+    }
+
+    @Override
+    public void cancel() {
+      this.cancelled = true;
+    }
+
+    @Override
+    public void disableAutoInboundFlowControl() {
+      autoFlowControl = false;
+    }
+
+    @Override
+    public void request(int count) {
+      pulls.add(count);
+    }
+
+    int popNextPull() throws InterruptedException {
+      Integer pull = pulls.poll(1, TimeUnit.SECONDS);
+      if (pull == null) {
+        pull = 0;
+      }
+      return pull;
+    }
+  }
+
+  static class MyStreamTracker implements StreamTracker<String, String> {
+    String resumeRequest;
+
+    public MyStreamTracker(String resumeRequest) {
+      this.resumeRequest = resumeRequest;
+    }
+
+    @Override
+    public void onProgress(String response) {}
+
+    @Override
+    public String getResumeRequest(String originalRequest) {
+      return null;
+    }
+  }
+
+  class RetryAlgorithm implements TimedRetryAlgorithm {
+    TimedAttemptSettings prevAttempt;
+    TimedAttemptSettings nextAttempt;
+    boolean shouldRetry = true;
+
+    public RetryAlgorithm(RetrySettings retrySettings) {
+      this.nextAttempt =
+          TimedAttemptSettings.newBuilder()
+              .setGlobalSettings(retrySettings)
+              .setRetryDelay(Duration.ZERO)
+              .setRpcTimeout(retrySettings.getTotalTimeout())
+              .setRandomizedRetryDelay(Duration.ZERO)
+              .setAttemptCount(0)
+              .setFirstAttemptStartTimeNanos(clock.nanoTime())
+              .build();
+    }
+
+    @Override
+    public TimedAttemptSettings createFirstAttempt() {
+      return nextAttempt;
+    }
+
+    @Override
+    public TimedAttemptSettings createNextAttempt(TimedAttemptSettings prevSettings) {
+      this.prevAttempt = prevAttempt;
+      return nextAttempt;
+    }
+
+    @Override
+    public boolean shouldRetry(TimedAttemptSettings nextAttemptSettings)
+        throws CancellationException {
+      return shouldRetry;
+    }
+  }
+
+  static class MyObserver implements ResponseObserver<String> {
+    final boolean autoFlow;
+    StreamController controller;
+    final BlockingDeque<String> responses = Queues.newLinkedBlockingDeque();
+    private Throwable error;
+    private boolean complete;
+
+    public MyObserver(boolean autoFlow) {
+      this.autoFlow = autoFlow;
+    }
+
+    @Override
+    public void onStart(StreamController controller) {
+      this.controller = controller;
+      if (!autoFlow) {
+        controller.disableAutoInboundFlowControl();
+      }
+    }
+
+    @Override
+    public void onResponse(String response) {
+      responses.add(response);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      this.error = t;
+    }
+
+    @Override
+    public void onComplete() {
+      this.complete = true;
+    }
+  }
+}

--- a/gax/src/test/java/com/google/api/gax/rpc/AntiIdleStreamingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/AntiIdleStreamingCallableTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.core.FakeApiClock;
+import com.google.api.gax.rpc.AntiIdleStreamingCallable.IdleConnectionException;
+import com.google.common.collect.Queues;
+import com.google.common.truth.Truth;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+import org.threeten.bp.Duration;
+
+@RunWith(JUnit4.class)
+public class AntiIdleStreamingCallableTest {
+
+  private UpstreamCallable<String, String> upstream;
+
+  private FakeApiClock clock;
+  private Duration waitTime = Duration.ofSeconds(10);
+  private Duration idleTime = Duration.ofMinutes(5);
+  private Duration checkInterval = Duration.ofSeconds(5);
+
+  private AntiIdleStreamingCallable<String, String> callable;
+
+  @Before
+  public void setUp() throws Exception {
+    clock = new FakeApiClock(0);
+    ScheduledExecutorService executor = Mockito.mock(ScheduledExecutorService.class);
+
+    upstream = new UpstreamCallable<>();
+
+    callable =
+        new AntiIdleStreamingCallable<>(
+            upstream, executor, clock, waitTime, idleTime, checkInterval);
+  }
+
+  @Test
+  public void testRequestPassthrough() throws Exception {
+    AccumulatingObserver<String> downstreamObserver = new AccumulatingObserver<>(false);
+    callable.call("req", downstreamObserver);
+    downstreamObserver.controller.get(1, TimeUnit.MILLISECONDS).request(1);
+
+    Call<String, String> call = upstream.calls.poll(1, TimeUnit.MILLISECONDS);
+    Truth.assertThat(call.upstreamController.getNextRequestCount()).isEqualTo(1);
+  }
+
+  @Test
+  public void testWaitTimeout() throws Exception {
+    AccumulatingObserver<String> downstreamObserver = new AccumulatingObserver<>(false);
+    callable.call("req", downstreamObserver);
+    downstreamObserver.controller.get(1, TimeUnit.MILLISECONDS).request(1);
+
+    Call<String, String> call = upstream.calls.poll(1, TimeUnit.MILLISECONDS);
+
+    clock.incrementNanoTime(waitTime.toNanos() - 1);
+    callable.checkAll();
+    Truth.assertThat(call.upstreamController.cancelled).isFalse();
+
+    clock.incrementNanoTime(1);
+    callable.checkAll();
+    Truth.assertThat(call.upstreamController.cancelled).isTrue();
+    call.observer.onError(
+        new RuntimeException("Some upstream exception representing cancellation"));
+
+    Throwable actualError = null;
+    try {
+      Truth.assertThat(downstreamObserver.done.get());
+    } catch (ExecutionException t) {
+      actualError = t.getCause();
+    }
+    Truth.assertThat(actualError).isInstanceOf(IdleConnectionException.class);
+  }
+
+  @Test
+  public void testIdleTimeout() throws InterruptedException {
+    AccumulatingObserver<String> downstreamObserver = new AccumulatingObserver<>(false);
+    callable.call("req", downstreamObserver);
+
+    Call<String, String> call = upstream.calls.poll(1, TimeUnit.MILLISECONDS);
+
+    clock.incrementNanoTime(idleTime.toNanos() - 1);
+    callable.checkAll();
+    Truth.assertThat(call.upstreamController.cancelled).isFalse();
+
+    clock.incrementNanoTime(1);
+    callable.checkAll();
+    Truth.assertThat(call.upstreamController.cancelled).isTrue();
+    call.observer.onError(
+        new RuntimeException("Some upstream exception representing cancellation"));
+
+    Throwable actualError = null;
+    try {
+      Truth.assertThat(downstreamObserver.done.get());
+    } catch (ExecutionException t) {
+      actualError = t.getCause();
+    }
+    Truth.assertThat(actualError).isInstanceOf(IdleConnectionException.class);
+  }
+
+  @Test
+  public void testMultiple() throws InterruptedException, ExecutionException {
+    // Start stream1
+    AccumulatingObserver<String> downstreamObserver1 = new AccumulatingObserver<>(false);
+    callable.call("req", downstreamObserver1);
+    Call<String, String> call1 = upstream.calls.poll(1, TimeUnit.MILLISECONDS);
+    downstreamObserver1.controller.get().request(1);
+
+    // Start stream2
+    AccumulatingObserver<String> downstreamObserver2 = new AccumulatingObserver<>(false);
+    callable.call("req2", downstreamObserver2);
+    Call<String, String> call2 = upstream.calls.poll(1, TimeUnit.MILLISECONDS);
+    downstreamObserver2.controller.get().request(1);
+
+    // Give stream1 a response at the last possible moment
+    clock.incrementNanoTime(waitTime.toNanos());
+    call1.observer.onResponse("resp1");
+
+    // run the callable
+    callable.checkAll();
+
+    // Call1 should be ok
+    Truth.assertThat(call1.upstreamController.cancelled).isFalse();
+
+    // Call2 should be timed out
+    Truth.assertThat(call2.upstreamController.cancelled).isTrue();
+  }
+
+  static class Call<ReqT, RespT> {
+    final ReqT request;
+    final ResponseObserver<RespT> observer;
+    private final AccumulatingController upstreamController;
+
+    Call(
+        ReqT request, ResponseObserver<RespT> observer, AccumulatingController upstreamController) {
+      this.request = request;
+      this.observer = observer;
+      this.upstreamController = upstreamController;
+    }
+  }
+
+  static class UpstreamCallable<ReqT, RespT> extends ServerStreamingCallable<ReqT, RespT> {
+    BlockingQueue<Call<ReqT, RespT>> calls = Queues.newLinkedBlockingDeque();
+
+    @Override
+    public void call(ReqT request, ResponseObserver<RespT> observer, ApiCallContext context) {
+      Call<ReqT, RespT> call = new Call<>(request, observer, new AccumulatingController());
+      calls.add(call);
+      call.observer.onStart(call.upstreamController);
+    }
+  }
+
+  static class AccumulatingController implements StreamController {
+    private BlockingQueue<Integer> requests = Queues.newLinkedBlockingDeque();
+    private boolean cancelled;
+
+    @Override
+    public void disableAutoInboundFlowControl() {}
+
+    @Override
+    public void request(int count) {
+      requests.add(count);
+    }
+
+    @Override
+    public void cancel() {
+      cancelled = true;
+    }
+
+    int getNextRequestCount() throws InterruptedException {
+      Integer count = requests.poll(1, TimeUnit.SECONDS);
+      if (count == null) {
+        count = 0;
+      }
+      return count;
+    }
+  }
+
+  static class AccumulatingObserver<T> implements ResponseObserver<T> {
+    boolean autoFlowControl;
+    SettableApiFuture<StreamController> controller = SettableApiFuture.create();
+    Queue<T> responses = Queues.newLinkedBlockingDeque();
+    SettableApiFuture<Void> done = SettableApiFuture.create();
+
+    AccumulatingObserver(boolean autoFlowControl) {
+      this.autoFlowControl = autoFlowControl;
+    }
+
+    @Override
+    public void onStart(StreamController controller) {
+      if (!autoFlowControl) {
+        controller.disableAutoInboundFlowControl();
+      }
+      this.controller.set(controller);
+    }
+
+    @Override
+    public void onResponse(T response) {
+      responses.add(response);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      done.setException(t);
+    }
+
+    @Override
+    public void onComplete() {
+      done.set(null);
+    }
+  }
+}


### PR DESCRIPTION
This is the cleaned up version of https://github.com/googleapis/gax-java/pull/403.  This is the full set of improvements I propose for ServerStreamingCallables. Each commit will be pulled out as a separate PR to review. This PR is meant to show the final goal and will be rebased as its parts get merged.

Currently, gax has rich support for UnaryCallable middleware that can be chained together to achieve complex chains of functionality like batched retries. This functionality is made possible by UnaryCallable's API of serializing all functionality into a single call() method. The streaming callable api, on the other hand, is a thin wrapper around gRpc primitives, which makes it very hard to build chainable middleware. The primary blocker is that ServerStreamingCallables requires the developer to implement 2 methods that have very different call semantics.

This proposal aims to:
- improve the composability of ServerStreamingCallables
- extend the api to make it more flexible (ie. allow it to be used with async back pressure)
- add some middleware on top of the new api

The primary motivation for these changes is to allow the Cloud Bigtable client to migrate to the veneer ecosystem.

Changes:
- ~~minor prep changes: fix intellij gradle support & separate out the ServerStreaming tests into own files~~
- ~~add back pressure support:~~
  - ~~add ResponseObserver that replaces ApiStreamObserver for ServerStreamingCallables~~
  - ~~add a StreamController that allows the user to manually adjust flow control~~
  - ~~update the GrpcDirectServerStreamingCallable to use the new interfaces~~
- ~~using the back pressure api, re-implement blocking iterator streaming in gax~~
  - ~~add a ServerStream that replaces the old Iterator and duplicates the logic in grpc's ClientCalls~~
- ~~add a helper utility for clients to implement back pressure aware response merging logic~~
- ~~wrap all errors in ApiExceptions~~
- ~~add syntatic sugar to convert a ServerStreamingCallable into UnaryCallables: first() & all()~~
- add watchdog middleware to prevent streams from hanging indefinitely
- retries w. support for resuming streams