### PR TITLE
Fix error propagtion for ServerStreamIterators.

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamIterator.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamIterator.java
@@ -102,7 +102,6 @@ final class ServerStreamIterator<V> implements Iterator<V> {
     if (last instanceof Throwable) {
       Throwable throwable = (Throwable) last;
 
-      Throwables.throwIfUnchecked(throwable);
       throw new RuntimeException(throwable);
     }
     return last != QueuingResponseObserver.EOF_MARKER;

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamIterator.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamIterator.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.common.base.Throwables;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 


### PR DESCRIPTION
Currently the ServerStreamIterator blindly re-throws errors encountered in the async
ResponseObserver. However this creates a confusing stacktrace which does not include any
of the frames from the sync invocation of .next(). This PR wraps the async errors in a
RuntimeException so that both stacktraces are accounted for.