### PR TITLE
first() and all(): Add syntactic sugar to treat ServerStreamingCallables like UnaryCallables

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/FirstElementCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FirstElementCallable.java
@@ -61,6 +61,8 @@ final class FirstElementCallable<RequestT, ResponseT> extends UnaryCallable<Requ
     FirstElementResponseObserver<ResponseT> observer = new FirstElementResponseObserver<>();
 
     streamingCallable.call(request, observer, context);
+    // NOTE: Since onStart must be called synchronously on this thread, the observer is now fully
+    // initialized and the future can be safely returned to the caller.
     return observer.getFuture();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/FirstElementCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FirstElementCallable.java
@@ -58,9 +58,9 @@ final class FirstElementCallable<RequestT, ResponseT> extends UnaryCallable<Requ
    */
   @Override
   public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext context) {
-    FirstElementResponseObserver<ResponseT> adapter = new FirstElementResponseObserver<>();
+    FirstElementResponseObserver<ResponseT> observer = new FirstElementResponseObserver<>();
 
-    streamingCallable.call(request, adapter, context);
-    return adapter.getFuture();
+    streamingCallable.call(request, observer, context);
+    return observer.getFuture();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/FirstElementCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FirstElementCallable.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.ApiFuture;
+
+/**
+ * Wraps a {@link ServerStreamingCallable} in a {@link UnaryCallable} that returns the first
+ * element. After returning the first element, the underlying stream will be gracefully cancelled.
+ *
+ * <p>Package-private for internal use.
+ *
+ * @param <RequestT> The type of the request.
+ * @param <ResponseT> The type of the item in the stream.
+ */
+final class FirstElementCallable<RequestT, ResponseT> extends UnaryCallable<RequestT, ResponseT> {
+  private final ServerStreamingCallable<RequestT, ResponseT> streamingCallable;
+
+  FirstElementCallable(ServerStreamingCallable<RequestT, ResponseT> streamingCallable) {
+    this.streamingCallable = streamingCallable;
+  }
+
+  /**
+   * Starts the RPC and returns a future wrapping the result. If the stream is empty, the result
+   * will be null. If a request is cancelled, the future will be rejected with a {@link
+   * java.util.concurrent.CancellationException}.
+   *
+   * @param request The request.
+   * @param context {@link ApiCallContext} to make the call with
+   * @return A {@link ApiFuture} wrapping a possible first element of the stream.
+   */
+  @Override
+  public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext context) {
+    FirstElementResponseObserver<ResponseT> adapter = new FirstElementResponseObserver<>();
+
+    streamingCallable.call(request, adapter, context);
+    return adapter.getFuture();
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/FirstElementResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FirstElementResponseObserver.java
@@ -46,6 +46,7 @@ class FirstElementResponseObserver<ResponseT> implements ResponseObserver<Respon
 
   @Override
   public void onStart(StreamController controller) {
+    // NOTE: the call is started before the future is exposed to the caller
     this.controller = controller;
 
     controller.disableAutoInboundFlowControl();
@@ -72,10 +73,7 @@ class FirstElementResponseObserver<ResponseT> implements ResponseObserver<Respon
     return future;
   }
 
-  /**
-   * Simple implementation of a future to prematurely interrupt the RPC before the first element is
-   * received.
-   */
+  /** Simple implementation of a future that allows the receiver to cancel the underlying stream. */
   private class MyFuture extends AbstractApiFuture<ResponseT> {
     @Override
     protected void interruptTask() {

--- a/gax/src/main/java/com/google/api/gax/rpc/FirstElementResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FirstElementResponseObserver.java
@@ -79,16 +79,16 @@ class FirstElementResponseObserver<ResponseT> implements ResponseObserver<Respon
   private class MyFuture extends AbstractApiFuture<ResponseT> {
     @Override
     protected void interruptTask() {
-      controller.cancel();
+      FirstElementResponseObserver.this.controller.cancel();
     }
 
     @Override
-    public boolean set(ResponseT value) {
+    protected boolean set(ResponseT value) {
       return super.set(value);
     }
 
     @Override
-    public boolean setException(Throwable throwable) {
+    protected boolean setException(Throwable throwable) {
       return super.setException(throwable);
     }
   }

--- a/gax/src/main/java/com/google/api/gax/rpc/FirstElementResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FirstElementResponseObserver.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.AbstractApiFuture;
+import com.google.api.core.ApiFuture;
+
+/**
+ * A {@link ResponseObserver} that wraps a future. The future will resolved upon receiving the first
+ * element or exhausting the streaming.
+ *
+ * <p>Package-private for internal use.
+ *
+ * @param <ResponseT> The type of the element in the stream.
+ */
+class FirstElementResponseObserver<ResponseT> implements ResponseObserver<ResponseT> {
+  private final MyFuture future = new MyFuture();
+  private StreamController controller;
+
+  @Override
+  public void onStart(StreamController controller) {
+    this.controller = controller;
+
+    controller.disableAutoInboundFlowControl();
+    controller.request(1);
+  }
+
+  @Override
+  public void onResponse(ResponseT response) {
+    future.set(response);
+    controller.cancel();
+  }
+
+  @Override
+  public void onError(Throwable t) {
+    future.setException(t);
+  }
+
+  @Override
+  public void onComplete() {
+    future.set(null);
+  }
+
+  ApiFuture<ResponseT> getFuture() {
+    return future;
+  }
+
+  /**
+   * Simple implementation of a future to prematurely interrupt the RPC before the first element is
+   * received.
+   */
+  private class MyFuture extends AbstractApiFuture<ResponseT> {
+    @Override
+    protected void interruptTask() {
+      controller.cancel();
+    }
+
+    @Override
+    public boolean set(ResponseT value) {
+      return super.set(value);
+    }
+
+    @Override
+    public boolean setException(Throwable throwable) {
+      return super.setException(throwable);
+    }
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/ResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ResponseObserver.java
@@ -54,7 +54,8 @@ import com.google.api.core.BetaApi;
 public interface ResponseObserver<V> {
 
   /**
-   * Called before the stream is started.
+   * Called before the stream is started. This must be invoked synchronously on the same thread that
+   * called {@link ServerStreamingCallable#call(Object, ResponseObserver, ApiCallContext)}
    *
    * <p>Allows for disabling flow control and early stream termination via {@code StreamController}.
    *

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
@@ -31,6 +31,7 @@ package com.google.api.gax.rpc;
 
 import com.google.api.core.BetaApi;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * A ServerStreamingCallable is an immutable object which is capable of making RPC calls to server
@@ -42,8 +43,49 @@ import java.util.Iterator;
  */
 @BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public abstract class ServerStreamingCallable<RequestT, ResponseT> {
+  private final FirstElementCallable<RequestT, ResponseT> firstCallable;
+  private final SpoolingCallable<RequestT, ResponseT> spoolingCallable;
 
-  protected ServerStreamingCallable() {}
+  protected ServerStreamingCallable() {
+    firstCallable = new FirstElementCallable<>(this);
+    spoolingCallable = new SpoolingCallable<>(this);
+  }
+
+  /**
+   * Construct a {@link UnaryCallable} that will yield the first item in the stream and cancel it.
+   * If the stream was empty, the item will be null.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * StreamingCallable<String> streamingCallable = // ..
+   * String theResult = streamingCallable.first().call(request);
+   * ApiFuture<String> theResult = streamingCallable.first().futureCall(request);
+   * }</pre>
+   *
+   * @return The {@link UnaryCallable}.
+   */
+  public UnaryCallable<RequestT, ResponseT> first() {
+    return firstCallable;
+  }
+
+  /**
+   * Construct a {@link UnaryCallable} that will buffer the entire stream into memory before
+   * completing. If the stream was empty, then the list will be empty.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * StreamingCallable<String> streamingCallable = // ..
+   * List<String></String> theResult = streamingCallable.all().call(request);
+   * ApiFuture<List<String>> theResult = streamingCallable.all().futureCall(request);
+   * }</pre>
+   *
+   * @return The {@link UnaryCallable}.
+   */
+  public UnaryCallable<RequestT, List<ResponseT>> all() {
+    return spoolingCallable;
+  }
 
   /**
    * Conduct a iteration server streaming call.

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
@@ -53,7 +53,7 @@ public abstract class ServerStreamingCallable<RequestT, ResponseT> {
 
   /**
    * Construct a {@link UnaryCallable} that will yield the first item in the stream and cancel it.
-   * If the stream was empty, the item will be null.
+   * If the stream is empty, the item will be null.
    *
    * <p>Example usage:
    *
@@ -71,13 +71,13 @@ public abstract class ServerStreamingCallable<RequestT, ResponseT> {
 
   /**
    * Construct a {@link UnaryCallable} that will buffer the entire stream into memory before
-   * completing. If the stream was empty, then the list will be empty.
+   * completing. If the stream is empty, then the list will be empty.
    *
    * <p>Example usage:
    *
    * <pre>{@code
    * StreamingCallable<String> streamingCallable = // ..
-   * List<String></String> theResult = streamingCallable.all().call(request);
+   * List<String> theResult = streamingCallable.all().call(request);
    * ApiFuture<List<String>> theResult = streamingCallable.all().futureCall(request);
    * }</pre>
    *

--- a/gax/src/main/java/com/google/api/gax/rpc/SpoolingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/SpoolingCallable.java
@@ -61,8 +61,8 @@ class SpoolingCallable<RequestT, ResponseT> extends UnaryCallable<RequestT, List
    */
   @Override
   public ApiFuture<List<ResponseT>> futureCall(RequestT request, ApiCallContext context) {
-    SpoolingResponseObserver<ResponseT> adapter = new SpoolingResponseObserver<>();
-    streamingCallable.call(request, adapter, context);
-    return adapter.getFuture();
+    SpoolingResponseObserver<ResponseT> observer = new SpoolingResponseObserver<>();
+    streamingCallable.call(request, observer, context);
+    return observer.getFuture();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/SpoolingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/SpoolingCallable.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.ApiFuture;
+import java.util.List;
+
+/**
+ * Wraps a {@link ServerStreamingCallable} in a buffering {@link UnaryCallable}. The {@link
+ * UnaryCallable} will buffer the entire stream in memory. This is meant to be used for short
+ * streams and provides interoperability with {@link UnaryCallable} middleware like {@link
+ * BatchingCallable}.
+ *
+ * <p>Package-private for internal use.
+ *
+ * @param <RequestT> The type of the request.
+ * @param <ResponseT> The type of an item in the stream.
+ */
+class SpoolingCallable<RequestT, ResponseT> extends UnaryCallable<RequestT, List<ResponseT>> {
+  private final ServerStreamingCallable<RequestT, ResponseT> streamingCallable;
+
+  SpoolingCallable(ServerStreamingCallable<RequestT, ResponseT> streamingCallable) {
+    this.streamingCallable = streamingCallable;
+  }
+
+  /**
+   * Starts the RPC and returns a future wrapping a list of results. If the stream is empty, the
+   * result will be an empty list. If a request is cancelled, the future will be rejected with a
+   * {@link java.util.concurrent.CancellationException}.
+   *
+   * @param request The request.
+   * @param context {@link ApiCallContext} to make the call with.
+   * @return A {@link ApiFuture} wrapping a possible first element of the stream.
+   */
+  @Override
+  public ApiFuture<List<ResponseT>> futureCall(RequestT request, ApiCallContext context) {
+    SpoolingResponseObserver<ResponseT> adapter = new SpoolingResponseObserver<>();
+    streamingCallable.call(request, adapter, context);
+    return adapter.getFuture();
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/SpoolingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/SpoolingCallable.java
@@ -63,6 +63,8 @@ class SpoolingCallable<RequestT, ResponseT> extends UnaryCallable<RequestT, List
   public ApiFuture<List<ResponseT>> futureCall(RequestT request, ApiCallContext context) {
     SpoolingResponseObserver<ResponseT> observer = new SpoolingResponseObserver<>();
     streamingCallable.call(request, observer, context);
+    // NOTE: Since onStart must be called synchronously on this thread, the observer is now fully
+    // initialized and the future can be safely returned to the caller.
     return observer.getFuture();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/SpoolingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/SpoolingResponseObserver.java
@@ -45,7 +45,7 @@ import java.util.List;
 class SpoolingResponseObserver<ResponseT> implements ResponseObserver<ResponseT> {
   private final MyFuture future = new MyFuture();
   private StreamController controller;
-  private List<ResponseT> buffer = Lists.newArrayList();
+  private final List<ResponseT> buffer = Lists.newArrayList();
 
   ApiFuture<List<ResponseT>> getFuture() {
     return future;
@@ -79,16 +79,16 @@ class SpoolingResponseObserver<ResponseT> implements ResponseObserver<ResponseT>
   class MyFuture extends AbstractApiFuture<List<ResponseT>> {
     @Override
     protected void interruptTask() {
-      controller.cancel();
+      SpoolingResponseObserver.this.controller.cancel();
     }
 
     @Override
-    public boolean set(List<ResponseT> value) {
+    protected boolean set(List<ResponseT> value) {
       return super.set(value);
     }
 
     @Override
-    public boolean setException(Throwable throwable) {
+    protected boolean setException(Throwable throwable) {
       return super.setException(throwable);
     }
   }

--- a/gax/src/main/java/com/google/api/gax/rpc/SpoolingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/SpoolingResponseObserver.java
@@ -35,7 +35,7 @@ import com.google.common.collect.Lists;
 import java.util.List;
 
 /**
- * A {@link ResponseObserver} that buffers the results from a {@link ServerStreamingCallable} in a
+ * A {@link ResponseObserver} that buffers the results from a {@link ServerStreamingCallable} in an
  * {@link ApiFuture}.
  *
  * <p>Package-private for internal use.
@@ -72,10 +72,7 @@ class SpoolingResponseObserver<ResponseT> implements ResponseObserver<ResponseT>
     future.set(buffer);
   }
 
-  /**
-   * Simple implementation of a future to prematurely interrupt the RPC before the first element is
-   * received.
-   */
+  /** Simple implementation of a future that allows the receiver to cancel the underlying stream. */
   class MyFuture extends AbstractApiFuture<List<ResponseT>> {
     @Override
     protected void interruptTask() {

--- a/gax/src/main/java/com/google/api/gax/rpc/SpoolingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/SpoolingResponseObserver.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.AbstractApiFuture;
+import com.google.api.core.ApiFuture;
+import com.google.common.collect.Lists;
+import java.util.List;
+
+/**
+ * A {@link ResponseObserver} that buffers the results from a {@link ServerStreamingCallable} in a
+ * {@link ApiFuture}.
+ *
+ * <p>Package-private for internal use.
+ *
+ * @param <ResponseT> The type of the element in the stream.
+ */
+class SpoolingResponseObserver<ResponseT> implements ResponseObserver<ResponseT> {
+  private final MyFuture future = new MyFuture();
+  private StreamController controller;
+  private List<ResponseT> buffer = Lists.newArrayList();
+
+  ApiFuture<List<ResponseT>> getFuture() {
+    return future;
+  }
+
+  @Override
+  public void onStart(StreamController controller) {
+    // NOTE: the call is started before the future is exposed to the caller
+    this.controller = controller;
+  }
+
+  @Override
+  public void onResponse(ResponseT response) {
+    buffer.add(response);
+  }
+
+  @Override
+  public void onError(Throwable t) {
+    future.setException(t);
+  }
+
+  @Override
+  public void onComplete() {
+    future.set(buffer);
+  }
+
+  /**
+   * Simple implementation of a future to prematurely interrupt the RPC before the first element is
+   * received.
+   */
+  class MyFuture extends AbstractApiFuture<List<ResponseT>> {
+    @Override
+    protected void interruptTask() {
+      controller.cancel();
+    }
+
+    @Override
+    public boolean set(List<ResponseT> value) {
+      return super.set(value);
+    }
+
+    @Override
+    public boolean setException(Throwable throwable) {
+      return super.setException(throwable);
+    }
+  }
+}

--- a/gax/src/test/java/com/google/api/gax/rpc/FirstElementCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/FirstElementCallableTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.ApiFuture;
+import com.google.common.collect.Queues;
+import com.google.common.truth.Truth;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class FirstElementCallableTest {
+  private AccumulatingCallable<String, String> upstream;
+  private FirstElementCallable<String, String> callable;
+
+  @Rule public ExpectedException expectedException = ExpectedException.none();
+
+  @Before
+  public void setup() {
+    upstream = new AccumulatingCallable<>();
+    callable = new FirstElementCallable<>(upstream);
+  }
+
+  @Test
+  public void testHappyPath() throws InterruptedException, ExecutionException {
+    ApiFuture<String> result = callable.futureCall("request");
+    AccumulatingController<String> call = upstream.getCall();
+
+    Truth.assertThat(call.autoFlowControl).isFalse();
+
+    Truth.assertThat(call.getLastRequestCount()).isEqualTo(1);
+    call.observer.onResponse("response");
+    Truth.assertThat(result.get()).isEqualTo("response");
+
+    Truth.assertThat(call.observer).isNotNull();
+  }
+
+  @Test
+  public void testEarlyTermination() throws Exception {
+    ApiFuture<String> result = callable.futureCall("request");
+    AccumulatingController<String> call = upstream.getCall();
+
+    // callable should request a single element on start
+    Truth.assertThat(call.autoFlowControl).isFalse();
+    Truth.assertThat(call.getLastRequestCount()).isEqualTo(1);
+
+    // Then the user promptly cancels it
+    result.cancel(true);
+
+    // The cancellation should propagate to the inner callable
+    Truth.assertThat(call.cancelled).isTrue();
+    // Then we fake a cancellation going the other way (it will be wrapped in StatusRuntimeException
+    // for grpc)
+    call.observer.onError(new RuntimeException("Some other upstream cancellation notice"));
+
+    Throwable actualError = null;
+    try {
+      result.get(1, TimeUnit.SECONDS);
+    } catch (Throwable e) {
+      actualError = e;
+    }
+
+    // However, that exception will be ignored and will be replaced by a generic CancellationException
+    Truth.assertThat(actualError).isInstanceOf(CancellationException.class);
+  }
+
+  @Test
+  public void testNoResults() throws Exception {
+    ApiFuture<String> result = callable.futureCall("request");
+    AccumulatingController<String> call = upstream.getCall();
+
+    Truth.assertThat(call.autoFlowControl).isFalse();
+
+    call.observer.onComplete();
+    Truth.assertThat(result.get()).isNull();
+  }
+
+  static class AccumulatingCallable<ReqT, RespT> extends ServerStreamingCallable<ReqT, RespT> {
+    BlockingQueue<AccumulatingController<RespT>> calls = Queues.newLinkedBlockingQueue();
+
+    @Override
+    public void call(
+        ReqT request, ResponseObserver<RespT> responseObserver, ApiCallContext context) {
+
+      AccumulatingController<RespT> controller = new AccumulatingController<>(responseObserver);
+      calls.add(controller);
+      responseObserver.onStart(controller);
+    }
+
+    AccumulatingController<RespT> getCall() throws InterruptedException {
+      return calls.poll(1, TimeUnit.SECONDS);
+    }
+  }
+
+  static class AccumulatingController<RespT> implements StreamController {
+    final ResponseObserver<RespT> observer;
+    boolean autoFlowControl = true;
+    final BlockingQueue<Integer> pulls = Queues.newLinkedBlockingQueue();
+    boolean cancelled;
+
+    AccumulatingController(ResponseObserver<RespT> observer) {
+      this.observer = observer;
+    }
+
+    @Override
+    public void cancel() {
+      cancelled = true;
+    }
+
+    @Override
+    public void disableAutoInboundFlowControl() {
+      autoFlowControl = false;
+    }
+
+    @Override
+    public void request(int count) {
+      pulls.add(count);
+    }
+
+    int getLastRequestCount() throws InterruptedException {
+      Integer pull = pulls.poll(1, TimeUnit.SECONDS);
+      if (pull == null) {
+        pull = 0;
+      }
+      return pull;
+    }
+  }
+}

--- a/gax/src/test/java/com/google/api/gax/rpc/FirstElementCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/FirstElementCallableTest.java
@@ -109,4 +109,16 @@ public class FirstElementCallableTest {
     call.getObserver().onComplete();
     Truth.assertThat(result.get()).isNull();
   }
+
+  @Test
+  public void testErrorAfterResultIsIgnored() throws Exception {
+    ApiFuture<String> result = callable.futureCall("request");
+    MockStreamController<String> call = upstream.popLastCall();
+
+    Truth.assertThat(call.isAutoFlowControlEnabled()).isFalse();
+    call.getObserver().onResponse("response");
+    call.getObserver().onError(new RuntimeException("some error that will be ignored"));
+
+    Truth.assertThat(result.get()).isEqualTo("response");
+  }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallableTest.java
@@ -198,4 +198,102 @@ public class ServerStreamingCallableTest {
     Truth.assertThat(actualContext.getChannel()).isSameAs(channel);
     Truth.assertThat(actualContext.getCredentials()).isSameAs(credentials);
   }
+
+  @Test
+  public void testFirstElementCall() {
+    ServerStreamingStashCallable<Integer, Integer> callIntList =
+        new ServerStreamingStashCallable<>(Arrays.asList(0, 1, 2));
+
+    ServerStreamingCallable<Integer, Integer> streamingCallable =
+        FakeCallableFactory.createServerStreamingCallable(
+            callIntList,
+            StreamingCallSettings.<Integer, Integer>newBuilder().build(),
+            clientContext);
+
+    UnaryCallable<Integer, Integer> callable = streamingCallable.first();
+    Truth.assertThat(callable.call(0)).isEqualTo(0);
+    Truth.assertThat(callIntList.getActualRequest()).isEqualTo(0);
+  }
+
+  @Test
+  public void testFirstElementCallWithDefaultContext() {
+    ApiCallContext defaultCallContext = FakeCallContext.createDefault();
+    ServerStreamingStashCallable<Integer, Integer> stashCallable =
+        new ServerStreamingStashCallable<>();
+
+    UnaryCallable<Integer, Integer> firstCallable =
+        stashCallable.first().withDefaultCallContext(defaultCallContext);
+    Integer request = 1;
+    firstCallable.call(request);
+    Truth.assertThat(stashCallable.getActualRequest()).isSameAs(request);
+    Truth.assertThat(stashCallable.getContext()).isSameAs(defaultCallContext);
+  }
+
+  @Test
+  public void testFirstElementCallWithContext() {
+    FakeChannel channel = new FakeChannel();
+    Credentials credentials = Mockito.mock(Credentials.class);
+    ApiCallContext context =
+        FakeCallContext.createDefault().withChannel(channel).withCredentials(credentials);
+    ServerStreamingStashCallable<Integer, Integer> stashCallable =
+        new ServerStreamingStashCallable<>();
+
+    UnaryCallable<Integer, Integer> firstCallable =
+        stashCallable.first().withDefaultCallContext(FakeCallContext.createDefault());
+    Integer request = 1;
+    firstCallable.call(request, context);
+    Truth.assertThat(stashCallable.getActualRequest()).isSameAs(request);
+    FakeCallContext actualContext = (FakeCallContext) stashCallable.getContext();
+    Truth.assertThat(actualContext.getChannel()).isSameAs(channel);
+    Truth.assertThat(actualContext.getCredentials()).isSameAs(credentials);
+  }
+
+  @Test
+  public void testAllElementCall() {
+    ServerStreamingStashCallable<Integer, Integer> callIntList =
+        new ServerStreamingStashCallable<>(Arrays.asList(0, 1, 2));
+
+    ServerStreamingCallable<Integer, Integer> streamingCallable =
+        FakeCallableFactory.createServerStreamingCallable(
+            callIntList,
+            StreamingCallSettings.<Integer, Integer>newBuilder().build(),
+            clientContext);
+
+    UnaryCallable<Integer, List<Integer>> callable = streamingCallable.all();
+    Truth.assertThat(callable.call(0)).containsExactly(0, 1, 2).inOrder();
+    Truth.assertThat(callIntList.getActualRequest()).isEqualTo(0);
+  }
+
+  @Test
+  public void testAllElementCallWithDefaultContext() {
+    ApiCallContext defaultCallContext = FakeCallContext.createDefault();
+    ServerStreamingStashCallable<Integer, Integer> stashCallable =
+        new ServerStreamingStashCallable<>();
+
+    UnaryCallable<Integer, List<Integer>> firstCallable =
+        stashCallable.all().withDefaultCallContext(defaultCallContext);
+    Integer request = 1;
+    firstCallable.call(request);
+    Truth.assertThat(stashCallable.getActualRequest()).isSameAs(request);
+    Truth.assertThat(stashCallable.getContext()).isSameAs(defaultCallContext);
+  }
+
+  @Test
+  public void testAllElementCallWithContext() {
+    FakeChannel channel = new FakeChannel();
+    Credentials credentials = Mockito.mock(Credentials.class);
+    ApiCallContext context =
+        FakeCallContext.createDefault().withChannel(channel).withCredentials(credentials);
+    ServerStreamingStashCallable<Integer, Integer> stashCallable =
+        new ServerStreamingStashCallable<>();
+
+    UnaryCallable<Integer, List<Integer>> firstCallable =
+        stashCallable.all().withDefaultCallContext(FakeCallContext.createDefault());
+    Integer request = 1;
+    firstCallable.call(request, context);
+    Truth.assertThat(stashCallable.getActualRequest()).isSameAs(request);
+    FakeCallContext actualContext = (FakeCallContext) stashCallable.getContext();
+    Truth.assertThat(actualContext.getChannel()).isSameAs(channel);
+    Truth.assertThat(actualContext.getCredentials()).isSameAs(credentials);
+  }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/SpoolingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/SpoolingCallableTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.core.ApiFuture;
+import com.google.common.collect.Queues;
+import com.google.common.truth.Truth;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SpoolingCallableTest {
+  private AccumulatingCallable<String, String> upstream;
+  private SpoolingCallable<String, String> callable;
+
+  @Rule public ExpectedException expectedException = ExpectedException.none();
+
+  @Before
+  public void setup() {
+    upstream = new AccumulatingCallable<>();
+    callable = new SpoolingCallable<>(upstream);
+  }
+
+  @Test
+  public void testHappyPath() throws InterruptedException, ExecutionException {
+    ApiFuture<List<String>> result = callable.futureCall("request");
+    AccumulatingController<String> call = upstream.getCall();
+
+    assertThat(call.autoFlowControl).isTrue();
+
+    call.observer.onResponse("response1");
+    call.observer.onResponse("response2");
+    call.observer.onComplete();
+
+    assertThat(result.get()).containsAllOf("response1", "response2").inOrder();
+  }
+
+  @Test
+  public void testEarlyTermination() throws Exception {
+    ApiFuture<List<String>> result = callable.futureCall("request");
+    AccumulatingController<String> call = upstream.getCall();
+
+    // The caller cancels the stream while receiving responses
+    call.observer.onResponse("response1");
+    result.cancel(true);
+    call.observer.onResponse("response2");
+
+    // The cancellation should propagate upstream
+    Truth.assertThat(call.cancelled).isTrue();
+    // Then we fake a cancellation going the other way (it will be wrapped in StatusRuntimeException
+    // for grpc)
+    call.observer.onError(new RuntimeException("Some other upstream cancellation indicator"));
+
+    // However the inner cancellation exception will be masked by an outer CancellationException
+    expectedException.expect(CancellationException.class);
+    result.get();
+  }
+
+  @Test
+  public void testNoResults() throws Exception {
+    ApiFuture<List<String>> result = callable.futureCall("request");
+    AccumulatingController<String> call = upstream.getCall();
+
+    call.observer.onComplete();
+
+    assertThat(result.get()).isEmpty();
+  }
+
+  static class AccumulatingCallable<ReqT, RespT> extends ServerStreamingCallable<ReqT, RespT> {
+    BlockingQueue<AccumulatingController<RespT>> calls = Queues.newLinkedBlockingQueue();
+
+    @Override
+    public void call(
+        ReqT request, ResponseObserver<RespT> responseObserver, ApiCallContext context) {
+
+      AccumulatingController<RespT> controller = new AccumulatingController<>(responseObserver);
+      calls.add(controller);
+      responseObserver.onStart(controller);
+    }
+
+    AccumulatingController<RespT> getCall() throws InterruptedException {
+      return calls.poll(1, TimeUnit.SECONDS);
+    }
+  }
+
+  static class AccumulatingController<RespT> implements StreamController {
+    final ResponseObserver<RespT> observer;
+    boolean autoFlowControl = true;
+    final BlockingQueue<Integer> pulls = Queues.newLinkedBlockingQueue();
+    boolean cancelled;
+
+    AccumulatingController(ResponseObserver<RespT> observer) {
+      this.observer = observer;
+    }
+
+    @Override
+    public void cancel() {
+      cancelled = true;
+    }
+
+    @Override
+    public void disableAutoInboundFlowControl() {
+      autoFlowControl = false;
+    }
+
+    @Override
+    public void request(int count) {
+      pulls.add(count);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds `first()` and `all()` callables on top of ServerStreamingCallables. This allows for simple interaction with short server streams.  Example usage:

```java
Row row = client.readRowsCallable().first().call(request)
ApiFuture<List<Row>> rows = client.readRowsCallable().all().futureCall(request)
```