### PR TITLE
ServerStreams: Add blocking iterator style api on top of ServerStreamingCallables

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcDirectServerStreamingCallable.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcDirectServerStreamingCallable.java
@@ -36,8 +36,6 @@ import com.google.api.gax.rpc.StreamController;
 import com.google.common.base.Preconditions;
 import io.grpc.ClientCall;
 import io.grpc.MethodDescriptor;
-import io.grpc.stub.ClientCalls;
-import java.util.Iterator;
 
 /**
  * {@code GrpcDirectServerStreamingCallable} creates server-streaming gRPC calls.
@@ -68,12 +66,5 @@ class GrpcDirectServerStreamingCallable<RequestT, ResponseT>
     GrpcDirectStreamController<RequestT, ResponseT> controller =
         new GrpcDirectStreamController<>(call, responseObserver);
     controller.start(request);
-  }
-
-  @Override
-  public Iterator<ResponseT> blockingServerStreamingCall(RequestT request, ApiCallContext context) {
-    Preconditions.checkNotNull(request);
-    ClientCall<RequestT, ResponseT> call = GrpcClientCalls.newCall(descriptor, context);
-    return ClientCalls.blockingServerStreamingCall(call, request);
   }
 }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcServerStreamingRequestParamCallable.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcServerStreamingRequestParamCallable.java
@@ -35,7 +35,6 @@ import com.google.api.gax.rpc.RequestUrlParamsEncoder;
 import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.common.base.Preconditions;
-import java.util.Iterator;
 
 /**
  * A {@code ServerStreamingCallable} that extracts values from the fields of the request and inserts
@@ -60,12 +59,6 @@ class GrpcServerStreamingRequestParamCallable<RequestT, ResponseT>
   public void call(
       RequestT request, ResponseObserver<ResponseT> responseObserver, ApiCallContext context) {
     callable.call(request, responseObserver, contextWithParamsEncoder(request, context));
-  }
-
-  @Override
-  public Iterator<ResponseT> blockingServerStreamingCall(RequestT request, ApiCallContext context) {
-    return callable.blockingServerStreamingCall(
-        request, contextWithParamsEncoder(request, context));
   }
 
   private ApiCallContext contextWithParamsEncoder(RequestT request, ApiCallContext inputContext) {

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectServerStreamingCallableTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectServerStreamingCallableTest.java
@@ -36,11 +36,12 @@ import com.google.api.gax.grpc.testing.FakeServiceImpl;
 import com.google.api.gax.grpc.testing.InProcessServer;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.ResponseObserver;
+import com.google.api.gax.rpc.ServerStream;
 import com.google.api.gax.rpc.ServerStreamingCallSettings;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.StreamController;
 import com.google.api.gax.rpc.testing.FakeCallContext;
-import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import com.google.common.truth.Truth;
 import com.google.type.Color;
 import com.google.type.Money;
@@ -50,8 +51,6 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
@@ -232,9 +231,8 @@ public class GrpcDirectServerStreamingCallableTest {
   @Test
   public void testBlockingServerStreaming() throws Exception {
     Color request = Color.newBuilder().setRed(0.5f).build();
-    Iterator<Money> response = streamingCallable.blockingServerStreamingCall(request);
-    List<Money> responseData = new ArrayList<>();
-    Iterators.addAll(responseData, response);
+    ServerStream<Money> response = streamingCallable.call(request);
+    List<Money> responseData = Lists.newArrayList(response);
 
     Money expected = Money.newBuilder().setCurrencyCode("USD").setUnits(127).build();
     Truth.assertThat(responseData).containsExactly(expected);

--- a/gax/src/main/java/com/google/api/gax/rpc/QueuingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/QueuingResponseObserver.java
@@ -40,12 +40,13 @@ import java.util.concurrent.BlockingQueue;
  * <ul>
  *   <li>empty: a item has been requested and we are awaiting the next item
  *   <li>1 item: an in progress stream with 1 item buffered
- *   <li>1 control signal: either a Throwable or an EOF_MARKER means that the stream is closed
+ *   <li>1 control signal: either a Throwable, or an EOF_MARKER which means that the stream is
+ *       closed
  *   <li>1 item & 1 control signal: this is the last item of the stream
  * </ul>
  *
- * The observer can also be abruptly cancelled, which cancels the underlying call and always returns
- * an EOF_MARKER.
+ * <p>The observer can also be abruptly cancelled, which cancels the underlying call and always
+ * returns an EOF_MARKER.
  *
  * <p>Package-private for internal use.
  *
@@ -96,7 +97,7 @@ final class QueuingResponseObserver<V> implements ResponseObserver<V> {
   }
 
   /**
-   * Buffer the response. There should be at most 1 response in the buffer
+   * Buffer the response. There should be at most 1 response in the buffer.
    *
    * @param response The received response.
    */
@@ -107,7 +108,7 @@ final class QueuingResponseObserver<V> implements ResponseObserver<V> {
 
   /**
    * Enqueue the error to be thrown later on. The error might occur without a request so the queue
-   * might grow to 2 elements, in that case the previous response will be consumed first.
+   * might grow to 2 elements, and in that case the previous response will be consumed first.
    *
    * @param t The error occurred on the stream
    */

--- a/gax/src/main/java/com/google/api/gax/rpc/QueuingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/QueuingResponseObserver.java
@@ -34,7 +34,7 @@ import java.util.concurrent.BlockingQueue;
 
 /**
  * A back pressure aware bridge from a {@link ResponseObserver} to a {@link BlockingQueue}. The
- * queue size is fixed to 1 item & a close signal. The observer will manage it's own flow control
+ * queue size is fixed to 1 item and a close signal. The observer will manage its own flow control,
  * keeping the queue in one of 3 states:
  *
  * <ul>
@@ -46,6 +46,8 @@ import java.util.concurrent.BlockingQueue;
  *
  * The observer can also be abruptly cancelled, which cancels the underlying call and always returns
  * an EOF_MARKER.
+ *
+ * <p>Package-private for internal use.
  *
  * @param <V> The item type.
  */
@@ -104,8 +106,8 @@ final class QueuingResponseObserver<V> implements ResponseObserver<V> {
   }
 
   /**
-   * Enqueue the error to be thrown later on. The error might occur w/o a request so the queue might
-   * grow to 2 elements, in that case the previous response will be consumed first.
+   * Enqueue the error to be thrown later on. The error might occur without a request so the queue
+   * might grow to 2 elements, in that case the previous response will be consumed first.
    *
    * @param t The error occurred on the stream
    */

--- a/gax/src/main/java/com/google/api/gax/rpc/QueuingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/QueuingResponseObserver.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.common.collect.Queues;
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * A back pressure aware bridge from a {@link ResponseObserver} to a {@link BlockingQueue}. The
+ * queue size is fixed to 1 item & a close signal. The observer will manage it's own flow control
+ * keeping the queue in one of 3 states:
+ *
+ * <ul>
+ *   <li>empty: a item has been requested and we are awaiting the next item
+ *   <li>1 item: an in progress stream with 1 item buffered
+ *   <li>1 control signal: either a Throwable or an EOF_MARKER means that the stream is closed
+ *   <li>1 item & 1 control signal: this is the last item of the stream
+ * </ul>
+ *
+ * The observer can also be abruptly cancelled, which cancels the underlying call and always returns
+ * an EOF_MARKER.
+ *
+ * @param <V> The item type.
+ */
+final class QueuingResponseObserver<V> implements ResponseObserver<V> {
+  static final Object EOF_MARKER = new Object();
+
+  private final BlockingQueue<Object> buffer = Queues.newArrayBlockingQueue(2);
+  private StreamController controller;
+  private boolean isCancelled;
+
+  void request() {
+    controller.request(1);
+  }
+
+  Object getNext() throws InterruptedException {
+    if (isCancelled) {
+      return EOF_MARKER;
+    }
+    return buffer.take();
+  }
+
+  boolean isReady() {
+    return isCancelled || !buffer.isEmpty();
+  }
+
+  /**
+   * Cancels the underlying RPC and causes getNext to always return EOF_MARKER. This can only be
+   * called after starting the underlying call.
+   */
+  void cancel() {
+    isCancelled = true;
+    controller.cancel();
+  }
+
+  /**
+   * Before starting the RPC, disable automatic flow control and retain a reference to the
+   * controller.
+   *
+   * @param controller The controller for the stream.
+   */
+  @Override
+  public void onStart(StreamController controller) {
+    this.controller = controller;
+    controller.disableAutoInboundFlowControl();
+    controller.request(1);
+  }
+
+  /**
+   * Buffer the response. There should be at most 1 response in the buffer
+   *
+   * @param response The received response.
+   */
+  @Override
+  public void onResponse(V response) {
+    buffer.add(response);
+  }
+
+  /**
+   * Enqueue the error to be thrown later on. The error might occur w/o a request so the queue might
+   * grow to 2 elements, in that case the previous response will be consumed first.
+   *
+   * @param t The error occurred on the stream
+   */
+  @Override
+  public void onError(Throwable t) {
+    buffer.add(t);
+  }
+
+  /**
+   * Enqueue a marker to notify the consumer that the stream is finished. In most situations this
+   * will cause the queue to grow to 2 elements: the requested response and an unsolicited
+   * completion marker.
+   */
+  @Override
+  public void onComplete() {
+    buffer.add(EOF_MARKER);
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStream.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStream.java
@@ -44,7 +44,7 @@ import javax.annotation.Nonnull;
  * <p>Please note that the stream can only be consumed once and must either be fully consumed or be
  * canceled.
  *
- * <p>This class nor the iterator it returns are not thread safe.
+ * <p>Neither this class nor the iterator it returns is thread-safe.
  *
  * <p>Example usage:
  *
@@ -56,6 +56,8 @@ import javax.annotation.Nonnull;
  *
  *   // Allow for early termination
  *   if (item.id().equals("needle")) {
+ *     // Cancelling the stream will cause `hasNext()` to return false on the next iteration,
+ *     // naturally breaking the loop.
  *     stream.cancel();
  *   }
  * }

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStream.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStream.java
@@ -31,11 +31,7 @@ package com.google.api.gax.rpc;
 
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
-import com.google.common.base.Throwables;
-import com.google.common.collect.Queues;
 import java.util.Iterator;
-import java.util.NoSuchElementException;
-import java.util.concurrent.BlockingQueue;
 import javax.annotation.Nonnull;
 
 /**
@@ -69,8 +65,6 @@ import javax.annotation.Nonnull;
  */
 @BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public final class ServerStream<V> implements Iterable<V> {
-  private static final Object EOF_MARKER = new Object();
-
   private final QueuingResponseObserver<V> observer = new QueuingResponseObserver<>();
   private final ServerStreamIterator<V> iterator = new ServerStreamIterator<>(observer);
   private boolean consumed;
@@ -112,176 +106,5 @@ public final class ServerStream<V> implements Iterable<V> {
    */
   public void cancel() {
     observer.cancel();
-  }
-
-  /**
-   * Internal implementation of a blocking Iterator, which will coordinate with the
-   * QueuingResponseObserver fetch new items from upstream. The Iterator expects the observer to
-   * request the first item, afterwards, new items will be requested when the current ones are
-   * consumed by next().
-   *
-   * @param <V> The type of items to be Iterated over.
-   */
-  private static final class ServerStreamIterator<V> implements Iterator<V> {
-    private final QueuingResponseObserver<V> observer;
-    private Object last;
-
-    ServerStreamIterator(QueuingResponseObserver<V> observer) {
-      this.observer = observer;
-    }
-
-    /**
-     * Checks if the next call to {@code hasNext()} (and {@code next()}) will block.
-     *
-     * @return true if the next call is guaranteed to be nonblocking.
-     */
-    boolean isReady() {
-      return last != null || observer.isReady();
-    }
-
-    /**
-     * Consumes the next response and asynchronously request the next response from the observer.
-     *
-     * @return The next response.
-     * @throws NoSuchElementException If the stream has been consumed or cancelled.
-     */
-    @Override
-    public V next() {
-      if (!hasNext()) {
-        throw new NoSuchElementException();
-      }
-      try {
-        observer.request();
-        @SuppressWarnings("unchecked")
-        V tmp = (V) last;
-        return tmp;
-      } finally {
-        last = null;
-      }
-    }
-
-    /**
-     * Checks if the stream has been fully consumed or cancelled. This method will block until the
-     * observer enqueues another event (response or completion event). If the observer encountered
-     * an error, this method will propagte the error and put itself into an error where it will
-     * always return the same error.
-     *
-     * @return true If iterator has more responses.
-     */
-    @Override
-    public boolean hasNext() {
-      if (last == null) {
-        try {
-          last = observer.getNext();
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          throw new RuntimeException(e);
-        }
-      }
-      if (last instanceof Throwable) {
-        Throwable throwable = (Throwable) this.last;
-
-        Throwables.throwIfUnchecked(throwable);
-        throw new RuntimeException(throwable);
-      }
-      return last != EOF_MARKER;
-    }
-
-    /** Unsupported. */
-    @Override
-    public void remove() {
-      throw new UnsupportedOperationException();
-    }
-  }
-
-  /**
-   * A back pressure aware bridge from a {@link ResponseObserver} to a {@link BlockingQueue}. The
-   * queue size is fixed to 1 item & a close signal. The observer will manage it's own flow control
-   * keeping the queue in one of 3 states:
-   *
-   * <ul>
-   *   <li>empty: a item has been requested and we are awaiting the next item
-   *   <li>1 item: an in progress stream with 1 item buffered
-   *   <li>1 control signal: either a Throwable or an EOF_MARKER means that the stream is closed
-   *   <li>1 item & 1 control signal: this is the last item of the stream
-   * </ul>
-   *
-   * The observer can also be abruptly cancelled, which cancels the underlying call and always
-   * returns an EOF_MARKER.
-   *
-   * @param <V> The item type.
-   */
-  private static final class QueuingResponseObserver<V> implements ResponseObserver<V> {
-    private final BlockingQueue<Object> buffer = Queues.newArrayBlockingQueue(2);
-    private StreamController controller;
-    private boolean isCancelled;
-
-    void request() {
-      controller.request(1);
-    }
-
-    Object getNext() throws InterruptedException {
-      if (isCancelled) {
-        return EOF_MARKER;
-      }
-      return buffer.take();
-    }
-
-    boolean isReady() {
-      return isCancelled || !buffer.isEmpty();
-    }
-
-    /**
-     * Cancels the underlying RPC and causes getNext to always return EOF_MARKER. This can only be
-     * called after starting the underlying call.
-     */
-    void cancel() {
-      isCancelled = true;
-      controller.cancel();
-    }
-
-    /**
-     * Before starting the RPC, disable automatic flow control and retain a reference to the
-     * controller.
-     *
-     * @param controller The controller for the stream.
-     */
-    @Override
-    public void onStart(StreamController controller) {
-      this.controller = controller;
-      controller.disableAutoInboundFlowControl();
-      controller.request(1);
-    }
-
-    /**
-     * Buffer the response. There should be at most 1 response in the buffer
-     *
-     * @param response The received response.
-     */
-    @Override
-    public void onResponse(V response) {
-      buffer.add(response);
-    }
-
-    /**
-     * Enqueue the error to be thrown later on. The error might occur w/o a request so the queue
-     * might grow to 2 elements, in that case the previous response will be consumed first.
-     *
-     * @param t The error occurred on the stream
-     */
-    @Override
-    public void onError(Throwable t) {
-      buffer.add(t);
-    }
-
-    /**
-     * Enqueue a marker to notify the consumer that the stream is finished. In most situations this
-     * will cause the queue to grow to 2 elements: the requested response and an unsolicited
-     * completion marker.
-     */
-    @Override
-    public void onComplete() {
-      buffer.add(EOF_MARKER);
-    }
   }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStream.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStream.java
@@ -44,7 +44,7 @@ import javax.annotation.Nonnull;
  * <p>Please note that the stream can only be consumed once and must either be fully consumed or be
  * canceled.
  *
- * <p>This class is not thread safe.
+ * <p>This class nor the iterator it returns are not thread safe.
  *
  * <p>Example usage:
  *

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStream.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStream.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Queues;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.concurrent.BlockingQueue;
+import javax.annotation.Nonnull;
+
+/**
+ * A blocking Iterable-style wrapper around server stream responses.
+ *
+ * <p>This class asynchronously pulls responses from upstream via {@link
+ * StreamController#request(int)} and exposes them via its Iterator. The implementation is back
+ * pressure aware and uses a constant buffer of 1 item.
+ *
+ * <p>Please note that the stream can only be consumed once and must either be fully consumed or be
+ * canceled.
+ *
+ * <p>This class is not thread safe.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * ServerStream<Item> stream = ...;
+ *
+ * for (Item item : stream) {
+ *   System.out.println(item.id());
+ *
+ *   // Allow for early termination
+ *   if (item.id().equals("needle")) {
+ *     stream.cancel();
+ *   }
+ * }
+ * }</pre>
+ *
+ * @param <V> The type of each response.
+ */
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
+public final class ServerStream<V> implements Iterable<V> {
+  private static final Object EOF_MARKER = new Object();
+
+  private final QueuingResponseObserver<V> observer = new QueuingResponseObserver<>();
+  private final ServerStreamIterator<V> iterator = new ServerStreamIterator<>(observer);
+  private boolean consumed;
+
+  @InternalApi("For use by ServerStreamingCallable only.")
+  ServerStream() {}
+
+  @InternalApi("For use by ServerStreamingCallable only.")
+  ResponseObserver<V> observer() {
+    return observer;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  @Nonnull
+  public Iterator<V> iterator() {
+    if (consumed) {
+      throw new IllegalStateException("Iterator already consumed");
+    }
+    consumed = true;
+
+    return iterator;
+  }
+
+  /**
+   * Returns true if the next call to the iterator's hasNext() or next() is guaranteed to be
+   * nonblocking.
+   *
+   * @return If the call on any of the iterator's methods is guaranteed to be nonblocking.
+   */
+  public boolean isReady() {
+    return iterator.isReady();
+  }
+
+  /**
+   * Cleanly cancels a partially consumed stream. The associated iterator will return false for the
+   * hasNext() in the next iteration. This maintains the contract that an observed true from
+   * hasNext() will yield an item in next(), but afterwards will return false.
+   */
+  public void cancel() {
+    observer.cancel();
+  }
+
+  /**
+   * Internal implementation of a blocking Iterator, which will coordinate with the
+   * QueuingResponseObserver fetch new items from upstream. The Iterator expects the observer to
+   * request the first item, afterwards, new items will be requested when the current ones are
+   * consumed by next().
+   *
+   * @param <V> The type of items to be Iterated over.
+   */
+  private static final class ServerStreamIterator<V> implements Iterator<V> {
+    private final QueuingResponseObserver<V> observer;
+    private Object last;
+
+    ServerStreamIterator(QueuingResponseObserver<V> observer) {
+      this.observer = observer;
+    }
+
+    /**
+     * Checks if the next call to {@code hasNext()} (and {@code next()}) will block.
+     *
+     * @return true if the next call is guaranteed to be nonblocking.
+     */
+    boolean isReady() {
+      return last != null || observer.isReady();
+    }
+
+    /**
+     * Consumes the next response and asynchronously request the next response from the observer.
+     *
+     * @return The next response.
+     * @throws NoSuchElementException If the stream has been consumed or cancelled.
+     */
+    @Override
+    public V next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      try {
+        observer.request();
+        @SuppressWarnings("unchecked")
+        V tmp = (V) last;
+        return tmp;
+      } finally {
+        last = null;
+      }
+    }
+
+    /**
+     * Checks if the stream has been fully consumed or cancelled. This method will block until the
+     * observer enqueues another event (response or completion event). If the observer encountered
+     * an error, this method will propagte the error and put itself into an error where it will
+     * always return the same error.
+     *
+     * @return true If iterator has more responses.
+     */
+    @Override
+    public boolean hasNext() {
+      if (last == null) {
+        try {
+          last = observer.getNext();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new RuntimeException(e);
+        }
+      }
+      if (last instanceof Throwable) {
+        Throwable throwable = (Throwable) this.last;
+
+        Throwables.throwIfUnchecked(throwable);
+        throw new RuntimeException(throwable);
+      }
+      return last != EOF_MARKER;
+    }
+
+    /** Unsupported. */
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  /**
+   * A back pressure aware bridge from a {@link ResponseObserver} to a {@link BlockingQueue}. The
+   * queue size is fixed to 1 item & a close signal. The observer will manage it's own flow control
+   * keeping the queue in one of 3 states:
+   *
+   * <ul>
+   *   <li>empty: a item has been requested and we are awaiting the next item
+   *   <li>1 item: an in progress stream with 1 item buffered
+   *   <li>1 control signal: either a Throwable or an EOF_MARKER means that the stream is closed
+   *   <li>1 item & 1 control signal: this is the last item of the stream
+   * </ul>
+   *
+   * The observer can also be abruptly cancelled, which cancels the underlying call and always
+   * returns an EOF_MARKER.
+   *
+   * @param <V> The item type.
+   */
+  private static final class QueuingResponseObserver<V> implements ResponseObserver<V> {
+    private final BlockingQueue<Object> buffer = Queues.newArrayBlockingQueue(2);
+    private StreamController controller;
+    private boolean isCancelled;
+
+    void request() {
+      controller.request(1);
+    }
+
+    Object getNext() throws InterruptedException {
+      if (isCancelled) {
+        return EOF_MARKER;
+      }
+      return buffer.take();
+    }
+
+    boolean isReady() {
+      return isCancelled || !buffer.isEmpty();
+    }
+
+    /**
+     * Cancels the underlying RPC and causes getNext to always return EOF_MARKER. This can only be
+     * called after starting the underlying call.
+     */
+    void cancel() {
+      isCancelled = true;
+      controller.cancel();
+    }
+
+    /**
+     * Before starting the RPC, disable automatic flow control and retain a reference to the
+     * controller.
+     *
+     * @param controller The controller for the stream.
+     */
+    @Override
+    public void onStart(StreamController controller) {
+      this.controller = controller;
+      controller.disableAutoInboundFlowControl();
+      controller.request(1);
+    }
+
+    /**
+     * Buffer the response. There should be at most 1 response in the buffer
+     *
+     * @param response The received response.
+     */
+    @Override
+    public void onResponse(V response) {
+      buffer.add(response);
+    }
+
+    /**
+     * Enqueue the error to be thrown later on. The error might occur w/o a request so the queue
+     * might grow to 2 elements, in that case the previous response will be consumed first.
+     *
+     * @param t The error occurred on the stream
+     */
+    @Override
+    public void onError(Throwable t) {
+      buffer.add(t);
+    }
+
+    /**
+     * Enqueue a marker to notify the consumer that the stream is finished. In most situations this
+     * will cause the queue to grow to 2 elements: the requested response and an unsolicited
+     * completion marker.
+     */
+    @Override
+    public void onComplete() {
+      buffer.add(EOF_MARKER);
+    }
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamIterator.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamIterator.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.common.base.Throwables;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Internal implementation of a blocking Iterator, which will coordinate with the
+ * QueuingResponseObserver to fetch new items from upstream. The Iterator expects the observer to
+ * request the first item, afterwards, new items will be requested when the current ones are
+ * consumed by next().
+ *
+ * @param <V> The type of items to be Iterated over.
+ */
+final class ServerStreamIterator<V> implements Iterator<V> {
+  private final QueuingResponseObserver<V> observer;
+  private Object last;
+
+  ServerStreamIterator(QueuingResponseObserver<V> observer) {
+    this.observer = observer;
+  }
+
+  /**
+   * Checks if the next call to {@code hasNext()} (and {@code next()}) will block.
+   *
+   * @return true if the next call is guaranteed to be nonblocking.
+   */
+  boolean isReady() {
+    return last != null || observer.isReady();
+  }
+
+  /**
+   * Consumes the next response and asynchronously request the next response from the observer.
+   *
+   * @return The next response.
+   * @throws NoSuchElementException If the stream has been consumed or cancelled.
+   */
+  @Override
+  public V next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    try {
+      observer.request();
+      @SuppressWarnings("unchecked")
+      V tmp = (V) last;
+      return tmp;
+    } finally {
+      last = null;
+    }
+  }
+
+  /**
+   * Checks if the stream has been fully consumed or cancelled. This method will block until the
+   * observer enqueues another event (response or completion event). If the observer encountered an
+   * error, this method will propagte the error and put itself into an error where it will always
+   * return the same error.
+   *
+   * @return true If iterator has more responses.
+   */
+  @Override
+  public boolean hasNext() {
+    if (last == null) {
+      try {
+        last = observer.getNext();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+    }
+    if (last instanceof Throwable) {
+      Throwable throwable = (Throwable) this.last;
+
+      Throwables.throwIfUnchecked(throwable);
+      throw new RuntimeException(throwable);
+    }
+    return last != QueuingResponseObserver.EOF_MARKER;
+  }
+
+  /** Unsupported. */
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamIterator.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamIterator.java
@@ -39,6 +39,8 @@ import java.util.NoSuchElementException;
  * request the first item, afterwards, new items will be requested when the current ones are
  * consumed by next().
  *
+ * <p>Package-private for internal use.
+ *
  * @param <V> The type of items to be Iterated over.
  */
 final class ServerStreamIterator<V> implements Iterator<V> {
@@ -82,7 +84,7 @@ final class ServerStreamIterator<V> implements Iterator<V> {
   /**
    * Checks if the stream has been fully consumed or cancelled. This method will block until the
    * observer enqueues another event (response or completion event). If the observer encountered an
-   * error, this method will propagte the error and put itself into an error where it will always
+   * error, this method will propagate the error and put itself into an error where it will always
    * return the same error.
    *
    * @return true If iterator has more responses.
@@ -98,7 +100,7 @@ final class ServerStreamIterator<V> implements Iterator<V> {
       }
     }
     if (last instanceof Throwable) {
-      Throwable throwable = (Throwable) this.last;
+      Throwable throwable = (Throwable) last;
 
       Throwables.throwIfUnchecked(throwable);
       throw new RuntimeException(throwable);

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamIterator.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamIterator.java
@@ -36,7 +36,7 @@ import java.util.NoSuchElementException;
 /**
  * Internal implementation of a blocking Iterator, which will coordinate with the
  * QueuingResponseObserver to fetch new items from upstream. The Iterator expects the observer to
- * request the first item, afterwards, new items will be requested when the current ones are
+ * request the first item, and afterwards, new items will be requested when the current ones are
  * consumed by next().
  *
  * <p>Package-private for internal use.

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
@@ -55,6 +55,8 @@ public abstract class ServerStreamingCallable<RequestT, ResponseT> {
    * ServerStream stream = streamingCallable.call(request)
    * for (String s : stream) {
    *   if ("needle".equals(s)) {
+   *     // Cancelling the stream will cause `hasNext()` to return false on the next iteration,
+   *     // naturally breaking the loop.
    *     stream.cancel();
    *   }
    * }
@@ -135,7 +137,7 @@ public abstract class ServerStreamingCallable<RequestT, ResponseT> {
   }
 
   /**
-   * Conduct a iteration server streaming call
+   * Conduct an iteration server streaming call
    *
    * @param request request
    * @param context context

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
@@ -46,6 +46,46 @@ public abstract class ServerStreamingCallable<RequestT, ResponseT> {
   protected ServerStreamingCallable() {}
 
   /**
+   * Conduct a iteration server streaming call.
+   *
+   * <p>This returns a live stream that must either be fully consumed or cancelled. Example usage:
+   *
+   * <pre>{@code
+   * StreamingCallable<String> streamingCallable = // ..
+   * ServerStream stream = streamingCallable.call(request)
+   * for (String s : stream) {
+   *   if ("needle".equals(s)) {
+   *     stream.cancel();
+   *   }
+   * }
+   * List<String></String> theResult = streamingCallable.all().call(request);
+   * ApiFuture<List<String>> theResult = streamingCallable.all().futureCall(request);
+   * }</pre>
+   *
+   * @param request request
+   * @return {@link ServerStream} which is used for iterating the responses.
+   */
+  public ServerStream<ResponseT> call(RequestT request) {
+    return call(request, (ApiCallContext) null);
+  }
+
+  /**
+   * Conduct a server streaming call with the given {@link ApiCallContext}.
+   *
+   * <p>This returns a live stream that must either be fully consumed or cancelled.
+   *
+   * @param request request
+   * @param context the context
+   * @return {@link ServerStream} which is used for iterating the responses.
+   */
+  public ServerStream<ResponseT> call(RequestT request, ApiCallContext context) {
+    ServerStream<ResponseT> stream = new ServerStream<>();
+    call(request, stream.observer(), context);
+
+    return stream;
+  }
+
+  /**
    * Conduct a server streaming call with the given {@link ApiCallContext}.
    *
    * @param request request
@@ -98,11 +138,23 @@ public abstract class ServerStreamingCallable<RequestT, ResponseT> {
    * Conduct a iteration server streaming call
    *
    * @param request request
+   * @param context context
    * @return {@link Iterator} which is used for iterating the responses.
+   * @deprecated Please use call() instead.
    */
-  public abstract Iterator<ResponseT> blockingServerStreamingCall(
-      RequestT request, ApiCallContext context);
+  @Deprecated
+  public Iterator<ResponseT> blockingServerStreamingCall(RequestT request, ApiCallContext context) {
+    return call(request, context).iterator();
+  }
 
+  /**
+   * Conduct a iteration server streaming call
+   *
+   * @param request request
+   * @return {@link Iterator} which is used for iterating the responses.
+   * @deprecated Please use call() instead.
+   */
+  @Deprecated
   public Iterator<ResponseT> blockingServerStreamingCall(RequestT request) {
     return blockingServerStreamingCall(request, null);
   }
@@ -123,13 +175,6 @@ public abstract class ServerStreamingCallable<RequestT, ResponseT> {
           ApiCallContext thisCallContext) {
         ServerStreamingCallable.this.call(
             request, responseObserver, defaultCallContext.merge(thisCallContext));
-      }
-
-      @Override
-      public Iterator<ResponseT> blockingServerStreamingCall(
-          RequestT request, ApiCallContext thisCallContext) {
-        return ServerStreamingCallable.this.blockingServerStreamingCall(
-            request, defaultCallContext.merge(thisCallContext));
       }
     };
   }

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.SettableApiFuture;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Queues;
+import com.google.common.truth.Truth;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ServerStreamTest {
+  private TestStreamController controller;
+  private ServerStream<Integer> stream;
+  private ExecutorService executor;
+
+  @Rule public ExpectedException expectedException = ExpectedException.none();
+
+  @Before
+  public void setUp() throws Exception {
+    controller = new TestStreamController();
+    stream = new ServerStream<>();
+
+    stream.observer().onStart(controller);
+    executor = Executors.newSingleThreadExecutor();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    executor.shutdownNow();
+  }
+
+  @Test
+  public void testEmptyStream() {
+    stream.observer().onStart(controller);
+    stream.observer().onComplete();
+
+    Truth.assertThat(Lists.newArrayList(stream)).isEmpty();
+  }
+
+  @Test
+  public void testMultipleItemStream() throws InterruptedException {
+    executor.submit(
+        new Callable<Void>() {
+          @Override
+          public Void call() throws InterruptedException {
+            for (int i = 0; i < 5; i++) {
+              int requestCount = controller.requests.poll(1, TimeUnit.SECONDS);
+
+              Truth.assertWithMessage("ServerStream should request one item at a time")
+                  .that(requestCount)
+                  .isEqualTo(1);
+
+              stream.observer().onResponse(i);
+            }
+            stream.observer().onComplete();
+            return null;
+          }
+        });
+
+    Truth.assertThat(Lists.newArrayList(stream)).containsExactly(0, 1, 2, 3, 4);
+  }
+
+  @Test
+  public void testEarlyTermination() throws Exception {
+    executor.submit(
+        new Callable<Void>() {
+          @Override
+          public Void call() throws InterruptedException, ExecutionException, TimeoutException {
+            int i = 0;
+            while (controller.requests.poll(500, TimeUnit.MILLISECONDS) != null) {
+              stream.observer().onResponse(i++);
+            }
+            Throwable cancelException = controller.cancelFuture.get(1, TimeUnit.SECONDS);
+            stream.observer().onError(cancelException);
+            return null;
+          }
+        });
+
+    List<Integer> results = Lists.newArrayList();
+    for (Integer result : stream) {
+      results.add(result);
+
+      if (result == 1) {
+        stream.cancel();
+      }
+    }
+
+    Truth.assertThat(results).containsExactly(0, 1);
+  }
+
+  @Test
+  public void testErrorPropagation() {
+    ClassCastException e = new ClassCastException("fake error");
+
+    stream.observer().onError(e);
+    expectedException.expectMessage(e.getMessage());
+    expectedException.expect(ClassCastException.class);
+
+    Lists.newArrayList(stream);
+  }
+
+  @Test
+  public void testNoErrorsBetweenHasNextAndNext() throws InterruptedException {
+    Iterator<Integer> it = stream.iterator();
+
+    controller.requests.poll(1, TimeUnit.SECONDS);
+    stream.observer().onResponse(1);
+
+    Truth.assertThat(it.hasNext()).isTrue();
+
+    RuntimeException fakeError = new RuntimeException("fake");
+    stream.observer().onError(fakeError);
+    Truth.assertThat(it.next()).isEqualTo(1);
+
+    // Now the error should be thrown
+    try {
+      it.next();
+      throw new RuntimeException("ServerStream never threw an error!");
+    } catch (RuntimeException e) {
+      Truth.assertThat(e).isSameAs(fakeError);
+    }
+  }
+
+  @Test
+  public void testReady() throws InterruptedException {
+    Iterator<Integer> it = stream.iterator();
+    Truth.assertThat(stream.isReady()).isFalse();
+
+    controller.requests.poll(1, TimeUnit.SECONDS);
+    stream.observer().onResponse(1);
+    Truth.assertThat(stream.isReady()).isTrue();
+
+    it.next();
+    Truth.assertThat(stream.isReady()).isFalse();
+  }
+
+  private static class TestStreamController implements StreamController {
+    SettableApiFuture<Throwable> cancelFuture = SettableApiFuture.create();
+    BlockingQueue<Integer> requests = Queues.newLinkedBlockingDeque();
+    boolean autoFlowControl = true;
+
+    @Override
+    public void cancel() {
+      cancelFuture.set(new CancellationException("User cancelled stream"));
+    }
+
+    @Override
+    public void disableAutoInboundFlowControl() {
+      autoFlowControl = false;
+    }
+
+    @Override
+    public void request(int count) {
+      requests.add(count);
+    }
+  }
+}

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallableTest.java
@@ -164,9 +164,7 @@ public class ServerStreamingCallableTest {
             callIntList,
             StreamingCallSettings.<Integer, Integer>newBuilder().build(),
             clientContext);
-    Truth.assertThat(ImmutableList.copyOf(callable.blockingServerStreamingCall(0)))
-        .containsExactly(0, 1, 2)
-        .inOrder();
+    Truth.assertThat(ImmutableList.copyOf(callable.call(0))).containsExactly(0, 1, 2).inOrder();
     Truth.assertThat(callIntList.getActualRequest()).isEqualTo(0);
   }
 
@@ -178,7 +176,7 @@ public class ServerStreamingCallableTest {
     ServerStreamingCallable<Integer, Integer> callable =
         stashCallable.withDefaultCallContext(defaultCallContext);
     Integer request = 1;
-    callable.blockingServerStreamingCall(request);
+    callable.call(request);
     Truth.assertThat(stashCallable.getActualRequest()).isSameAs(request);
     Truth.assertThat(stashCallable.getContext()).isSameAs(defaultCallContext);
   }
@@ -194,7 +192,7 @@ public class ServerStreamingCallableTest {
     ServerStreamingCallable<Integer, Integer> callable =
         stashCallable.withDefaultCallContext(FakeCallContext.createDefault());
     Integer request = 1;
-    callable.blockingServerStreamingCall(request, context);
+    callable.call(request, context);
     Truth.assertThat(stashCallable.getActualRequest()).isSameAs(request);
     FakeCallContext actualContext = (FakeCallContext) stashCallable.getContext();
     Truth.assertThat(actualContext.getChannel()).isSameAs(channel);

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeStreamingApi.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeStreamingApi.java
@@ -42,7 +42,6 @@ import com.google.api.gax.rpc.StreamController;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Queues;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CancellationException;
@@ -154,14 +153,6 @@ public class FakeStreamingApi {
       StreamControllerStash<ResponseT> controller =
           new StreamControllerStash<>(responseList, responseObserver);
       controller.start();
-    }
-
-    @Override
-    public Iterator<ResponseT> blockingServerStreamingCall(
-        RequestT request, ApiCallContext context) {
-      this.actualRequest = request;
-      this.context = context;
-      return responseList.iterator();
     }
 
     public ApiCallContext getContext() {


### PR DESCRIPTION
Currently gax relies on grpc-stub to make this conversion, which makes it hard to compose ServerStreamingCallables. By pulling the implementation into gax, it allows for ServerStreamingCallables to be composed using simple call(Request, ResponseObserver, Context) chaining.  Furthermore, this adds the ability to cleanly cancel partially consumed streams.