### PR TITLE
Making autovalue a compile-only dependency

### DIFF
--- a/gax-grpc/build.gradle
+++ b/gax-grpc/build.gradle
@@ -9,12 +9,13 @@ dependencies {
     libraries.grpcProtobuf,
     libraries.guava,
     libraries.jsr305,
-    libraries.autovalue,
     libraries.threetenbp,
     libraries.auth,
     libraries.authCredentials,
     libraries.commonProtos,
     libraries.apiCommon
+
+  compileOnly libraries.autovalue
 
   testCompile project(':gax').sourceSets.test.output,
     libraries.junit,

--- a/gax-httpjson/build.gradle
+++ b/gax-httpjson/build.gradle
@@ -6,12 +6,13 @@ dependencies {
     libraries.gson,
     libraries.guava,
     libraries.jsr305,
-    libraries.autovalue,
     libraries.threetenbp,
     libraries.httpClient,
     libraries.auth,
     libraries.authCredentials,
     libraries.apiCommon
+
+  compileOnly libraries.autovalue
 
   testCompile project(':gax').sourceSets.test.output,
     libraries.junit,

--- a/gax/build.gradle
+++ b/gax/build.gradle
@@ -15,14 +15,16 @@ archivesBaseName = "gax"
 dependencies {
   compile libraries.guava,
     libraries.jsr305,
-    libraries.autovalue,
     libraries.threetenbp,
     libraries.auth,
     libraries.apiCommon
 
+  compileOnly libraries.autovalue
+
   testCompile libraries.junit,
     libraries.mockito,
-    libraries.truth
+    libraries.truth,
+    libraries.autovalue
 
   apt libraries.autovalue
 


### PR DESCRIPTION
This makes it so that autovalue doesn't show up in consumer dependency trees. This is possible since autovalue has only source retention as an annotation. 