### PR TITLE
Add ResponseObserver sanity checks.

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcExceptionServerStreamingCallable.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcExceptionServerStreamingCallable.java
@@ -29,11 +29,11 @@
  */
 package com.google.api.gax.grpc;
 
-import com.google.api.gax.rpc.AbstractResponseObserver;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StateCheckingResponseObserver;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.api.gax.rpc.StreamController;
 import java.util.Set;
@@ -62,7 +62,7 @@ class GrpcExceptionServerStreamingCallable<RequestT, ResponseT>
     inner.call(request, new ExceptionResponseObserver(responseObserver), context);
   }
 
-  private class ExceptionResponseObserver extends AbstractResponseObserver<ResponseT> {
+  private class ExceptionResponseObserver extends StateCheckingResponseObserver<ResponseT> {
     private ResponseObserver<ResponseT> innerObserver;
     private volatile CancellationException cancellationException;
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcExceptionServerStreamingCallable.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcExceptionServerStreamingCallable.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.api.gax.rpc.AbstractResponseObserver;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.ResponseObserver;
@@ -61,7 +62,7 @@ class GrpcExceptionServerStreamingCallable<RequestT, ResponseT>
     inner.call(request, new ExceptionResponseObserver(responseObserver), context);
   }
 
-  private class ExceptionResponseObserver implements ResponseObserver<ResponseT> {
+  private class ExceptionResponseObserver extends AbstractResponseObserver<ResponseT> {
     private ResponseObserver<ResponseT> innerObserver;
     private volatile CancellationException cancellationException;
 
@@ -70,7 +71,7 @@ class GrpcExceptionServerStreamingCallable<RequestT, ResponseT>
     }
 
     @Override
-    public void onStart(final StreamController controller) {
+    public void onStartImpl(final StreamController controller) {
       innerObserver.onStart(
           new StreamController() {
             @Override
@@ -92,12 +93,12 @@ class GrpcExceptionServerStreamingCallable<RequestT, ResponseT>
     }
 
     @Override
-    public void onResponse(ResponseT response) {
+    public void onResponseImpl(ResponseT response) {
       innerObserver.onResponse(response);
     }
 
     @Override
-    public void onError(Throwable t) {
+    public void onErrorImpl(Throwable t) {
       if (cancellationException != null) {
         t = cancellationException;
       } else {
@@ -107,7 +108,7 @@ class GrpcExceptionServerStreamingCallable<RequestT, ResponseT>
     }
 
     @Override
-    public void onComplete() {
+    public void onCompleteImpl() {
       innerObserver.onComplete();
     }
   }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcExceptionServerStreamingCallable.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcExceptionServerStreamingCallable.java
@@ -71,7 +71,7 @@ class GrpcExceptionServerStreamingCallable<RequestT, ResponseT>
     }
 
     @Override
-    public void onStartImpl(final StreamController controller) {
+    protected void onStartImpl(final StreamController controller) {
       innerObserver.onStart(
           new StreamController() {
             @Override
@@ -93,12 +93,12 @@ class GrpcExceptionServerStreamingCallable<RequestT, ResponseT>
     }
 
     @Override
-    public void onResponseImpl(ResponseT response) {
+    protected void onResponseImpl(ResponseT response) {
       innerObserver.onResponse(response);
     }
 
     @Override
-    public void onErrorImpl(Throwable t) {
+    protected void onErrorImpl(Throwable t) {
       if (cancellationException != null) {
         t = cancellationException;
       } else {
@@ -108,7 +108,7 @@ class GrpcExceptionServerStreamingCallable<RequestT, ResponseT>
     }
 
     @Override
-    public void onCompleteImpl() {
+    protected void onCompleteImpl() {
       innerObserver.onComplete();
     }
   }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectServerStreamingCallableTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectServerStreamingCallableTest.java
@@ -206,20 +206,20 @@ public class GrpcDirectServerStreamingCallableTest {
     ResponseObserver<Money> moneyObserver =
         new AbstractResponseObserver<Money>() {
           @Override
-          public void onStartImpl(StreamController controller) {}
+          protected void onStartImpl(StreamController controller) {}
 
           @Override
-          public void onResponseImpl(Money response) {
+          protected void onResponseImpl(Money response) {
             throw expectedCause;
           }
 
           @Override
-          public void onErrorImpl(Throwable t) {
+          protected void onErrorImpl(Throwable t) {
             actualErrorF.set(t);
           }
 
           @Override
-          public void onCompleteImpl() {
+          protected void onCompleteImpl() {
             actualErrorF.set(null);
           }
         };
@@ -262,7 +262,7 @@ public class GrpcDirectServerStreamingCallableTest {
     }
 
     @Override
-    public void onStartImpl(StreamController controller) {
+    protected void onStartImpl(StreamController controller) {
       this.controller = controller;
       if (!autoFlowControl) {
         controller.disableAutoInboundFlowControl();
@@ -270,19 +270,19 @@ public class GrpcDirectServerStreamingCallableTest {
     }
 
     @Override
-    public void onResponseImpl(Money value) {
+    protected void onResponseImpl(Money value) {
       response = value;
       latch.countDown();
     }
 
     @Override
-    public void onErrorImpl(Throwable t) {
+    protected void onErrorImpl(Throwable t) {
       error = t;
       latch.countDown();
     }
 
     @Override
-    public void onCompleteImpl() {
+    protected void onCompleteImpl() {
       completed = true;
       latch.countDown();
     }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectServerStreamingCallableTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectServerStreamingCallableTest.java
@@ -34,13 +34,13 @@ import static com.google.api.gax.grpc.testing.FakeServiceGrpc.METHOD_SERVER_STRE
 import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.grpc.testing.FakeServiceImpl;
 import com.google.api.gax.grpc.testing.InProcessServer;
-import com.google.api.gax.rpc.AbstractResponseObserver;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStream;
 import com.google.api.gax.rpc.ServerStreamingCallSettings;
 import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StateCheckingResponseObserver;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.StreamController;
 import com.google.api.gax.rpc.testing.FakeCallContext;
@@ -204,7 +204,7 @@ public class GrpcDirectServerStreamingCallableTest {
     final SettableApiFuture<Throwable> actualErrorF = SettableApiFuture.create();
 
     ResponseObserver<Money> moneyObserver =
-        new AbstractResponseObserver<Money>() {
+        new StateCheckingResponseObserver<Money>() {
           @Override
           protected void onStartImpl(StreamController controller) {}
 
@@ -247,7 +247,7 @@ public class GrpcDirectServerStreamingCallableTest {
     Truth.assertThat(responseData).containsExactly(expected);
   }
 
-  private static class MoneyObserver extends AbstractResponseObserver<Money> {
+  private static class MoneyObserver extends StateCheckingResponseObserver<Money> {
     private final boolean autoFlowControl;
     private final CountDownLatch latch;
 

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectServerStreamingCallableTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectServerStreamingCallableTest.java
@@ -34,6 +34,7 @@ import static com.google.api.gax.grpc.testing.FakeServiceGrpc.METHOD_SERVER_STRE
 import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.grpc.testing.FakeServiceImpl;
 import com.google.api.gax.grpc.testing.InProcessServer;
+import com.google.api.gax.rpc.AbstractResponseObserver;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.ResponseObserver;
@@ -203,22 +204,22 @@ public class GrpcDirectServerStreamingCallableTest {
     final SettableApiFuture<Throwable> actualErrorF = SettableApiFuture.create();
 
     ResponseObserver<Money> moneyObserver =
-        new ResponseObserver<Money>() {
+        new AbstractResponseObserver<Money>() {
           @Override
-          public void onStart(StreamController controller) {}
+          public void onStartImpl(StreamController controller) {}
 
           @Override
-          public void onResponse(Money response) {
+          public void onResponseImpl(Money response) {
             throw expectedCause;
           }
 
           @Override
-          public void onError(Throwable t) {
+          public void onErrorImpl(Throwable t) {
             actualErrorF.set(t);
           }
 
           @Override
-          public void onComplete() {
+          public void onCompleteImpl() {
             actualErrorF.set(null);
           }
         };
@@ -246,7 +247,7 @@ public class GrpcDirectServerStreamingCallableTest {
     Truth.assertThat(responseData).containsExactly(expected);
   }
 
-  private static class MoneyObserver implements ResponseObserver<Money> {
+  private static class MoneyObserver extends AbstractResponseObserver<Money> {
     private final boolean autoFlowControl;
     private final CountDownLatch latch;
 
@@ -261,7 +262,7 @@ public class GrpcDirectServerStreamingCallableTest {
     }
 
     @Override
-    public void onStart(StreamController controller) {
+    public void onStartImpl(StreamController controller) {
       this.controller = controller;
       if (!autoFlowControl) {
         controller.disableAutoInboundFlowControl();
@@ -269,19 +270,19 @@ public class GrpcDirectServerStreamingCallableTest {
     }
 
     @Override
-    public void onResponse(Money value) {
+    public void onResponseImpl(Money value) {
       response = value;
       latch.countDown();
     }
 
     @Override
-    public void onError(Throwable t) {
+    public void onErrorImpl(Throwable t) {
       error = t;
       latch.countDown();
     }
 
     @Override
-    public void onComplete() {
+    public void onCompleteImpl() {
       completed = true;
       latch.countDown();
     }

--- a/gax/src/main/java/com/google/api/gax/rpc/AbstractResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/AbstractResponseObserver.java
@@ -38,6 +38,12 @@ public abstract class AbstractResponseObserver<V> implements ResponseObserver<V>
   private boolean isStarted;
   private boolean isClosed;
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation simply delegates to {@link #onStartImpl(StreamController)} after
+   * ensuring consistent state.
+   */
   public final void onStart(StreamController controller) {
     Preconditions.checkState(!isStarted, getClass() + " is already started.");
     isStarted = true;
@@ -45,65 +51,50 @@ public abstract class AbstractResponseObserver<V> implements ResponseObserver<V>
     onStartImpl(controller);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation simply delegates to {@link #onResponse(Object)} after ensuring
+   * consistent state.
+   */
   public final void onResponse(V response) {
     Preconditions.checkState(!isClosed, getClass() + " received a response after being closed.");
     onResponseImpl(response);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation simply delegates to {@link #onComplete()} after ensuring consistent
+   * state.
+   */
   public final void onComplete() {
     Preconditions.checkState(!isClosed, getClass() + " tried to double close.");
     isClosed = true;
     onCompleteImpl();
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation simply delegates to {@link #onError(Throwable)} after ensuring
+   * consistent state.
+   */
   public final void onError(Throwable t) {
     Preconditions.checkState(!isClosed, getClass() + " received error after being closed", t);
     isClosed = true;
     onErrorImpl(t);
   }
 
-  /**
-   * Called before the stream is started. This must be invoked synchronously on the same thread that
-   * called {@link ServerStreamingCallable#call(Object, ResponseObserver, ApiCallContext)}
-   *
-   * <p>Allows for disabling flow control and early stream termination via {@code StreamController}.
-   *
-   * @param controller The controller for the stream.
-   */
+  /** @see #onStart(StreamController) */
   protected abstract void onStartImpl(StreamController controller);
 
-  /**
-   * Receives a value from the stream.
-   *
-   * <p>Can be called many times but is never called after {@link #onError(Throwable)} or {@link
-   * #onComplete()} are called.
-   *
-   * <p>Clients may may receive 0 or more onResponse callbacks.
-   *
-   * <p>If an exception is thrown by an implementation the caller will terminate the stream by
-   * calling {@link #onError(Throwable)} with the caught exception as the cause.
-   *
-   * @param response the value passed to the stream
-   */
+  /** @see #onResponse(Object) */
   protected abstract void onResponseImpl(V response);
 
-  /**
-   * Receives a terminating error from the stream.
-   *
-   * <p>May only be called once, and if called, it must be the last method called. In particular, if
-   * an exception is thrown by an implementation of {@code onError}, no further calls to any method
-   * are allowed.
-   *
-   * @param t the error occurred on the stream
-   */
+  /** @see #onErrorImpl(Throwable) */
   protected abstract void onErrorImpl(Throwable t);
 
-  /**
-   * Receives a notification of successful stream completion.
-   *
-   * <p>May only be called once, and if called, it must be the last method called. In particular, if
-   * an exception is thrown by an implementation of {@code onComplete}, no further calls to any
-   * method are allowed.
-   */
+  /** @see #onComplete() */
   protected abstract void onCompleteImpl();
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/AbstractResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/AbstractResponseObserver.java
@@ -29,11 +29,15 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
 import com.google.common.base.Preconditions;
 
-/** Base implementation of {@link ResponseObserver} that performs state sanity checks. */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
+/**
+ * Base implementation of {@link ResponseObserver} that performs state sanity checks.
+ *
+ * <p>This is public only for technical reasons, for advanced usage.
+ */
+@InternalApi
 public abstract class AbstractResponseObserver<V> implements ResponseObserver<V> {
   private boolean isStarted;
   private boolean isClosed;

--- a/gax/src/main/java/com/google/api/gax/rpc/AbstractResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/AbstractResponseObserver.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.BetaApi;
+import com.google.common.base.Preconditions;
+
+/** Base implementation of {@link ResponseObserver} that performs state sanity checks. */
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
+public abstract class AbstractResponseObserver<V> implements ResponseObserver<V> {
+  private boolean isStarted;
+  private boolean isClosed;
+
+  public final void onStart(StreamController controller) {
+    Preconditions.checkState(!isStarted, getClass() + " is already started.");
+    isStarted = true;
+
+    onStartImpl(controller);
+  }
+
+  public final void onResponse(V response) {
+    Preconditions.checkState(!isClosed, getClass() + " received a response after being closed.");
+    onResponseImpl(response);
+  }
+
+  public final void onComplete() {
+    Preconditions.checkState(!isClosed, getClass() + " tried to double close.");
+    isClosed = true;
+    onCompleteImpl();
+  }
+
+  public final void onError(Throwable t) {
+    Preconditions.checkState(!isClosed, getClass() + " received error after being closed", t);
+    isClosed = true;
+    onErrorImpl(t);
+  }
+
+  /**
+   * Called before the stream is started. This must be invoked synchronously on the same thread that
+   * called {@link ServerStreamingCallable#call(Object, ResponseObserver, ApiCallContext)}
+   *
+   * <p>Allows for disabling flow control and early stream termination via {@code StreamController}.
+   *
+   * @param controller The controller for the stream.
+   */
+  protected abstract void onStartImpl(StreamController controller);
+
+  /**
+   * Receives a value from the stream.
+   *
+   * <p>Can be called many times but is never called after {@link #onError(Throwable)} or {@link
+   * #onComplete()} are called.
+   *
+   * <p>Clients may may receive 0 or more onResponse callbacks.
+   *
+   * <p>If an exception is thrown by an implementation the caller will terminate the stream by
+   * calling {@link #onError(Throwable)} with the caught exception as the cause.
+   *
+   * @param response the value passed to the stream
+   */
+  protected abstract void onResponseImpl(V response);
+
+  /**
+   * Receives a terminating error from the stream.
+   *
+   * <p>May only be called once, and if called, it must be the last method called. In particular, if
+   * an exception is thrown by an implementation of {@code onError}, no further calls to any method
+   * are allowed.
+   *
+   * @param t the error occurred on the stream
+   */
+  protected abstract void onErrorImpl(Throwable t);
+
+  /**
+   * Receives a notification of successful stream completion.
+   *
+   * <p>May only be called once, and if called, it must be the last method called. In particular, if
+   * an exception is thrown by an implementation of {@code onComplete}, no further calls to any
+   * method are allowed.
+   */
+  protected abstract void onCompleteImpl();
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/AbstractResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/AbstractResponseObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Google LLC All rights reserved.
+ * Copyright 2018, Google LLC All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/gax/src/main/java/com/google/api/gax/rpc/FirstElementResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FirstElementResponseObserver.java
@@ -45,7 +45,7 @@ class FirstElementResponseObserver<ResponseT> extends AbstractResponseObserver<R
   private StreamController controller;
 
   @Override
-  public void onStartImpl(StreamController controller) {
+  protected void onStartImpl(StreamController controller) {
     // NOTE: the call is started before the future is exposed to the caller
     this.controller = controller;
 
@@ -54,18 +54,18 @@ class FirstElementResponseObserver<ResponseT> extends AbstractResponseObserver<R
   }
 
   @Override
-  public void onResponseImpl(ResponseT response) {
+  protected void onResponseImpl(ResponseT response) {
     future.set(response);
     controller.cancel();
   }
 
   @Override
-  public void onErrorImpl(Throwable t) {
+  protected void onErrorImpl(Throwable t) {
     future.setException(t);
   }
 
   @Override
-  public void onCompleteImpl() {
+  protected void onCompleteImpl() {
     future.set(null);
   }
 

--- a/gax/src/main/java/com/google/api/gax/rpc/FirstElementResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FirstElementResponseObserver.java
@@ -40,12 +40,12 @@ import com.google.api.core.ApiFuture;
  *
  * @param <ResponseT> The type of the element in the stream.
  */
-class FirstElementResponseObserver<ResponseT> implements ResponseObserver<ResponseT> {
+class FirstElementResponseObserver<ResponseT> extends AbstractResponseObserver<ResponseT> {
   private final MyFuture future = new MyFuture();
   private StreamController controller;
 
   @Override
-  public void onStart(StreamController controller) {
+  public void onStartImpl(StreamController controller) {
     // NOTE: the call is started before the future is exposed to the caller
     this.controller = controller;
 
@@ -54,18 +54,18 @@ class FirstElementResponseObserver<ResponseT> implements ResponseObserver<Respon
   }
 
   @Override
-  public void onResponse(ResponseT response) {
+  public void onResponseImpl(ResponseT response) {
     future.set(response);
     controller.cancel();
   }
 
   @Override
-  public void onError(Throwable t) {
+  public void onErrorImpl(Throwable t) {
     future.setException(t);
   }
 
   @Override
-  public void onComplete() {
+  public void onCompleteImpl() {
     future.set(null);
   }
 

--- a/gax/src/main/java/com/google/api/gax/rpc/FirstElementResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FirstElementResponseObserver.java
@@ -40,7 +40,7 @@ import com.google.api.core.ApiFuture;
  *
  * @param <ResponseT> The type of the element in the stream.
  */
-class FirstElementResponseObserver<ResponseT> extends AbstractResponseObserver<ResponseT> {
+class FirstElementResponseObserver<ResponseT> extends StateCheckingResponseObserver<ResponseT> {
   private final MyFuture future = new MyFuture();
   private StreamController controller;
 

--- a/gax/src/main/java/com/google/api/gax/rpc/QueuingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/QueuingResponseObserver.java
@@ -52,7 +52,7 @@ import java.util.concurrent.BlockingQueue;
  *
  * @param <V> The item type.
  */
-final class QueuingResponseObserver<V> implements ResponseObserver<V> {
+final class QueuingResponseObserver<V> extends AbstractResponseObserver<V> {
   static final Object EOF_MARKER = new Object();
 
   private final BlockingQueue<Object> buffer = Queues.newArrayBlockingQueue(2);
@@ -90,7 +90,7 @@ final class QueuingResponseObserver<V> implements ResponseObserver<V> {
    * @param controller The controller for the stream.
    */
   @Override
-  public void onStart(StreamController controller) {
+  public void onStartImpl(StreamController controller) {
     this.controller = controller;
     controller.disableAutoInboundFlowControl();
     controller.request(1);
@@ -102,7 +102,7 @@ final class QueuingResponseObserver<V> implements ResponseObserver<V> {
    * @param response The received response.
    */
   @Override
-  public void onResponse(V response) {
+  public void onResponseImpl(V response) {
     buffer.add(response);
   }
 
@@ -113,7 +113,7 @@ final class QueuingResponseObserver<V> implements ResponseObserver<V> {
    * @param t The error occurred on the stream
    */
   @Override
-  public void onError(Throwable t) {
+  public void onErrorImpl(Throwable t) {
     buffer.add(t);
   }
 
@@ -123,7 +123,7 @@ final class QueuingResponseObserver<V> implements ResponseObserver<V> {
    * completion marker.
    */
   @Override
-  public void onComplete() {
+  public void onCompleteImpl() {
     buffer.add(EOF_MARKER);
   }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/QueuingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/QueuingResponseObserver.java
@@ -52,7 +52,7 @@ import java.util.concurrent.BlockingQueue;
  *
  * @param <V> The item type.
  */
-final class QueuingResponseObserver<V> extends AbstractResponseObserver<V> {
+final class QueuingResponseObserver<V> extends StateCheckingResponseObserver<V> {
   static final Object EOF_MARKER = new Object();
 
   private final BlockingQueue<Object> buffer = Queues.newArrayBlockingQueue(2);

--- a/gax/src/main/java/com/google/api/gax/rpc/QueuingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/QueuingResponseObserver.java
@@ -90,7 +90,7 @@ final class QueuingResponseObserver<V> extends AbstractResponseObserver<V> {
    * @param controller The controller for the stream.
    */
   @Override
-  public void onStartImpl(StreamController controller) {
+  protected void onStartImpl(StreamController controller) {
     this.controller = controller;
     controller.disableAutoInboundFlowControl();
     controller.request(1);
@@ -102,7 +102,7 @@ final class QueuingResponseObserver<V> extends AbstractResponseObserver<V> {
    * @param response The received response.
    */
   @Override
-  public void onResponseImpl(V response) {
+  protected void onResponseImpl(V response) {
     buffer.add(response);
   }
 
@@ -113,7 +113,7 @@ final class QueuingResponseObserver<V> extends AbstractResponseObserver<V> {
    * @param t The error occurred on the stream
    */
   @Override
-  public void onErrorImpl(Throwable t) {
+  protected void onErrorImpl(Throwable t) {
     buffer.add(t);
   }
 
@@ -123,7 +123,7 @@ final class QueuingResponseObserver<V> extends AbstractResponseObserver<V> {
    * completion marker.
    */
   @Override
-  public void onCompleteImpl() {
+  protected void onCompleteImpl() {
     buffer.add(EOF_MARKER);
   }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/ReframingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ReframingResponseObserver.java
@@ -121,7 +121,7 @@ public class ReframingResponseObserver<InnerT, OuterT> extends AbstractResponseO
    * @param controller The controller for the upstream stream.
    */
   @Override
-  public void onStartImpl(StreamController controller) {
+  protected void onStartImpl(StreamController controller) {
     innerController = controller;
     innerController.disableAutoInboundFlowControl();
 
@@ -201,7 +201,7 @@ public class ReframingResponseObserver<InnerT, OuterT> extends AbstractResponseO
    * <p>If the delivery loop is stopped, this will restart it.
    */
   @Override
-  public void onResponseImpl(InnerT response) {
+  protected void onResponseImpl(InnerT response) {
     synchronized (lock) {
       Preconditions.checkState(awaitingInner, "Received unsolicited response from upstream");
       awaitingInner = false;
@@ -217,7 +217,7 @@ public class ReframingResponseObserver<InnerT, OuterT> extends AbstractResponseO
    * <p>If the delivery loop is stopped, this will restart it.
    */
   @Override
-  public void onErrorImpl(Throwable t) {
+  protected void onErrorImpl(Throwable t) {
     synchronized (lock) {
       if (error == null) {
         error = t;
@@ -234,7 +234,7 @@ public class ReframingResponseObserver<InnerT, OuterT> extends AbstractResponseO
    * <p>If the delivery loop is stopped, this will restart it.
    */
   @Override
-  public void onCompleteImpl() {
+  protected void onCompleteImpl() {
     synchronized (lock) {
       closeOnDone = true;
     }

--- a/gax/src/main/java/com/google/api/gax/rpc/ReframingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ReframingResponseObserver.java
@@ -67,7 +67,8 @@ import javax.annotation.concurrent.GuardedBy;
  * }</pre>
  */
 @BetaApi("The surface for streaming is not stable yet and may change in the future.")
-public class ReframingResponseObserver<InnerT, OuterT> extends AbstractResponseObserver<InnerT> {
+public class ReframingResponseObserver<InnerT, OuterT>
+    extends StateCheckingResponseObserver<InnerT> {
   private final Object lock = new Object();
 
   @GuardedBy("lock")

--- a/gax/src/main/java/com/google/api/gax/rpc/ReframingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ReframingResponseObserver.java
@@ -67,7 +67,7 @@ import javax.annotation.concurrent.GuardedBy;
  * }</pre>
  */
 @BetaApi("The surface for streaming is not stable yet and may change in the future.")
-public class ReframingResponseObserver<InnerT, OuterT> implements ResponseObserver<InnerT> {
+public class ReframingResponseObserver<InnerT, OuterT> extends AbstractResponseObserver<InnerT> {
   private final Object lock = new Object();
 
   @GuardedBy("lock")
@@ -121,7 +121,7 @@ public class ReframingResponseObserver<InnerT, OuterT> implements ResponseObserv
    * @param controller The controller for the upstream stream.
    */
   @Override
-  public void onStart(StreamController controller) {
+  public void onStartImpl(StreamController controller) {
     innerController = controller;
     innerController.disableAutoInboundFlowControl();
 
@@ -201,7 +201,7 @@ public class ReframingResponseObserver<InnerT, OuterT> implements ResponseObserv
    * <p>If the delivery loop is stopped, this will restart it.
    */
   @Override
-  public void onResponse(InnerT response) {
+  public void onResponseImpl(InnerT response) {
     synchronized (lock) {
       Preconditions.checkState(awaitingInner, "Received unsolicited response from upstream");
       awaitingInner = false;
@@ -217,7 +217,7 @@ public class ReframingResponseObserver<InnerT, OuterT> implements ResponseObserv
    * <p>If the delivery loop is stopped, this will restart it.
    */
   @Override
-  public void onError(Throwable t) {
+  public void onErrorImpl(Throwable t) {
     synchronized (lock) {
       if (error == null) {
         error = t;
@@ -234,7 +234,7 @@ public class ReframingResponseObserver<InnerT, OuterT> implements ResponseObserv
    * <p>If the delivery loop is stopped, this will restart it.
    */
   @Override
-  public void onComplete() {
+  public void onCompleteImpl() {
     synchronized (lock) {
       closeOnDone = true;
     }

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
@@ -239,22 +239,22 @@ public abstract class ServerStreamingCallable<RequestT, ResponseT> {
     }
 
     @Override
-    public void onStartImpl(StreamController controller) {
+    protected void onStartImpl(StreamController controller) {
       // Noop: the old style assumes automatic flow control and doesn't support cancellation.
     }
 
     @Override
-    public void onResponseImpl(T response) {
+    protected void onResponseImpl(T response) {
       delegate.onNext(response);
     }
 
     @Override
-    public void onErrorImpl(Throwable t) {
+    protected void onErrorImpl(Throwable t) {
       delegate.onError(t);
     }
 
     @Override
-    public void onCompleteImpl() {
+    protected void onCompleteImpl() {
       delegate.onCompleted();
     }
   }

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
@@ -231,7 +231,7 @@ public abstract class ServerStreamingCallable<RequestT, ResponseT> {
    * @deprecated Use ResponseObserver directly
    */
   @Deprecated
-  private static class ApiStreamObserverAdapter<T> extends AbstractResponseObserver<T> {
+  private static class ApiStreamObserverAdapter<T> extends StateCheckingResponseObserver<T> {
     private final ApiStreamObserver<T> delegate;
 
     ApiStreamObserverAdapter(ApiStreamObserver<T> delegate) {

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
@@ -231,7 +231,7 @@ public abstract class ServerStreamingCallable<RequestT, ResponseT> {
    * @deprecated Use ResponseObserver directly
    */
   @Deprecated
-  private static class ApiStreamObserverAdapter<T> implements ResponseObserver<T> {
+  private static class ApiStreamObserverAdapter<T> extends AbstractResponseObserver<T> {
     private final ApiStreamObserver<T> delegate;
 
     ApiStreamObserverAdapter(ApiStreamObserver<T> delegate) {
@@ -239,22 +239,22 @@ public abstract class ServerStreamingCallable<RequestT, ResponseT> {
     }
 
     @Override
-    public void onStart(StreamController controller) {
+    public void onStartImpl(StreamController controller) {
       // Noop: the old style assumes automatic flow control and doesn't support cancellation.
     }
 
     @Override
-    public void onResponse(T response) {
+    public void onResponseImpl(T response) {
       delegate.onNext(response);
     }
 
     @Override
-    public void onError(Throwable t) {
+    public void onErrorImpl(Throwable t) {
       delegate.onError(t);
     }
 
     @Override
-    public void onComplete() {
+    public void onCompleteImpl() {
       delegate.onCompleted();
     }
   }

--- a/gax/src/main/java/com/google/api/gax/rpc/SpoolingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/SpoolingResponseObserver.java
@@ -52,23 +52,23 @@ class SpoolingResponseObserver<ResponseT> extends AbstractResponseObserver<Respo
   }
 
   @Override
-  public void onStartImpl(StreamController controller) {
+  protected void onStartImpl(StreamController controller) {
     // NOTE: the call is started before the future is exposed to the caller
     this.controller = controller;
   }
 
   @Override
-  public void onResponseImpl(ResponseT response) {
+  protected void onResponseImpl(ResponseT response) {
     buffer.add(response);
   }
 
   @Override
-  public void onErrorImpl(Throwable t) {
+  protected void onErrorImpl(Throwable t) {
     future.setException(t);
   }
 
   @Override
-  public void onCompleteImpl() {
+  protected void onCompleteImpl() {
     future.set(buffer);
   }
 

--- a/gax/src/main/java/com/google/api/gax/rpc/SpoolingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/SpoolingResponseObserver.java
@@ -42,7 +42,7 @@ import java.util.List;
  *
  * @param <ResponseT> The type of the element in the stream.
  */
-class SpoolingResponseObserver<ResponseT> implements ResponseObserver<ResponseT> {
+class SpoolingResponseObserver<ResponseT> extends AbstractResponseObserver<ResponseT> {
   private final MyFuture future = new MyFuture();
   private StreamController controller;
   private final List<ResponseT> buffer = Lists.newArrayList();
@@ -52,23 +52,23 @@ class SpoolingResponseObserver<ResponseT> implements ResponseObserver<ResponseT>
   }
 
   @Override
-  public void onStart(StreamController controller) {
+  public void onStartImpl(StreamController controller) {
     // NOTE: the call is started before the future is exposed to the caller
     this.controller = controller;
   }
 
   @Override
-  public void onResponse(ResponseT response) {
+  public void onResponseImpl(ResponseT response) {
     buffer.add(response);
   }
 
   @Override
-  public void onError(Throwable t) {
+  public void onErrorImpl(Throwable t) {
     future.setException(t);
   }
 
   @Override
-  public void onComplete() {
+  public void onCompleteImpl() {
     future.set(buffer);
   }
 

--- a/gax/src/main/java/com/google/api/gax/rpc/SpoolingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/SpoolingResponseObserver.java
@@ -42,7 +42,7 @@ import java.util.List;
  *
  * @param <ResponseT> The type of the element in the stream.
  */
-class SpoolingResponseObserver<ResponseT> extends AbstractResponseObserver<ResponseT> {
+class SpoolingResponseObserver<ResponseT> extends StateCheckingResponseObserver<ResponseT> {
   private final MyFuture future = new MyFuture();
   private StreamController controller;
   private final List<ResponseT> buffer = Lists.newArrayList();

--- a/gax/src/main/java/com/google/api/gax/rpc/StateCheckingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StateCheckingResponseObserver.java
@@ -54,7 +54,7 @@ public abstract class StateCheckingResponseObserver<V> implements ResponseObserv
   /**
    * {@inheritDoc}
    *
-   * <p>This implementation simply delegates to {@link #onResponse(Object)} after ensuring
+   * <p>This implementation simply delegates to {@link #onResponseImpl(Object)} after ensuring
    * consistent state.
    */
   public final void onResponse(V response) {
@@ -65,7 +65,7 @@ public abstract class StateCheckingResponseObserver<V> implements ResponseObserv
   /**
    * {@inheritDoc}
    *
-   * <p>This implementation simply delegates to {@link #onComplete()} after ensuring consistent
+   * <p>This implementation simply delegates to {@link #onCompleteImpl()} after ensuring consistent
    * state.
    */
   public final void onComplete() {
@@ -77,7 +77,7 @@ public abstract class StateCheckingResponseObserver<V> implements ResponseObserv
   /**
    * {@inheritDoc}
    *
-   * <p>This implementation simply delegates to {@link #onError(Throwable)} after ensuring
+   * <p>This implementation simply delegates to {@link #onErrorImpl(Throwable)} after ensuring
    * consistent state.
    */
   public final void onError(Throwable t) {

--- a/gax/src/main/java/com/google/api/gax/rpc/StateCheckingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StateCheckingResponseObserver.java
@@ -29,16 +29,12 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.InternalApi;
+import com.google.api.core.BetaApi;
 import com.google.common.base.Preconditions;
 
-/**
- * Base implementation of {@link ResponseObserver} that performs state sanity checks.
- *
- * <p>This is public only for technical reasons, for advanced usage.
- */
-@InternalApi
-public abstract class AbstractResponseObserver<V> implements ResponseObserver<V> {
+/** Base implementation of {@link ResponseObserver} that performs state sanity checks. */
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
+public abstract class StateCheckingResponseObserver<V> implements ResponseObserver<V> {
   private boolean isStarted;
   private boolean isClosed;
 

--- a/gax/src/test/java/com/google/api/gax/rpc/ReframingResponseObserverTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ReframingResponseObserverTest.java
@@ -47,6 +47,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -123,7 +124,7 @@ public class ReframingResponseObserverTest {
     outerObserver.completeBreakpoint.release();
 
     // Should have no errors delivered.
-    Truth.assertThat(outerObserver.getFinalError()).isNull();
+    Truth.assertThat(outerObserver.getFinalError()).isInstanceOf(TimeoutException.class);
 
     // Should have no errors thrown.
     Throwable error = null;

--- a/gax/src/test/java/com/google/api/gax/rpc/ReframingResponseObserverTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ReframingResponseObserverTest.java
@@ -218,7 +218,6 @@ public class ReframingResponseObserverTest {
 
     outerObserver.getController().request(1);
     innerController.getObserver().onResponse("a-b");
-    innerController.getObserver().onComplete();
 
     outerObserver.popNextResponse();
     outerObserver.getController().cancel();
@@ -365,13 +364,13 @@ public class ReframingResponseObserverTest {
     }
 
     @Override
-    public void onError(Throwable t) {
+    protected void onErrorImpl(Throwable t) {
       super.onError(t);
       errorBreakpoint.arrive();
     }
 
     @Override
-    public void onComplete() {
+    protected void onCompleteImpl() {
       super.onComplete();
       completeBreakpoint.arrive();
     }

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamTest.java
@@ -71,7 +71,6 @@ public class ServerStreamTest {
 
   @Test
   public void testEmptyStream() {
-    stream.observer().onStart(controller);
     stream.observer().onComplete();
 
     Truth.assertThat(Lists.newArrayList(stream)).isEmpty();

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallableTest.java
@@ -68,22 +68,22 @@ public class ServerStreamingCallableTest {
     private boolean completed = false;
 
     @Override
-    public void onStartImpl(StreamController controller) {
+    protected void onStartImpl(StreamController controller) {
       this.controller = controller;
     }
 
     @Override
-    public void onResponseImpl(Integer value) {
+    protected void onResponseImpl(Integer value) {
       values.add(value);
     }
 
     @Override
-    public void onErrorImpl(Throwable t) {
+    protected void onErrorImpl(Throwable t) {
       error = t;
     }
 
     @Override
-    public void onCompleteImpl() {
+    protected void onCompleteImpl() {
       completed = true;
     }
 

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallableTest.java
@@ -61,7 +61,7 @@ public class ServerStreamingCallableTest {
             .build();
   }
 
-  private static class AccumulatingStreamObserver extends AbstractResponseObserver<Integer> {
+  private static class AccumulatingStreamObserver extends StateCheckingResponseObserver<Integer> {
     private List<Integer> values = new ArrayList<>();
     private StreamController controller;
     private Throwable error;
@@ -125,7 +125,8 @@ public class ServerStreamingCallableTest {
     ServerStreamingCallable<Integer, Integer> callable =
         stashCallable.withDefaultCallContext(defaultCallContext);
     @SuppressWarnings("unchecked")
-    AbstractResponseObserver<Integer> observer = Mockito.mock(AbstractResponseObserver.class);
+    StateCheckingResponseObserver<Integer> observer =
+        Mockito.mock(StateCheckingResponseObserver.class);
     Integer request = 1;
     callable.call(request, observer);
     Truth.assertThat(stashCallable.getActualObserver()).isSameAs(observer);
@@ -144,7 +145,7 @@ public class ServerStreamingCallableTest {
     ServerStreamingCallable<Integer, Integer> callable =
         stashCallable.withDefaultCallContext(FakeCallContext.createDefault());
     @SuppressWarnings("unchecked")
-    ResponseObserver<Integer> observer = Mockito.mock(AbstractResponseObserver.class);
+    ResponseObserver<Integer> observer = Mockito.mock(StateCheckingResponseObserver.class);
     Integer request = 1;
     callable.call(request, observer, context);
     Truth.assertThat(stashCallable.getActualObserver()).isSameAs(observer);

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallableTest.java
@@ -61,29 +61,29 @@ public class ServerStreamingCallableTest {
             .build();
   }
 
-  private static class AccumulatingStreamObserver implements ResponseObserver<Integer> {
+  private static class AccumulatingStreamObserver extends AbstractResponseObserver<Integer> {
     private List<Integer> values = new ArrayList<>();
     private StreamController controller;
     private Throwable error;
     private boolean completed = false;
 
     @Override
-    public void onStart(StreamController controller) {
+    public void onStartImpl(StreamController controller) {
       this.controller = controller;
     }
 
     @Override
-    public void onResponse(Integer value) {
+    public void onResponseImpl(Integer value) {
       values.add(value);
     }
 
     @Override
-    public void onError(Throwable t) {
+    public void onErrorImpl(Throwable t) {
       error = t;
     }
 
     @Override
-    public void onComplete() {
+    public void onCompleteImpl() {
       completed = true;
     }
 
@@ -125,7 +125,7 @@ public class ServerStreamingCallableTest {
     ServerStreamingCallable<Integer, Integer> callable =
         stashCallable.withDefaultCallContext(defaultCallContext);
     @SuppressWarnings("unchecked")
-    ResponseObserver<Integer> observer = Mockito.mock(ResponseObserver.class);
+    AbstractResponseObserver<Integer> observer = Mockito.mock(AbstractResponseObserver.class);
     Integer request = 1;
     callable.call(request, observer);
     Truth.assertThat(stashCallable.getActualObserver()).isSameAs(observer);
@@ -144,7 +144,7 @@ public class ServerStreamingCallableTest {
     ServerStreamingCallable<Integer, Integer> callable =
         stashCallable.withDefaultCallContext(FakeCallContext.createDefault());
     @SuppressWarnings("unchecked")
-    ResponseObserver<Integer> observer = Mockito.mock(ResponseObserver.class);
+    ResponseObserver<Integer> observer = Mockito.mock(AbstractResponseObserver.class);
     Integer request = 1;
     callable.call(request, observer, context);
     Truth.assertThat(stashCallable.getActualObserver()).isSameAs(observer);

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/MockStreamingApi.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/MockStreamingApi.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.rpc.testing;
 
 import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.rpc.AbstractResponseObserver;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStreamingCallable;
@@ -126,7 +127,7 @@ public class MockStreamingApi {
     }
   }
 
-  public static class MockResponseObserver<T> implements ResponseObserver<T> {
+  public static class MockResponseObserver<T> extends AbstractResponseObserver<T> {
     private final boolean autoFlowControl;
     private StreamController controller;
     private final BlockingQueue<T> responses = Queues.newLinkedBlockingDeque();
@@ -137,7 +138,7 @@ public class MockStreamingApi {
     }
 
     @Override
-    public void onStart(StreamController controller) {
+    protected void onStartImpl(StreamController controller) {
       this.controller = controller;
       if (!autoFlowControl) {
         controller.disableAutoInboundFlowControl();
@@ -145,22 +146,18 @@ public class MockStreamingApi {
     }
 
     @Override
-    public void onResponse(T response) {
+    protected void onResponseImpl(T response) {
       responses.add(response);
     }
 
     @Override
-    public void onError(Throwable t) {
-      if (!done.setException(t)) {
-        throw new IllegalStateException("Tried to set error on a closed MockResponseObserver");
-      }
+    protected void onErrorImpl(Throwable t) {
+      done.setException(t);
     }
 
     @Override
-    public void onComplete() {
-      if (!done.set(null)) {
-        throw new IllegalStateException("Tried to complete a closed MockResponseObserver");
-      }
+    protected void onCompleteImpl() {
+      done.set(null);
     }
 
     public StreamController getController() {

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/MockStreamingApi.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/MockStreamingApi.java
@@ -30,10 +30,10 @@
 package com.google.api.gax.rpc.testing;
 
 import com.google.api.core.SettableApiFuture;
-import com.google.api.gax.rpc.AbstractResponseObserver;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StateCheckingResponseObserver;
 import com.google.api.gax.rpc.StreamController;
 import com.google.common.collect.Queues;
 import java.util.concurrent.BlockingQueue;
@@ -127,7 +127,7 @@ public class MockStreamingApi {
     }
   }
 
-  public static class MockResponseObserver<T> extends AbstractResponseObserver<T> {
+  public static class MockResponseObserver<T> extends StateCheckingResponseObserver<T> {
     private final boolean autoFlowControl;
     private StreamController controller;
     private final BlockingQueue<T> responses = Queues.newLinkedBlockingDeque();


### PR DESCRIPTION
Introduce AbstractResponseObserver that checks the current state of the observer before processing incoming events. This helps to localize issues in streaming callable chains.

Flaky tests should be addressed by #454.  