### PR TITLE
Expose retryableCodes on ServerStreamingCallables.

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -235,7 +235,8 @@ public class GrpcCallableFactory {
               callable, grpcCallSettings.getParamsExtractor());
     }
     callable =
-        new GrpcExceptionServerStreamingCallable<>(callable, ImmutableSet.<StatusCode.Code>of());
+        new GrpcExceptionServerStreamingCallable<>(
+            callable, streamingCallSettings.getRetryableCodes());
 
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
   }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallableFactoryTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallableFactoryTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.grpc;
+
+import com.google.api.gax.grpc.testing.FakeServiceGrpc;
+import com.google.api.gax.grpc.testing.FakeServiceImpl;
+import com.google.api.gax.grpc.testing.InProcessServer;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.InvalidArgumentException;
+import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.common.truth.Truth;
+import com.google.type.Color;
+import com.google.type.Money;
+import io.grpc.CallOptions;
+import io.grpc.ManagedChannel;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class GrpcCallableFactoryTest {
+  private InProcessServer<FakeServiceImpl> inprocessServer;
+  private ManagedChannel channel;
+  private ClientContext clientContext;
+
+  @Before
+  public void setUp() throws Exception {
+    String serverName = "fakeservice";
+    FakeServiceImpl serviceImpl = new FakeServiceImpl();
+    inprocessServer = new InProcessServer<>(serviceImpl, serverName);
+    inprocessServer.start();
+
+    channel =
+        InProcessChannelBuilder.forName(serverName).directExecutor().usePlaintext(true).build();
+    clientContext =
+        ClientContext.newBuilder()
+            .setTransportChannel(GrpcTransportChannel.create(channel))
+            .setDefaultCallContext(GrpcCallContext.of(channel, CallOptions.DEFAULT))
+            .build();
+  }
+
+  @After
+  public void tearDown() {
+    channel.shutdown();
+    inprocessServer.stop();
+  }
+
+  @Test
+  public void createServerStreamingCallableRetryableExceptions() throws Exception {
+    GrpcCallSettings<Color, Money> grpcCallSettings =
+        GrpcCallSettings.create(FakeServiceGrpc.METHOD_STREAMING_RECOGNIZE_ERROR);
+
+    // Base case: without config, invalid argument errors are not retryable.
+    ServerStreamingCallSettings<Color, Money> nonRetryableSettings =
+        ServerStreamingCallSettings.<Color, Money>newBuilder().build();
+
+    ServerStreamingCallable<Color, Money> nonRetryableCallable =
+        GrpcCallableFactory.createServerStreamingCallable(
+            grpcCallSettings, nonRetryableSettings, clientContext);
+
+    Throwable actualError = null;
+    try {
+      nonRetryableCallable
+          .first()
+          .call(Color.getDefaultInstance(), clientContext.getDefaultCallContext());
+    } catch (Throwable e) {
+      actualError = e;
+    }
+    Truth.assertThat(actualError).isInstanceOf(InvalidArgumentException.class);
+    Truth.assertThat(((InvalidArgumentException) actualError).isRetryable()).isFalse();
+
+    // Actual test: with config, invalid argument errors are retryable.
+    ServerStreamingCallSettings<Color, Money> retryableSettings =
+        ServerStreamingCallSettings.<Color, Money>newBuilder()
+            .setRetryableCodes(Code.INVALID_ARGUMENT)
+            .build();
+
+    ServerStreamingCallable<Color, Money> retryableCallable =
+        GrpcCallableFactory.createServerStreamingCallable(
+            grpcCallSettings, retryableSettings, clientContext);
+
+    Throwable actualError2 = null;
+    try {
+      retryableCallable
+          .first()
+          .call(Color.getDefaultInstance(), clientContext.getDefaultCallContext());
+    } catch (Throwable e) {
+      actualError2 = e;
+    }
+    Truth.assertThat(actualError2).isInstanceOf(InvalidArgumentException.class);
+    Truth.assertThat(((InvalidArgumentException) actualError2).isRetryable()).isTrue();
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -30,6 +30,10 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import java.util.Set;
 
 /**
  * A settings class to configure a {@link ServerStreamingCallable}.
@@ -40,7 +44,15 @@ import com.google.api.core.BetaApi;
 public final class ServerStreamingCallSettings<RequestT, ResponseT>
     extends StreamingCallSettings<RequestT, ResponseT> {
 
-  private ServerStreamingCallSettings(Builder<RequestT, ResponseT> builder) {}
+  private final Set<Code> retryableCodes;
+
+  private ServerStreamingCallSettings(Builder<RequestT, ResponseT> builder) {
+    this.retryableCodes = ImmutableSet.copyOf(builder.retryableCodes);
+  }
+
+  public Set<Code> getRetryableCodes() {
+    return retryableCodes;
+  }
 
   public Builder<RequestT, ResponseT> toBuilder() {
     return new Builder<>(this);
@@ -53,10 +65,29 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
   public static class Builder<RequestT, ResponseT>
       extends StreamingCallSettings.Builder<RequestT, ResponseT> {
 
-    private Builder() {}
+    private Set<StatusCode.Code> retryableCodes;
+
+    private Builder() {
+      this.retryableCodes = ImmutableSet.of();
+    }
 
     private Builder(ServerStreamingCallSettings<RequestT, ResponseT> settings) {
       super(settings);
+      this.retryableCodes = settings.retryableCodes;
+    }
+
+    public Builder<RequestT, ResponseT> setRetryableCodes(StatusCode.Code... codes) {
+      this.setRetryableCodes(Sets.newHashSet(codes));
+      return this;
+    }
+
+    public Builder<RequestT, ResponseT> setRetryableCodes(Set<Code> retryableCodes) {
+      this.retryableCodes = Sets.newHashSet(retryableCodes);
+      return this;
+    }
+
+    public Set<Code> getRetryableCodes() {
+      return retryableCodes;
     }
 
     @Override

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallSettingsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.truth.Truth;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ServerStreamingCallSettingsTest {
+  @Test
+  public void retryableCodesAreNotLost() {
+    Set<Code> codes = ImmutableSet.of(Code.UNAVAILABLE, Code.RESOURCE_EXHAUSTED);
+    ServerStreamingCallSettings.Builder<Object, Object> builder =
+        ServerStreamingCallSettings.newBuilder();
+    builder.setRetryableCodes(codes);
+
+    Truth.assertThat(builder.getRetryableCodes()).containsExactlyElementsIn(codes);
+    Truth.assertThat(builder.build().getRetryableCodes()).containsExactlyElementsIn(codes);
+    Truth.assertThat(builder.build().toBuilder().getRetryableCodes())
+        .containsExactlyElementsIn(codes);
+  }
+
+  @Test
+  public void retryableCodesVarArgs() {
+    ServerStreamingCallSettings.Builder<Object, Object> builder =
+        ServerStreamingCallSettings.newBuilder().setRetryableCodes(Code.UNKNOWN, Code.ABORTED);
+
+    Truth.assertThat(builder.getRetryableCodes()).containsExactly(Code.UNKNOWN, Code.ABORTED);
+  }
+}


### PR DESCRIPTION
This allows configuration of the ApiException callable on in ServerStreamingCallable chain.
Eventually this will be paired with RetrySettings and a RetryingServerStreamingCallable to
provide retries for streaming rpcs. For now, it unblocks the development of a retry solution
outside of the gax repo.

This is necessary to unblock development of the bigtable client, while I work on integrating #449.