### PR TITLE
Reframer: add a helper to mediate m:n server streaming response transformations

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/IncompleteStreamException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/IncompleteStreamException.java
@@ -38,6 +38,6 @@ import com.google.api.core.BetaApi;
 @BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public class IncompleteStreamException extends RuntimeException {
   IncompleteStreamException() {
-    super("Upstream closed too early leaving an incomplete response.");
+    super("Upstream closed too early, leaving an incomplete response.");
   }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/IncompleteStreamException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/IncompleteStreamException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.BetaApi;
+
+/**
+ * Thrown by {@link ReframingResponseObserver} to signal that a stream closed prematurely, leaving
+ * behind a partial filled buffer.
+ */
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
+public class IncompleteStreamException extends RuntimeException {
+  IncompleteStreamException() {
+    super("Upstream closed too early leaving an incomplete response.");
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/Reframer.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Reframer.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.BetaApi;
+
+/**
+ * Interface for the business logic of the stream transformation. All method will be called in a
+ * synchronized so implementations don't need to be thread safe or be concerned with back pressure.
+ *
+ * <p>The flow is:
+ *
+ * <pre>
+ * hasFullFrame?
+ *  -&gt; true -&gt; pop()
+ *  -&gt; false
+ *    -&gt; upstream complete?
+ *      -&gt; true
+ *        -&gt; hasPartialFrame?
+ *          -&gt; true
+ *            =&gt; notify error
+ *          -&gt; false
+ *            =&gt; notify complete
+ *      -&gt; false
+ *        =&gt; push() and restart at hasFullFrame?
+ * </pre>
+ *
+ * @param <InnerT> The type of responses coming from the inner ServerStreamingCallable.
+ * @param <OuterT> The type of responses the outer {@link ResponseObserver} expects.
+ */
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
+public interface Reframer<OuterT, InnerT> {
+  /**
+   * Refill internal buffers with inner/upstream response. Will only be invoked if hasFullFrame
+   * returns false.
+   */
+  void push(InnerT response);
+
+  /** Checks if there is a frame to be popped. */
+  boolean hasFullFrame();
+
+  /** Checks if there is any incomplete data. Used to check if the stream closed prematurely. */
+  boolean hasPartialFrame();
+
+  /**
+   * Returns and removes the current completed frame. Will only be called if hasFullFrame returns
+   * true.
+   */
+  OuterT pop();
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/Reframer.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Reframer.java
@@ -32,7 +32,7 @@ package com.google.api.gax.rpc;
 import com.google.api.core.BetaApi;
 
 /**
- * Interface for the business logic of the stream transformation. All method will be called in a
+ * Interface for the business logic of a stream transformation. All method will be called in a
  * synchronized so implementations don't need to be thread safe or be concerned with back pressure.
  *
  * <p>The flow is:
@@ -58,7 +58,7 @@ import com.google.api.core.BetaApi;
 @BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public interface Reframer<OuterT, InnerT> {
   /**
-   * Refill internal buffers with inner/upstream response. Will only be invoked if hasFullFrame
+   * Refill internal buffers with inner/upstream response. Should only be invoked if hasFullFrame
    * returns false.
    */
   void push(InnerT response);
@@ -70,7 +70,7 @@ public interface Reframer<OuterT, InnerT> {
   boolean hasPartialFrame();
 
   /**
-   * Returns and removes the current completed frame. Will only be called if hasFullFrame returns
+   * Returns and removes the current completed frame. Should only be called if hasFullFrame returns
    * true.
    */
   OuterT pop();

--- a/gax/src/main/java/com/google/api/gax/rpc/Reframer.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Reframer.java
@@ -32,8 +32,9 @@ package com.google.api.gax.rpc;
 import com.google.api.core.BetaApi;
 
 /**
- * Interface for the business logic of a stream transformation. All method will be called in a
- * synchronized so implementations don't need to be thread safe or be concerned with back pressure.
+ * Interface for the business logic of a stream transformation. All methods will be called in a
+ * synchronized block, so implementations don't need to be thread safe or be concerned with back
+ * pressure.
  *
  * <p>The flow is:
  *
@@ -58,8 +59,8 @@ import com.google.api.core.BetaApi;
 @BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public interface Reframer<OuterT, InnerT> {
   /**
-   * Refill internal buffers with inner/upstream response. Should only be invoked if hasFullFrame
-   * returns false.
+   * Refill internal buffers with inner/upstream response. Should only be invoked if {@link
+   * #hasFullFrame} returns false.
    */
   void push(InnerT response);
 

--- a/gax/src/main/java/com/google/api/gax/rpc/ReframingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ReframingResponseObserver.java
@@ -238,10 +238,6 @@ public class ReframingResponseObserver<InnerT, OuterT> implements ResponseObserv
     deliver();
   }
 
-  /**
-   * The message pump that interacts with the {@link this#outerResponseObserver}. All interactions
-   * with outer {@link ResponseObserver} will be serialized via this method.
-   */
   /** Tries to kick off the delivery loop, wrapping it in error handling. */
   private void deliver() {
     // Ensure mutual exclusion via the inDelivery flag, if there is a currently active delivery

--- a/gax/src/main/java/com/google/api/gax/rpc/ReframingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ReframingResponseObserver.java
@@ -39,11 +39,11 @@ import javax.annotation.concurrent.GuardedBy;
  * stream needs to be transformed in such a way where the incoming responses do not map 1:1 to the
  * output responses.
  *
- * <p>It manages back pressure between M upstream responses and N downstream responses. This
- * class buffers responses when M &gt; N and spools them when M &lt; N. The downstream responses
- * will be delivered via either the upstream thread or the downstream thread that called request(),
- * in either case, the downstream methods will be invoked sequentially. Neither the downstream
- * {@link ResponseObserver} nor the {@link Reframer} need to be threadsafe.
+ * <p>It manages back pressure between M upstream responses and N downstream responses. This class
+ * buffers responses when M &gt; N and spools them when M &lt; N. The downstream responses will be
+ * delivered via either the upstream thread or the downstream thread that called request(), in
+ * either case, the downstream methods will be invoked sequentially. Neither the downstream {@link
+ * ResponseObserver} nor the {@link Reframer} need to be threadsafe.
  *
  * <p>All invocations to the {@link Reframer} will be made while holding a lock.
  *

--- a/gax/src/main/java/com/google/api/gax/rpc/ReframingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ReframingResponseObserver.java
@@ -39,7 +39,7 @@ import javax.annotation.concurrent.GuardedBy;
  * stream needs to be transformed in such a way where the incoming responses do not map 1:1 to the
  * output responses.
  *
- * <p>It manages back pressure between M upstream responses represent N downstream responses. This
+ * <p>It manages back pressure between M upstream responses and N downstream responses. This
  * class buffers responses when M &gt; N and spools them when M &lt; N. The downstream responses
  * will be delivered via either the upstream thread or the downstream thread that called request(),
  * in either case, the downstream methods will be invoked sequentially. Neither the downstream
@@ -97,7 +97,7 @@ public class ReframingResponseObserver<InnerT, OuterT> implements ResponseObserv
   // However, when a stream is cancelled, the errors should be immediate
   @GuardedBy("lock")
   private boolean deferError = true;
-  // Deferred delivery stop: the upstream is exhausted, request down notification when internal buffers are exhausted
+  // Deferred delivery stop: the upstream is exhausted, request downstream notification when internal buffers are exhausted
   @GuardedBy("lock")
   private boolean closeOnDone;
   // When closing signal error.

--- a/gax/src/main/java/com/google/api/gax/rpc/ReframingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ReframingResponseObserver.java
@@ -35,17 +35,17 @@ import java.util.concurrent.CancellationException;
 import javax.annotation.concurrent.GuardedBy;
 
 /**
- * Mediates message flow between 2 {@link ResponseObserver}s. Its intended for situations when a
+ * Mediates message flow between two {@link ResponseObserver}s. It is intended for situations when a
  * stream needs to be transformed in such a way where the incoming responses do not map 1:1 to the
  * output responses.
  *
  * <p>It manages back pressure between M upstream responses and N downstream responses. This class
  * buffers responses when M &gt; N and spools them when M &lt; N. The downstream responses will be
- * delivered via either the upstream thread or the downstream thread that called request(), in
+ * delivered via either the upstream thread or the downstream thread that called request(); in
  * either case, the downstream methods will be invoked sequentially. Neither the downstream {@link
  * ResponseObserver} nor the {@link Reframer} need to be threadsafe.
  *
- * <p>All invocations to the {@link Reframer} will be made while holding a lock.
+ * <p>All invocations to the {@link Reframer} are made while holding a lock.
  *
  * <p>Expected usage:
  *
@@ -136,12 +136,12 @@ public class ReframingResponseObserver<InnerT, OuterT> implements ResponseObserv
 
           @Override
           public void request(int count) {
-            onRequest(count);
+            ReframingResponseObserver.this.onRequest(count);
           }
 
           @Override
           public void cancel() {
-            onCancel();
+            ReframingResponseObserver.this.onCancel();
           }
         });
 
@@ -209,7 +209,7 @@ public class ReframingResponseObserver<InnerT, OuterT> implements ResponseObserv
 
   /**
    * Process inner/upstream callable's onError notification. This will be queued to be delivered
-   * after the delegate exhausts it's buffers.
+   * after the delegate exhausts its buffers.
    *
    * <p>If the delivery loop is stopped, this will restart it.
    */
@@ -226,7 +226,7 @@ public class ReframingResponseObserver<InnerT, OuterT> implements ResponseObserv
 
   /**
    * Process inner/upstream callable's onComplete notification. This will be queued to be delivered
-   * after the delegate exhausts it's buffers.
+   * after the delegate exhausts its buffers.
    *
    * <p>If the delivery loop is stopped, this will restart it.
    */
@@ -267,7 +267,7 @@ public class ReframingResponseObserver<InnerT, OuterT> implements ResponseObserv
     DELIVER,
     /** There is demand but no supply, so request more from upstream */
     REQUEST_MORE,
-    /** There is demand but no supply and with an outstanding request , so do nothing */
+    /** There is demand but no supply and with an outstanding request, so do nothing */
     AWAIT_MORE_DATA,
     /** Demand has been fully supplied */
     FULFILLED,
@@ -277,9 +277,9 @@ public class ReframingResponseObserver<InnerT, OuterT> implements ResponseObserv
 
   /**
    * Coordinates state transfer between inner/downstream callable and the outer/upstream. It
-   * orchestrates the flow of demand from downstream to upstream. The data flow from upstream
-   * through the delegate to downstream. It's back pressure aware and will only send as many
-   * messages that were requested. However it will send unsolicited onComplete & onError messages.
+   * orchestrates the flow of demand from downstream to upstream. The data flows from upstream
+   * through the delegate to downstream. It is back pressure aware and will only send as many
+   * messages as were requested. However, it will send unsolicited onComplete & onError messages.
    *
    * <p>This method is thread safe and performs all state changes (including interactions with the
    * Reframer) in a synchronized block. The lock is released when interacting with outer/downstream

--- a/gax/src/main/java/com/google/api/gax/rpc/ReframingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ReframingResponseObserver.java
@@ -1,0 +1,420 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.BetaApi;
+import com.google.common.base.Preconditions;
+import java.util.concurrent.CancellationException;
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * Mediates message flow between 2 {@link ResponseObserver}s. Its intended for situations when a
+ * stream needs to be transformed in such a way where the incoming responses do not map 1:1 to the
+ * output responses.
+ *
+ * <p>It manages back pressure between M upstream responses represent N downstream responses. This
+ * class buffers responses when M &gt; N and spools them when M &lt; N. The downstream responses
+ * will be delivered via either the upstream thread or the downstream thread that called request(),
+ * in either case, the downstream methods will be invoked sequentially. Neither the downstream
+ * {@link ResponseObserver} nor the {@link Reframer} need to be threadsafe.
+ *
+ * <p>All invocations to the {@link Reframer} will be made while holding a lock.
+ *
+ * <p>Expected usage:
+ *
+ * <pre>{@code
+ *  class OuterStreamingCallable extends ServerStreamingCallable<Request, FullResponse> {
+ *    private final ServerStreamingCallable<Request, Chunk> innerCallable;
+ *
+ *    OuterStreamingCallable(ServerStreamingCallable<Request, Chunk> innerCallable) {
+ *      this.innerCallable = innerCallable;
+ *    }
+ *
+ *    public void call(Request request, ResponseObserver<FullResponse> outerObserver,
+ * ApiCallContext context) {
+ *      Reframer<Chunk, FullResponse> myReframer = new Reframer<>();
+ *      innerCallable.call(request, new ReframingResponseObserver(myReframer, outerObserver),
+ * context);
+ *    }
+ *  }
+ * }</pre>
+ */
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
+public class ReframingResponseObserver<InnerT, OuterT> implements ResponseObserver<InnerT> {
+  private final Object lock = new Object();
+
+  @GuardedBy("lock")
+  private final ResponseObserver<OuterT> outerResponseObserver;
+
+  @GuardedBy("lock")
+  private final Reframer<OuterT, InnerT> reframer;
+
+  private StreamController innerController;
+  private boolean hasStarted;
+  private boolean autoFlowControl = true;
+
+  @GuardedBy("lock")
+  private int numPending;
+
+  /** Delivery mutual exclusion: only one thread can be delivering at a time */
+  @GuardedBy("lock")
+  private boolean inDelivery;
+  /** When another thread is delivering, signal it to take an extra run to pick up changes */
+  @GuardedBy("lock")
+  private boolean missed;
+
+  // Request mutex: only one upstream request can be active at a time
+  @GuardedBy("lock")
+  private boolean awaitingInner;
+  // By default all errors should be deferred until buffers have been exhausted
+  // However, when a stream is cancelled, the errors should be immediate
+  @GuardedBy("lock")
+  private boolean deferError = true;
+  // Deferred delivery stop: the upstream is exhausted, request down notification when internal buffers are exhausted
+  @GuardedBy("lock")
+  private boolean closeOnDone;
+  // When closing signal error.
+  @GuardedBy("lock")
+  private Throwable error;
+  // This stream has been closed, prevent further processing.
+  @GuardedBy("lock")
+  private boolean closed;
+
+  public static class IncompleteStreamException extends RuntimeException {
+
+    IncompleteStreamException() {
+      super("Upstream closed too early leaving an incomplete response.");
+    }
+  }
+
+  /**
+   * Interface for the business logic of the stream transformation. All method will be called in a
+   * synchronized so implementations don't need to be thread safe or be concerned with back
+   * pressure.
+   *
+   * <p>The flow is:
+   *
+   * <pre>
+   * hasFullFrame?
+   *  -&gt; true -&gt; pop()
+   *  -&gt; false
+   *    -&gt; upstream complete?
+   *      -&gt; true
+   *        -&gt; hasPartialFrame?
+   *          -&gt; true
+   *            =&gt; notify error
+   *          -&gt; false
+   *            =&gt; notify complete
+   *      -&gt; false
+   *        =&gt; push() and restart at hasFullFrame?
+   * </pre>
+   *
+   * @param <InnerT> The type of responses coming from the inner ServerStreamingCallable.
+   * @param <OuterT> The type of responses the outer {@link ResponseObserver} expects.
+   */
+  public interface Reframer<OuterT, InnerT> {
+    /**
+     * Refill internal buffers with inner/upstream response. Will only be invoked if hasFullFrame
+     * returns false.
+     */
+    void push(InnerT response);
+
+    /** Checks if there is a frame to be popped. */
+    boolean hasFullFrame();
+
+    /** Checks if there is any incomplete data. Used to check if the stream closed prematurely. */
+    boolean hasPartialFrame();
+
+    /**
+     * Returns and removes the current completed frame. Will only be called if hasFullFrame returns
+     * true.
+     */
+    OuterT pop();
+  }
+
+  public ReframingResponseObserver(
+      ResponseObserver<OuterT> observer, Reframer<OuterT, InnerT> reframer) {
+    this.outerResponseObserver = observer;
+    this.reframer = reframer;
+  }
+
+  /**
+   * Callback that will be notified when the inner/upstream callable starts. This will in turn
+   * notify the outer/downstreamObserver of stream start. Regardless of the
+   * outer/downstreamObserver, the upstream controller will be put into manual flow control.
+   *
+   * @param controller The controller for the upstream stream.
+   */
+  @Override
+  public void onStart(StreamController controller) {
+    innerController = controller;
+
+    outerResponseObserver.onStart(
+        new StreamController() {
+          @Override
+          public void disableAutoInboundFlowControl() {
+            Preconditions.checkState(
+                !hasStarted, "Can't disable automatic flow control once the stream has started");
+            autoFlowControl = false;
+            numPending = 0;
+          }
+
+          @Override
+          public void request(int count) {
+            onRequest(count);
+          }
+
+          @Override
+          public void cancel() {
+            onCancel();
+          }
+        });
+
+    hasStarted = true;
+
+    if (autoFlowControl) {
+      numPending = Integer.MAX_VALUE;
+      deliver();
+    }
+  }
+
+  /**
+   * Request n responses to be delivered to the outer/downstream {@link
+   * ResponseObserver#onResponse(Object)}. This method might synchronously deliver the messages if
+   * they have already been buffered. Or it will deliver them asynchronously if they need to be
+   * requested from upstream.
+   *
+   * @param count The maximum number of responses to deliver
+   */
+  private void onRequest(int count) {
+    Preconditions.checkState(!autoFlowControl, "Auto flow control enabled");
+    Preconditions.checkArgument(count > 0, "Count must be > 0");
+
+    synchronized (lock) {
+      int maxCount = Integer.MAX_VALUE - numPending;
+      count = Math.min(maxCount, count);
+
+      numPending += count;
+    }
+
+    deliver();
+  }
+
+  /**
+   * Cancels the stream and notifies the downstream {@link ResponseObserver#onError(Throwable)}.
+   * This method can be called multiple times, but only the first time has any effect. Please note
+   * that there is a race condition between cancellation and the stream completing normally. Please
+   * note that you can only specify a message or a cause, not both.
+   */
+  private void onCancel() {
+    innerController.cancel();
+
+    synchronized (lock) {
+      deferError = false;
+      error = new CancellationException("User cancelled stream");
+    }
+
+    deliver();
+  }
+
+  /**
+   * Process a new response from inner/upstream callable. The message will be fed to the reframer
+   * and the output will be delivered to the downstream {@link ResponseObserver}.
+   *
+   * <p>If the delivery loop is stopped, this will restart it.
+   */
+  @Override
+  public void onResponse(InnerT response) {
+    synchronized (lock) {
+      awaitingInner = false;
+      reframer.push(response);
+    }
+    deliver();
+  }
+
+  /**
+   * Process inner/upstream callable's onError notification. This will be queued to be delivered
+   * after the delegate exhausts it's buffers.
+   *
+   * <p>If the delivery loop is stopped, this will restart it.
+   */
+  @Override
+  public void onError(Throwable t) {
+    synchronized (lock) {
+      if (error == null) {
+        error = t;
+      }
+      closeOnDone = true;
+    }
+    deliver();
+  }
+
+  /**
+   * Process inner/upstream callable's onComplete notification. This will be queued to be delivered
+   * after the delegate exhausts it's buffers.
+   *
+   * <p>If the delivery loop is stopped, this will restart it.
+   */
+  @Override
+  public void onComplete() {
+    synchronized (lock) {
+      closeOnDone = true;
+    }
+    deliver();
+  }
+
+  /**
+   * The message pump that interacts with the {@link this#outerResponseObserver}. All interactions
+   * with outer {@link ResponseObserver} will be serialized via this method.
+   */
+  /** Tries to kick off the delivery loop, wrapping it in error handling. */
+  private void deliver() {
+    // Ensure mutual exclusion via the inDelivery flag, if there is a currently active delivery
+    // then use the missed flag to schedule an extra delivery run.
+    synchronized (lock) {
+      if (closed || inDelivery) {
+        missed = true;
+        return;
+      }
+      inDelivery = true;
+    }
+
+    try {
+      unsafeDeliver();
+    } catch (Throwable t) {
+      outerResponseObserver.onError(t);
+    }
+  }
+
+  /** The internal states of the delivery loop */
+  private enum DeliveryAction {
+    /** There is supply & demand, so deliver the current message */
+    DELIVER,
+    /** There is demand but no supply, so request more from upstream */
+    REQUEST_MORE,
+    /** There is demand but no supply and with an outstanding request , so do nothing */
+    AWAIT_MORE_DATA,
+    /** Demand has been fully supplied */
+    FULFILLED,
+    /** The stream should be closed for various reasons */
+    CLOSE
+  }
+
+  /**
+   * Coordinates state transfer between inner/downstream callable and the outer/upstream. It
+   * orchestrates the flow of demand from downstream to upstream. The data flow from upstream
+   * through the delegate to downstream. It's back pressure aware and will only send as many
+   * messages that were requested. However it will send unsolicited onComplete & onError messages.
+   *
+   * <p>This method is thread safe and performs all state changes (including interactions with the
+   * Reframer) in a synchronized block. The lock is released when interacting with outer/downstream
+   * {@link ResponseObserver} and the inner/upstream callable.
+   */
+  private void unsafeDeliver() {
+    // Outer loop: will iterate while there missed deliveries
+    while (true) {
+      DeliveryAction action;
+      Throwable closeError = null;
+
+      // Data pump: will loop while there is both supply & demand.
+      do {
+        OuterT result = null;
+
+        synchronized (lock) {
+          // Check for early cancellation.
+          if (!deferError && error != null) {
+            closed = true;
+            closeError = this.error;
+            action = DeliveryAction.CLOSE;
+          }
+          // There is supply & demand: schedule delivery.
+          else if (numPending > 0 && reframer.hasFullFrame()) {
+            result = reframer.pop();
+            if (!autoFlowControl) {
+              numPending--;
+            }
+            action = DeliveryAction.DELIVER;
+          }
+          // There is demand, the buffer is empty, request more from upstream.
+          else if (numPending > 0 && !reframer.hasFullFrame() && !closeOnDone) {
+            if (!awaitingInner) {
+              action = DeliveryAction.REQUEST_MORE;
+            } else {
+              action = DeliveryAction.AWAIT_MORE_DATA;
+            }
+          }
+          // There is no supply and more can't be requested, notify regardless of demand
+          else if (!reframer.hasFullFrame() && closeOnDone) {
+            if (error == null && reframer.hasPartialFrame()) {
+              error = new IncompleteStreamException();
+            }
+            closed = true;
+            closeError = error;
+            action = DeliveryAction.CLOSE;
+          }
+          // demand has been fulfilled, do nothing
+          else if (numPending == 0) {
+            action = DeliveryAction.FULFILLED;
+          } else {
+            throw new IllegalStateException("ReframingResponseObserver is in an unexpected state");
+          }
+        }
+
+        if (action == DeliveryAction.DELIVER) {
+          outerResponseObserver.onResponse(result);
+        }
+      } while (action == DeliveryAction.DELIVER);
+
+      switch (action) {
+        case REQUEST_MORE:
+          innerController.request(1);
+          break;
+        case CLOSE:
+          if (closeError != null) {
+            outerResponseObserver.onError(closeError);
+          } else {
+            outerResponseObserver.onComplete();
+          }
+          break;
+      }
+
+      // exit only if there were no missed delivery requests
+      synchronized (lock) {
+        if (missed) {
+          missed = false;
+          continue;
+        }
+
+        inDelivery = false;
+        return;
+      }
+    }
+  }
+}

--- a/gax/src/test/java/com/google/api/gax/rpc/ReframingResponseObserverTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ReframingResponseObserverTest.java
@@ -227,7 +227,7 @@ public class ReframingResponseObserverTest {
 
     // Make sure completion is delivered
     Truth.assertThat(downstreamObserver.getFinalError())
-        .isInstanceOf(ReframingResponseObserver.IncompleteStreamException.class);
+        .isInstanceOf(IncompleteStreamException.class);
   }
 
   @Test
@@ -266,11 +266,11 @@ public class ReframingResponseObserverTest {
   }
 
   /**
-   * A simple implementation of a {@link ReframingResponseObserver.Reframer}. The input string is
-   * split by dash, and the output is concatenated by dashes. The test can verify M:N behavior by
-   * adjusting the partsPerResponse parameter and the number of dashes in the input.
+   * A simple implementation of a {@link Reframer}. The input string is split by dash, and the
+   * output is concatenated by dashes. The test can verify M:N behavior by adjusting the
+   * partsPerResponse parameter and the number of dashes in the input.
    */
-  static class DasherizingReframer implements ReframingResponseObserver.Reframer<String, String> {
+  static class DasherizingReframer implements Reframer<String, String> {
     final Queue<String> buffer = Queues.newArrayDeque();
     final int partsPerResponse;
 

--- a/gax/src/test/java/com/google/api/gax/rpc/ReframingResponseObserverTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ReframingResponseObserverTest.java
@@ -34,7 +34,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Queues;
 import com.google.common.truth.Truth;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CancellationException;
@@ -308,13 +307,6 @@ public class ReframingResponseObserverTest {
   static class ServerStreamingStashCallable<RequestT, ResponseT>
       extends ServerStreamingCallable<RequestT, ResponseT> {
     final BlockingQueue<StashController> controllers = Queues.newLinkedBlockingDeque();
-
-    // TODO(igorbernstein2): remove this once the ServerStream PR lands
-    @Override
-    public Iterator<ResponseT> blockingServerStreamingCall(
-        RequestT request, ApiCallContext context) {
-      throw new UnsupportedOperationException("not used for tests");
-    }
 
     @Override
     public void call(

--- a/gax/src/test/java/com/google/api/gax/rpc/ReframingResponseObserverTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ReframingResponseObserverTest.java
@@ -34,6 +34,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Queues;
 import com.google.common.truth.Truth;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CancellationException;
@@ -307,6 +308,13 @@ public class ReframingResponseObserverTest {
   static class ServerStreamingStashCallable<RequestT, ResponseT>
       extends ServerStreamingCallable<RequestT, ResponseT> {
     final BlockingQueue<StashController> controllers = Queues.newLinkedBlockingDeque();
+
+    // TODO(igorbernstein2): remove this once the ServerStream PR lands
+    @Override
+    public Iterator<ResponseT> blockingServerStreamingCall(
+        RequestT request, ApiCallContext context) {
+      throw new UnsupportedOperationException("not used for tests");
+    }
 
     @Override
     public void call(

--- a/gax/src/test/java/com/google/api/gax/rpc/ReframingResponseObserverTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ReframingResponseObserverTest.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.SettableApiFuture;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Queues;
+import com.google.common.truth.Truth;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ReframingResponseObserverTest {
+  private ExecutorService executor;
+
+  private AccumulatingObserver<String> downstreamObserver;
+  private ReframingResponseObserver<String, String> mediator;
+  private StashController upstreamCall;
+
+  @Before
+  public void setUp() throws Exception {
+    executor = Executors.newCachedThreadPool();
+  }
+
+  private void setUpPipeline(boolean autoFlowControl, int partsPerResponse) {
+    downstreamObserver = new AccumulatingObserver<>(autoFlowControl);
+
+    mediator =
+        new ReframingResponseObserver<>(
+            downstreamObserver, new DasherizingReframer(partsPerResponse));
+
+    ServerStreamingStashCallable<String, String> callable = new ServerStreamingStashCallable<>();
+    callable.call("request", mediator);
+    this.upstreamCall = callable.getControllerForLastCall();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    executor.shutdownNow();
+  }
+
+  @Test
+  public void testOneToOne() throws InterruptedException {
+    setUpPipeline(false, 1);
+
+    // simple path: downstream requests 1 response, the request is proxied to upstream & upstream delivers.
+    downstreamObserver.controller.request(1);
+    Truth.assertThat(upstreamCall.getLastRequestCount()).isEqualTo(1);
+    mediator.onResponse("a");
+    Truth.assertThat(downstreamObserver.getNextResponse()).isEqualTo("a");
+
+    mediator.onComplete();
+    Truth.assertThat(downstreamObserver.isDone()).isTrue();
+  }
+
+  @Test
+  public void testOneToOneAuto() throws InterruptedException {
+    setUpPipeline(true, 1);
+
+    Truth.assertThat(upstreamCall.getLastRequestCount()).isEqualTo(1);
+    mediator.onResponse("a");
+    Truth.assertThat(downstreamObserver.getNextResponse()).isEqualTo("a");
+
+    Truth.assertThat(upstreamCall.getLastRequestCount()).isEqualTo(1);
+    mediator.onResponse("b");
+    Truth.assertThat(downstreamObserver.getNextResponse()).isEqualTo("b");
+
+    mediator.onComplete();
+    Truth.assertThat(downstreamObserver.isDone()).isTrue();
+  }
+
+  @Test
+  public void testManyToOne() throws InterruptedException {
+    setUpPipeline(false, 1);
+
+    // First downstream request makes the upstream over produce
+    downstreamObserver.controller.request(1);
+    Truth.assertThat(upstreamCall.getLastRequestCount()).isEqualTo(1);
+    mediator.onResponse("a-b");
+    Truth.assertThat(downstreamObserver.getNextResponse()).isEqualTo("a");
+    Truth.assertThat(downstreamObserver.getNextResponse()).isNull();
+
+    // Next downstream request should fetch from buffer
+    downstreamObserver.controller.request(1);
+    Truth.assertThat(upstreamCall.getLastRequestCount()).isEqualTo(0);
+    Truth.assertThat(downstreamObserver.getNextResponse()).isEqualTo("b");
+
+    // Make sure completion is delivered
+    mediator.onComplete();
+    Truth.assertThat(downstreamObserver.isDone()).isTrue();
+  }
+
+  @Test
+  public void testManyToOneAuto() throws InterruptedException {
+    setUpPipeline(true, 1);
+
+    // First downstream request makes the upstream over produce
+    Truth.assertThat(upstreamCall.getLastRequestCount()).isEqualTo(1);
+    mediator.onResponse("a-b");
+    mediator.onComplete();
+
+    Truth.assertThat(downstreamObserver.getNextResponse()).isEqualTo("a");
+    Truth.assertThat(downstreamObserver.getNextResponse()).isEqualTo("b");
+    Truth.assertThat(downstreamObserver.isDone()).isTrue();
+  }
+
+  @Test
+  public void testManyToOneCompleteIsQueued() throws InterruptedException {
+    setUpPipeline(false, 1);
+
+    downstreamObserver.controller.request(1);
+    mediator.onResponse("a-b");
+    mediator.onComplete();
+
+    downstreamObserver.getNextResponse();
+    Truth.assertThat(downstreamObserver.isDone()).isFalse();
+
+    downstreamObserver.controller.request(1);
+    downstreamObserver.getNextResponse();
+
+    Truth.assertThat(downstreamObserver.isDone()).isTrue();
+  }
+
+  @Test
+  public void testManyToOneCancelEarly() throws InterruptedException {
+    setUpPipeline(false, 1);
+
+    downstreamObserver.controller.request(1);
+    mediator.onResponse("a-b");
+    mediator.onComplete();
+
+    downstreamObserver.getNextResponse();
+    downstreamObserver.controller.cancel();
+
+    Truth.assertThat(upstreamCall.cancelled).isTrue();
+    upstreamCall.downstreamObserver.onError(new RuntimeException("Some other upstream error"));
+
+    Truth.assertThat(downstreamObserver.getFinalError()).isInstanceOf(CancellationException.class);
+  }
+
+  @Test
+  public void testOneToMany() throws InterruptedException {
+    setUpPipeline(false, 2);
+
+    // First request gets a partial response upstream
+    downstreamObserver.controller.request(1);
+    Truth.assertThat(upstreamCall.getLastRequestCount()).isEqualTo(1);
+    mediator.onResponse("a");
+    Truth.assertThat(downstreamObserver.getNextResponse()).isNull();
+
+    // Mediator will automatically send another request upstream to complete the response
+    Truth.assertThat(upstreamCall.getLastRequestCount()).isEqualTo(1);
+    mediator.onResponse("b");
+    Truth.assertThat(downstreamObserver.getNextResponse()).isEqualTo("a-b");
+
+    // Make sure completion is delivered
+    mediator.onComplete();
+    Truth.assertThat(downstreamObserver.isDone()).isTrue();
+  }
+
+  @Test
+  public void testOneToManyAuto() throws InterruptedException {
+    setUpPipeline(true, 2);
+
+    // First request gets a partial response upstream
+    Truth.assertThat(upstreamCall.getLastRequestCount()).isEqualTo(1);
+    mediator.onResponse("a");
+    Truth.assertThat(downstreamObserver.getNextResponse()).isNull();
+
+    // Mediator will automatically send another request upstream to complete the response
+    Truth.assertThat(upstreamCall.getLastRequestCount()).isEqualTo(1);
+    mediator.onResponse("b");
+    Truth.assertThat(downstreamObserver.getNextResponse()).isEqualTo("a-b");
+
+    // Make sure completion is delivered
+    mediator.onComplete();
+    Truth.assertThat(downstreamObserver.isDone()).isTrue();
+  }
+
+  @Test
+  public void testOneToManyIncomplete() {
+    setUpPipeline(false, 2);
+
+    // First request gets a partial response upstream
+    downstreamObserver.controller.request(1);
+    mediator.onResponse("a");
+    mediator.onComplete();
+
+    // Make sure completion is delivered
+    Truth.assertThat(downstreamObserver.getFinalError())
+        .isInstanceOf(ReframingResponseObserver.IncompleteStreamException.class);
+  }
+
+  @Test
+  public void testConcurrentCancel() throws InterruptedException {
+    setUpPipeline(true, 1);
+    final CountDownLatch latch = new CountDownLatch(2);
+
+    executor.submit(
+        new Runnable() {
+          @Override
+          public void run() {
+            while (!downstreamObserver.isDone()) {
+              downstreamObserver.getNextResponse();
+            }
+            latch.countDown();
+          }
+        });
+
+    executor.submit(
+        new Runnable() {
+          @Override
+          public void run() {
+            while (!upstreamCall.cancelled) {
+              if (upstreamCall.getLastRequestCount() > 0) {
+                mediator.onResponse("a");
+              }
+            }
+            upstreamCall.getObserver().onError(new RuntimeException("Some other upstream error"));
+            latch.countDown();
+          }
+        });
+
+    downstreamObserver.controller.cancel();
+
+    Truth.assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
+  }
+
+  /**
+   * A simple implementation of a {@link ReframingResponseObserver.Reframer}. The input string is
+   * split by dash, and the output is concatenated by dashes. The test can verify M:N behavior by
+   * adjusting the partsPerResponse parameter and the number of dashes in the input.
+   */
+  static class DasherizingReframer implements ReframingResponseObserver.Reframer<String, String> {
+    final Queue<String> buffer = Queues.newArrayDeque();
+    final int partsPerResponse;
+
+    DasherizingReframer(int partsPerResponse) {
+      this.partsPerResponse = partsPerResponse;
+    }
+
+    @Override
+    public void push(String response) {
+      buffer.addAll(Arrays.asList(response.split("-")));
+    }
+
+    @Override
+    public boolean hasFullFrame() {
+      return buffer.size() >= partsPerResponse;
+    }
+
+    @Override
+    public boolean hasPartialFrame() {
+      return !buffer.isEmpty();
+    }
+
+    @Override
+    public String pop() {
+      String[] parts = new String[partsPerResponse];
+
+      for (int i = 0; i < partsPerResponse; i++) {
+        parts[i] = buffer.poll();
+      }
+      return Joiner.on("-").join(parts);
+    }
+  }
+
+  static class ServerStreamingStashCallable<RequestT, ResponseT>
+      extends ServerStreamingCallable<RequestT, ResponseT> {
+    final BlockingQueue<StashController> controllers = Queues.newLinkedBlockingDeque();
+
+    @Override
+    public void call(
+        RequestT request, ResponseObserver<ResponseT> responseObserver, ApiCallContext context) {
+
+      StashController<ResponseT> controller = new StashController<>(responseObserver);
+      controllers.add(controller);
+      responseObserver.onStart(controller);
+    }
+
+    StashController getControllerForLastCall() {
+      try {
+        return controllers.poll(1, TimeUnit.SECONDS);
+      } catch (Throwable e) {
+        return null;
+      }
+    }
+  }
+
+  static class StashController<ResponseT> implements StreamController {
+    final ResponseObserver<ResponseT> downstreamObserver;
+
+    final BlockingQueue<Integer> pulls = Queues.newLinkedBlockingQueue();
+    volatile boolean cancelled;
+
+    StashController(ResponseObserver<ResponseT> downstreamObserver) {
+      this.downstreamObserver = downstreamObserver;
+    }
+
+    @Override
+    public void disableAutoInboundFlowControl() {}
+
+    @Override
+    public void request(int count) {
+      pulls.add(count);
+    }
+
+    @Override
+    public void cancel() {
+      cancelled = true;
+    }
+
+    ResponseObserver<ResponseT> getObserver() {
+      return downstreamObserver;
+    }
+
+    int getLastRequestCount() {
+      Integer results;
+
+      try {
+        results = pulls.poll(1, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+
+      if (results == null) {
+        return 0;
+      } else {
+        return results;
+      }
+    }
+  }
+
+  static class AccumulatingObserver<T> implements ResponseObserver<T> {
+    final boolean autoFlowControl;
+    StreamController controller;
+    final BlockingQueue<T> responses = Queues.newLinkedBlockingDeque();
+    final SettableApiFuture<Void> done = SettableApiFuture.create();
+
+    AccumulatingObserver(boolean autoFlowControl) {
+      this.autoFlowControl = autoFlowControl;
+    }
+
+    private T getNextResponse() {
+      try {
+        return responses.poll(1, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+    }
+
+    private Throwable getFinalError() {
+      try {
+        done.get(1, TimeUnit.SECONDS);
+        return null;
+      } catch (ExecutionException e) {
+        return e.getCause();
+      } catch (Throwable t) {
+        return t;
+      }
+    }
+
+    private boolean isDone() {
+      return done.isDone();
+    }
+
+    @Override
+    public void onStart(StreamController controller) {
+      this.controller = controller;
+      if (!autoFlowControl) {
+        controller.disableAutoInboundFlowControl();
+      }
+    }
+
+    @Override
+    public void onResponse(T response) {
+      responses.add(response);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      done.setException(t);
+    }
+
+    @Override
+    public void onComplete() {
+      done.set(null);
+    }
+  }
+}


### PR DESCRIPTION
Please review this after the Settings & ServerStream PRs.

Its nontrivial to implement a back pressure aware client for server streaming RPCs that batch responses. For example, in the cloud bigtable read rows protocol, each response message may contain chunks for many logic rows, or will only a part of a single row. The bigtable client will need to shield the caller from having to deal with this complexity. This PR introduces a ResponseObserver implementation that handles all of the heavy lifting of managing back pressure and delegates the business logic of merging & splitting the messages to a Reframer.

The main difficulty of implementing such protocols is dealing with an rpc response that contains many logical responses. The rpc response will need to act as a buffer and the ensuing client calls will need to thread hop from a grpc thread for the initial response, to the caller's thread when reading the buffer.

Please note that there is some duplication in the test code for constructing test objects, these are intentional to allow this PR to be reviewed in parallel with the other features. I will pull out the test helpers once the other prs land.