### PR TITLE
ApiExceptions: Wrap streaming errors in ApiExceptions.

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcApiExceptionFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcApiExceptionFactory.java
@@ -40,7 +40,7 @@ import java.util.Set;
 
 /**
  * Core logic for transforming GRPC exceptions into {@link ApiException}s. This logic is shared
- * amongst all of the call types
+ * amongst all of the call types.
  *
  * <p>Package-private for internal use.
  */

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcApiExceptionFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcApiExceptionFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.grpc;
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.ApiExceptionFactory;
+import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.common.collect.ImmutableSet;
+import io.grpc.Status;
+import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
+import java.util.Set;
+
+/**
+ * Core logic for transforming GRPC exceptions into {@link ApiException}s. This logic is shared
+ * amongst all of the call types
+ *
+ * <p>Package-private for internal use.
+ */
+class GrpcApiExceptionFactory {
+  private final ImmutableSet<Code> retryableCodes;
+
+  GrpcApiExceptionFactory(Set<Code> retryCodes) {
+    this.retryableCodes = ImmutableSet.copyOf(retryCodes);
+  }
+
+  ApiException create(Throwable throwable) {
+    if (throwable instanceof StatusException) {
+      StatusException e = (StatusException) throwable;
+      return create(throwable, e.getStatus().getCode());
+    } else if (throwable instanceof StatusRuntimeException) {
+      StatusRuntimeException e = (StatusRuntimeException) throwable;
+      return create(throwable, e.getStatus().getCode());
+    } else if (throwable instanceof ApiException) {
+      return (ApiException) throwable;
+    } else {
+      // Do not retry on unknown throwable, even when UNKNOWN is in retryableCodes
+      return ApiExceptionFactory.createException(
+          throwable, GrpcStatusCode.of(Status.Code.UNKNOWN), false);
+    }
+  }
+
+  private ApiException create(Throwable throwable, Status.Code statusCode) {
+    boolean canRetry = retryableCodes.contains(GrpcStatusCode.grpcCodeToStatusCode(statusCode));
+    return ApiExceptionFactory.createException(throwable, GrpcStatusCode.of(statusCode), canRetry);
+  }
+}

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcApiExceptionResponseObserver.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcApiExceptionResponseObserver.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.grpc;
+
+import com.google.api.gax.rpc.ApiStreamObserver;
+
+/**
+ * An {@link ApiStreamObserver} that wraps grpc's errors into {@link
+ * com.google.api.gax.rpc.ApiException}s.
+ *
+ * <p>Package-private for internal use.
+ *
+ * @param <ResponseT>
+ */
+final class GrpcApiExceptionResponseObserver<ResponseT> implements ApiStreamObserver<ResponseT> {
+  private final ApiStreamObserver<ResponseT> innerObserver;
+  private final GrpcApiExceptionFactory exceptionFactory;
+
+  GrpcApiExceptionResponseObserver(
+      ApiStreamObserver<ResponseT> innerObserver, GrpcApiExceptionFactory exceptionFactory) {
+    this.innerObserver = innerObserver;
+    this.exceptionFactory = exceptionFactory;
+  }
+
+  @Override
+  public void onNext(ResponseT value) {
+    innerObserver.onNext(value);
+  }
+
+  @Override
+  public void onError(Throwable t) {
+    innerObserver.onError(exceptionFactory.create(t));
+  }
+
+  @Override
+  public void onCompleted() {
+    innerObserver.onCompleted();
+  }
+}

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -42,9 +42,11 @@ import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.PagedCallSettings;
 import com.google.api.gax.rpc.ServerStreamingCallSettings;
 import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.StreamingCallSettings;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.collect.ImmutableSet;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 
@@ -173,6 +175,10 @@ public class GrpcCallableFactory {
           ClientContext clientContext) {
     BidiStreamingCallable<RequestT, ResponseT> callable =
         new GrpcDirectBidiStreamingCallable<>(grpcCallSettings.getMethodDescriptor());
+
+    callable =
+        new GrpcExceptionBidiStreamingCallable<>(callable, ImmutableSet.<StatusCode.Code>of());
+
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
   }
 
@@ -224,6 +230,9 @@ public class GrpcCallableFactory {
           new GrpcServerStreamingRequestParamCallable<>(
               callable, grpcCallSettings.getParamsExtractor());
     }
+    callable =
+        new GrpcExceptionServerStreamingCallable<>(callable, ImmutableSet.<StatusCode.Code>of());
+
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
   }
 
@@ -245,6 +254,10 @@ public class GrpcCallableFactory {
           ClientContext clientContext) {
     ClientStreamingCallable<RequestT, ResponseT> callable =
         new GrpcDirectClientStreamingCallable<>(grpcCallSettings.getMethodDescriptor());
+
+    callable =
+        new GrpcExceptionClientStreamingCallable<>(callable, ImmutableSet.<StatusCode.Code>of());
+
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
   }
 }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcExceptionBidiStreamingCallable.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcExceptionBidiStreamingCallable.java
@@ -29,71 +29,37 @@
  */
 package com.google.api.gax.grpc;
 
-import com.google.api.core.AbstractApiFuture;
-import com.google.api.core.ApiFuture;
-import com.google.api.core.ApiFutureCallback;
-import com.google.api.core.ApiFutures;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.StatusCode;
-import com.google.api.gax.rpc.UnaryCallable;
-import com.google.common.base.Preconditions;
 import java.util.Set;
-import java.util.concurrent.CancellationException;
 
 /**
  * Transforms all {@code Throwable}s thrown during a call into an instance of {@link ApiException}.
  *
  * <p>Package-private for internal use.
  */
-class GrpcExceptionCallable<RequestT, ResponseT> extends UnaryCallable<RequestT, ResponseT> {
-  private final UnaryCallable<RequestT, ResponseT> callable;
+final class GrpcExceptionBidiStreamingCallable<RequestT, ResponseT>
+    extends BidiStreamingCallable<RequestT, ResponseT> {
+  private final BidiStreamingCallable<RequestT, ResponseT> innerCallable;
   private final GrpcApiExceptionFactory exceptionFactory;
 
-  GrpcExceptionCallable(
-      UnaryCallable<RequestT, ResponseT> callable, Set<StatusCode.Code> retryableCodes) {
-    this.callable = Preconditions.checkNotNull(callable);
+  GrpcExceptionBidiStreamingCallable(
+      BidiStreamingCallable<RequestT, ResponseT> innerCallable,
+      Set<StatusCode.Code> retryableCodes) {
+    this.innerCallable = innerCallable;
     this.exceptionFactory = new GrpcApiExceptionFactory(retryableCodes);
   }
 
   @Override
-  public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext inputContext) {
-    GrpcCallContext context = GrpcCallContext.createDefault().nullToSelf(inputContext);
-    ApiFuture<ResponseT> innerCallFuture = callable.futureCall(request, context);
-    ExceptionTransformingFuture transformingFuture =
-        new ExceptionTransformingFuture(innerCallFuture);
-    ApiFutures.addCallback(innerCallFuture, transformingFuture);
-    return transformingFuture;
-  }
+  public ApiStreamObserver<RequestT> bidiStreamingCall(
+      ApiStreamObserver<ResponseT> responseObserver, ApiCallContext context) {
 
-  private class ExceptionTransformingFuture extends AbstractApiFuture<ResponseT>
-      implements ApiFutureCallback<ResponseT> {
-    private ApiFuture<ResponseT> innerCallFuture;
-    private volatile boolean cancelled = false;
+    GrpcApiExceptionResponseObserver<ResponseT> innerObserver =
+        new GrpcApiExceptionResponseObserver<>(responseObserver, exceptionFactory);
 
-    public ExceptionTransformingFuture(ApiFuture<ResponseT> innerCallFuture) {
-      this.innerCallFuture = innerCallFuture;
-    }
-
-    @Override
-    protected void interruptTask() {
-      cancelled = true;
-      innerCallFuture.cancel(true);
-    }
-
-    @Override
-    public void onSuccess(ResponseT r) {
-      super.set(r);
-    }
-
-    @Override
-    public void onFailure(Throwable throwable) {
-      if (throwable instanceof CancellationException && cancelled) {
-        // this just circled around, so ignore.
-        return;
-      } else {
-        setException(exceptionFactory.create(throwable));
-      }
-    }
+    return innerCallable.bidiStreamingCall(innerObserver, context);
   }
 }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcExceptionBidiStreamingCallable.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcExceptionBidiStreamingCallable.java
@@ -57,8 +57,8 @@ final class GrpcExceptionBidiStreamingCallable<RequestT, ResponseT>
   public ApiStreamObserver<RequestT> bidiStreamingCall(
       ApiStreamObserver<ResponseT> responseObserver, ApiCallContext context) {
 
-    GrpcApiExceptionResponseObserver<ResponseT> innerObserver =
-        new GrpcApiExceptionResponseObserver<>(responseObserver, exceptionFactory);
+    GrpcExceptionTranslatingStreamObserver<ResponseT> innerObserver =
+        new GrpcExceptionTranslatingStreamObserver<>(responseObserver, exceptionFactory);
 
     return innerCallable.bidiStreamingCall(innerObserver, context);
   }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcExceptionClientStreamingCallable.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcExceptionClientStreamingCallable.java
@@ -29,71 +29,37 @@
  */
 package com.google.api.gax.grpc;
 
-import com.google.api.core.AbstractApiFuture;
-import com.google.api.core.ApiFuture;
-import com.google.api.core.ApiFutureCallback;
-import com.google.api.core.ApiFutures;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.ClientStreamingCallable;
 import com.google.api.gax.rpc.StatusCode;
-import com.google.api.gax.rpc.UnaryCallable;
-import com.google.common.base.Preconditions;
 import java.util.Set;
-import java.util.concurrent.CancellationException;
 
 /**
  * Transforms all {@code Throwable}s thrown during a call into an instance of {@link ApiException}.
  *
  * <p>Package-private for internal use.
  */
-class GrpcExceptionCallable<RequestT, ResponseT> extends UnaryCallable<RequestT, ResponseT> {
-  private final UnaryCallable<RequestT, ResponseT> callable;
+final class GrpcExceptionClientStreamingCallable<RequestT, ResponseT>
+    extends ClientStreamingCallable<RequestT, ResponseT> {
+  private final ClientStreamingCallable<RequestT, ResponseT> innerCallable;
   private final GrpcApiExceptionFactory exceptionFactory;
 
-  GrpcExceptionCallable(
-      UnaryCallable<RequestT, ResponseT> callable, Set<StatusCode.Code> retryableCodes) {
-    this.callable = Preconditions.checkNotNull(callable);
+  GrpcExceptionClientStreamingCallable(
+      ClientStreamingCallable<RequestT, ResponseT> innerCallable,
+      Set<StatusCode.Code> retryableCodes) {
+    this.innerCallable = innerCallable;
     this.exceptionFactory = new GrpcApiExceptionFactory(retryableCodes);
   }
 
   @Override
-  public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext inputContext) {
-    GrpcCallContext context = GrpcCallContext.createDefault().nullToSelf(inputContext);
-    ApiFuture<ResponseT> innerCallFuture = callable.futureCall(request, context);
-    ExceptionTransformingFuture transformingFuture =
-        new ExceptionTransformingFuture(innerCallFuture);
-    ApiFutures.addCallback(innerCallFuture, transformingFuture);
-    return transformingFuture;
-  }
+  public ApiStreamObserver<RequestT> clientStreamingCall(
+      ApiStreamObserver<ResponseT> responseObserver, ApiCallContext context) {
 
-  private class ExceptionTransformingFuture extends AbstractApiFuture<ResponseT>
-      implements ApiFutureCallback<ResponseT> {
-    private ApiFuture<ResponseT> innerCallFuture;
-    private volatile boolean cancelled = false;
+    GrpcApiExceptionResponseObserver<ResponseT> innerObserver =
+        new GrpcApiExceptionResponseObserver<>(responseObserver, exceptionFactory);
 
-    public ExceptionTransformingFuture(ApiFuture<ResponseT> innerCallFuture) {
-      this.innerCallFuture = innerCallFuture;
-    }
-
-    @Override
-    protected void interruptTask() {
-      cancelled = true;
-      innerCallFuture.cancel(true);
-    }
-
-    @Override
-    public void onSuccess(ResponseT r) {
-      super.set(r);
-    }
-
-    @Override
-    public void onFailure(Throwable throwable) {
-      if (throwable instanceof CancellationException && cancelled) {
-        // this just circled around, so ignore.
-        return;
-      } else {
-        setException(exceptionFactory.create(throwable));
-      }
-    }
+    return innerCallable.clientStreamingCall(innerObserver, context);
   }
 }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcExceptionClientStreamingCallable.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcExceptionClientStreamingCallable.java
@@ -57,8 +57,8 @@ final class GrpcExceptionClientStreamingCallable<RequestT, ResponseT>
   public ApiStreamObserver<RequestT> clientStreamingCall(
       ApiStreamObserver<ResponseT> responseObserver, ApiCallContext context) {
 
-    GrpcApiExceptionResponseObserver<ResponseT> innerObserver =
-        new GrpcApiExceptionResponseObserver<>(responseObserver, exceptionFactory);
+    GrpcExceptionTranslatingStreamObserver<ResponseT> innerObserver =
+        new GrpcExceptionTranslatingStreamObserver<>(responseObserver, exceptionFactory);
 
     return innerCallable.clientStreamingCall(innerObserver, context);
   }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcExceptionTranslatingStreamObserver.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcExceptionTranslatingStreamObserver.java
@@ -39,11 +39,12 @@ import com.google.api.gax.rpc.ApiStreamObserver;
  *
  * @param <ResponseT>
  */
-final class GrpcApiExceptionResponseObserver<ResponseT> implements ApiStreamObserver<ResponseT> {
+final class GrpcExceptionTranslatingStreamObserver<ResponseT>
+    implements ApiStreamObserver<ResponseT> {
   private final ApiStreamObserver<ResponseT> innerObserver;
   private final GrpcApiExceptionFactory exceptionFactory;
 
-  GrpcApiExceptionResponseObserver(
+  GrpcExceptionTranslatingStreamObserver(
       ApiStreamObserver<ResponseT> innerObserver, GrpcApiExceptionFactory exceptionFactory) {
     this.innerObserver = innerObserver;
     this.exceptionFactory = exceptionFactory;

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectStreamingCallableTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectStreamingCallableTest.java
@@ -35,10 +35,12 @@ import static com.google.api.gax.grpc.testing.FakeServiceGrpc.METHOD_STREAMING_R
 
 import com.google.api.gax.grpc.testing.FakeServiceImpl;
 import com.google.api.gax.grpc.testing.InProcessServer;
+import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.ApiStreamObserver;
 import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.ClientStreamingCallable;
+import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.common.truth.Truth;
 import com.google.type.Color;
 import com.google.type.Money;
@@ -125,8 +127,9 @@ public class GrpcDirectStreamingCallableTest {
 
     latch.await(20, TimeUnit.SECONDS);
     Truth.assertThat(moneyObserver.error).isNotNull();
-    Truth.assertThat(moneyObserver.error).isInstanceOf(StatusRuntimeException.class);
-    Truth.assertThat(((StatusRuntimeException) moneyObserver.error).getStatus())
+    Truth.assertThat(moneyObserver.error).isInstanceOf(ApiException.class);
+    Truth.assertThat(moneyObserver.error.getCause()).isInstanceOf(StatusRuntimeException.class);
+    Truth.assertThat(((StatusRuntimeException) moneyObserver.error.getCause()).getStatus())
         .isEqualTo(Status.INVALID_ARGUMENT);
     Truth.assertThat(moneyObserver.response).isNull();
   }
@@ -147,9 +150,9 @@ public class GrpcDirectStreamingCallableTest {
 
     latch.await(20, TimeUnit.SECONDS);
     Truth.assertThat(moneyObserver.error).isNotNull();
-    Truth.assertThat(moneyObserver.error).isInstanceOf(StatusRuntimeException.class);
-    Truth.assertThat(((StatusRuntimeException) moneyObserver.error).getStatus().getCode())
-        .isEqualTo(Status.CANCELLED.getCode());
+    Truth.assertThat(moneyObserver.error).isInstanceOf(ApiException.class);
+    Truth.assertThat(((ApiException) moneyObserver.error).getStatusCode().getCode())
+        .isEqualTo(Code.CANCELLED);
     Truth.assertThat(moneyObserver.response).isNull();
     StatusException serverReceivedError = (StatusException) serviceImpl.getLastRecievedError();
     Truth.assertThat(serverReceivedError.getStatus()).isEqualTo(Status.CANCELLED);


### PR DESCRIPTION
note: This changes current behavior in non-backward compatible ways.

This adds exception wrapping for all streaming rpcs (client, server & bidi). 

This should address #383 and https://github.com/GoogleCloudPlatform/google-cloud-java/issues/2671