### PR TITLE
fix default channelPoolSize to be 1 (instead of 0)

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -235,6 +235,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
 
     private Builder() {
       processorCount = Runtime.getRuntime().availableProcessors();
+      poolSize = 1;
     }
 
     private Builder(InstantiatingGrpcChannelProvider provider) {


### PR DESCRIPTION
Fix a bug introduced in #436