### PR TITLE
Server streaming retries take 2

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -238,6 +238,11 @@ public class GrpcCallableFactory {
         new GrpcExceptionServerStreamingCallable<>(
             callable, streamingCallSettings.getRetryableCodes());
 
+    if (!streamingCallSettings.getRetryableCodes().isEmpty()
+        && streamingCallSettings.getRetrySettings().getMaxAttempts() > 1) {
+      callable = Callables.retrying(callable, streamingCallSettings, clientContext);
+    }
+
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
   }
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -236,10 +236,7 @@ public class GrpcCallableFactory {
         new GrpcExceptionServerStreamingCallable<>(
             callable, streamingCallSettings.getRetryableCodes());
 
-    if (!streamingCallSettings.getRetryableCodes().isEmpty()
-        && streamingCallSettings.getRetrySettings().getMaxAttempts() > 1) {
-      callable = Callables.retrying(callable, streamingCallSettings, clientContext);
-    }
+    callable = Callables.retrying(callable, streamingCallSettings, clientContext);
 
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
   }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -67,7 +67,10 @@ public class GrpcCallableFactory {
     }
     callable = new GrpcExceptionCallable<>(callable, callSettings.getRetryableCodes());
 
-    callable = Callables.retrying(callable, callSettings, clientContext);
+    if (!callSettings.getRetryableCodes().isEmpty()
+        && callSettings.getRetrySettings().getMaxAttempts() > 1) {
+      callable = Callables.retrying(callable, callSettings, clientContext);
+    }
 
     return callable;
   }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -67,10 +67,8 @@ public class GrpcCallableFactory {
     }
     callable = new GrpcExceptionCallable<>(callable, callSettings.getRetryableCodes());
 
-    if (!callSettings.getRetryableCodes().isEmpty()
-        && callSettings.getRetrySettings().getMaxAttempts() > 1) {
-      callable = Callables.retrying(callable, callSettings, clientContext);
-    }
+    callable = Callables.retrying(callable, callSettings, clientContext);
+
     return callable;
   }
 

--- a/gax/src/main/java/com/google/api/gax/retrying/NonCancellableFuture.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/NonCancellableFuture.java
@@ -46,15 +46,15 @@ public final class NonCancellableFuture<ResponseT> extends AbstractApiFuture<Res
     return false;
   }
 
-  public void cancelPrivately() {
+  void cancelPrivately() {
     super.cancel(false);
   }
 
-  public boolean setPrivately(ResponseT value) {
+  boolean setPrivately(ResponseT value) {
     return super.set(value);
   }
 
-  public boolean setExceptionPrivately(Throwable throwable) {
+  boolean setExceptionPrivately(Throwable throwable) {
     return super.setException(throwable);
   }
 }

--- a/gax/src/main/java/com/google/api/gax/retrying/ServerStreamingAttemptException.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/ServerStreamingAttemptException.java
@@ -38,7 +38,7 @@ import com.google.api.core.InternalApi;
  *
  * <p>For internal use only - public for technical reasons.
  */
-@InternalApi("For internal use only")
+@InternalApi
 public class ServerStreamingAttemptException extends RuntimeException {
   private final boolean canResume;
   private final boolean seenResponses;

--- a/gax/src/main/java/com/google/api/gax/retrying/SimpleStreamResumptionStrategy.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/SimpleStreamResumptionStrategy.java
@@ -54,4 +54,9 @@ public final class SimpleStreamResumptionStrategy<RequestT, ResponseT>
   public RequestT getResumeRequest(RequestT originalRequest) {
     return seenFirstResponse ? null : originalRequest;
   }
+
+  @Override
+  public boolean canResume() {
+    return !seenFirstResponse;
+  }
 }

--- a/gax/src/main/java/com/google/api/gax/retrying/SimpleStreamResumptionStrategy.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/SimpleStreamResumptionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Google LLC All rights reserved.
+ * Copyright 2018, Google LLC All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,32 +29,29 @@
  */
 package com.google.api.gax.retrying;
 
-import com.google.api.core.AbstractApiFuture;
-import com.google.api.core.InternalApi;
+import com.google.api.core.BetaApi;
 
 /**
- * A future which cannot be cancelled from the external package.
- *
- * <p>For internal use, public for technical reasons.
- *
- * @param <ResponseT> future response type
+ * Simplest implementation of a {@link StreamResumptionStrategy} which returns the initial request
+ * for unstarted streams.
  */
-@InternalApi
-public final class NonCancellableFuture<ResponseT> extends AbstractApiFuture<ResponseT> {
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
+public final class SimpleStreamResumptionStrategy<RequestT, ResponseT>
+    implements StreamResumptionStrategy<RequestT, ResponseT> {
+  private boolean seenFirstResponse;
+
   @Override
-  public boolean cancel(boolean mayInterruptIfRunning) {
-    return false;
+  public StreamResumptionStrategy<RequestT, ResponseT> createNew() {
+    return new SimpleStreamResumptionStrategy<>();
   }
 
-  public void cancelPrivately() {
-    super.cancel(false);
+  @Override
+  public void onProgress(ResponseT response) {
+    seenFirstResponse = true;
   }
 
-  public boolean setPrivately(ResponseT value) {
-    return super.set(value);
-  }
-
-  public boolean setExceptionPrivately(Throwable throwable) {
-    return super.setException(throwable);
+  @Override
+  public RequestT getResumeRequest(RequestT originalRequest) {
+    return seenFirstResponse ? null : originalRequest;
   }
 }

--- a/gax/src/main/java/com/google/api/gax/retrying/StreamResumptionStrategy.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/StreamResumptionStrategy.java
@@ -43,21 +43,21 @@ public interface StreamResumptionStrategy<RequestT, ResponseT> {
   /** Creates a new instance of this StreamResumptionStrategy without accumulated state */
   StreamResumptionStrategy<RequestT, ResponseT> createNew();
 
-  /** Called by the {@link com.google.api.gax.rpc.ServerStreamingAttemptCallable} when a response has been successfully received. */
+  /**
+   * Called by the {@code ServerStreamingAttemptCallable} when a response has been successfully
+   * received.
+   */
   void onProgress(ResponseT response);
 
   /**
    * Called when a stream needs to be restarted, the implementation should generate a request that
    * will yield a new stream whose first response would come right after the last response received
-   * by onProgress. If this strategy can't resume the stream, it should return null.
+   * by onProgress.
    *
-   * @return Either a request that can be used to resume the stream or null to indicate that the
-   *     stream can't be resumed.
+   * @return A request that can be used to resume the stream.
    */
   RequestT getResumeRequest(RequestT originalRequest);
 
-  /**
-   * If the strategy can produce a resume request
-   */
+  /** If a resume request can be created. */
   boolean canResume();
 }

--- a/gax/src/main/java/com/google/api/gax/retrying/StreamResumptionStrategy.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/StreamResumptionStrategy.java
@@ -55,4 +55,9 @@ public interface StreamResumptionStrategy<RequestT, ResponseT> {
    *     stream can't be resumed.
    */
   RequestT getResumeRequest(RequestT originalRequest);
+
+  /**
+   * If the strategy can produce a resume request
+   */
+  boolean canResume();
 }

--- a/gax/src/main/java/com/google/api/gax/retrying/StreamingRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/StreamingRetryAlgorithm.java
@@ -58,11 +58,12 @@ public final class StreamingRetryAlgorithm<ResponseT> extends RetryAlgorithm<Res
       Throwable prevThrowable, ResponseT prevResponse, TimedAttemptSettings prevSettings) {
 
     if (prevThrowable instanceof ServerStreamingAttemptException) {
-      ServerStreamingAttemptException wrapper = (ServerStreamingAttemptException) prevThrowable;
+      ServerStreamingAttemptException attemptException =
+          (ServerStreamingAttemptException) prevThrowable;
       prevThrowable = prevThrowable.getCause();
 
       // If we have made progress in the last attempt, then reset the delays
-      if (wrapper.hasSeenResponses()) {
+      if (attemptException.hasSeenResponses()) {
         prevSettings =
             createFirstAttempt()
                 .toBuilder()
@@ -87,10 +88,11 @@ public final class StreamingRetryAlgorithm<ResponseT> extends RetryAlgorithm<Res
 
     // Unwrap
     if (prevThrowable instanceof ServerStreamingAttemptException) {
-      ServerStreamingAttemptException wrapper = (ServerStreamingAttemptException) prevThrowable;
+      ServerStreamingAttemptException attemptExceptino =
+          (ServerStreamingAttemptException) prevThrowable;
       prevThrowable = prevThrowable.getCause();
 
-      if (!wrapper.canResume()) {
+      if (!attemptExceptino.canResume()) {
         return false;
       }
     }

--- a/gax/src/main/java/com/google/api/gax/retrying/StreamingRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/StreamingRetryAlgorithm.java
@@ -1,54 +1,100 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.google.api.gax.retrying;
 
 import com.google.api.core.InternalApi;
-import com.google.api.gax.rpc.ServerStreamingAttemptCallable;
 import java.util.concurrent.CancellationException;
 
 /**
+ * The streaming retry algorithm, which makes decision based either on the thrown exception and the
+ * execution time settings of the previous attempt. This extends {@link RetryAlgorithm} to take
+ * additional information (provided by {@code ServerStreamingAttemptCallable}) into account.
  *
- * @param <ResponseT>
+ * <p>This class is thread-safe.
+ *
+ * <p>Internal use only - public for technical reasons.
  */
 @InternalApi("For internal use only")
-public class StreamingRetryAlgorithm<ResponseT> extends RetryAlgorithm<ResponseT> {
+public final class StreamingRetryAlgorithm<ResponseT> extends RetryAlgorithm<ResponseT> {
   public StreamingRetryAlgorithm(
-      ResultRetryAlgorithm<ResponseT> resultAlgorithm,
-      TimedRetryAlgorithm timedAlgorithm) {
+      ResultRetryAlgorithm<ResponseT> resultAlgorithm, TimedRetryAlgorithm timedAlgorithm) {
     super(resultAlgorithm, timedAlgorithm);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The attempt settings will be reset if the stream attempt produced any messages.
+   */
   @Override
-  public TimedAttemptSettings createNextAttempt(Throwable prevThrowable, ResponseT prevResponse,
-      TimedAttemptSettings prevSettings) {
+  public TimedAttemptSettings createNextAttempt(
+      Throwable prevThrowable, ResponseT prevResponse, TimedAttemptSettings prevSettings) {
 
-    if (prevThrowable instanceof ServerStreamingAttemptCallable.WrappedApiException) {
-      ServerStreamingAttemptCallable.WrappedApiException wrapper = (ServerStreamingAttemptCallable.WrappedApiException) prevThrowable;
-
-      // Unwrap
+    if (prevThrowable instanceof ServerStreamingAttemptException) {
+      ServerStreamingAttemptException wrapper = (ServerStreamingAttemptException) prevThrowable;
       prevThrowable = prevThrowable.getCause();
 
       // If we have made progress in the last attempt, then reset the delays
-      if (wrapper.hasSeenSuccessSinceLastError()) {
-        prevSettings = createFirstAttempt().toBuilder()
-            .setFirstAttemptStartTimeNanos(prevSettings.getFirstAttemptStartTimeNanos())
-            .build();
+      if (wrapper.hasSeenResponses()) {
+        prevSettings =
+            createFirstAttempt()
+                .toBuilder()
+                .setFirstAttemptStartTimeNanos(prevSettings.getFirstAttemptStartTimeNanos())
+                .build();
       }
     }
 
     return super.createNextAttempt(prevThrowable, prevResponse, prevSettings);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Ensures retries are only scheduled if the {@link StreamResumptionStrategy} in the {@code
+   * ServerStreamingAttemptCallable} supports it.
+   */
   @Override
-  public boolean shouldRetry(Throwable prevThrowable, ResponseT prevResponse,
-      TimedAttemptSettings nextAttemptSettings) throws CancellationException {
+  public boolean shouldRetry(
+      Throwable prevThrowable, ResponseT prevResponse, TimedAttemptSettings nextAttemptSettings)
+      throws CancellationException {
 
     // Unwrap
-    if (prevThrowable instanceof ServerStreamingAttemptCallable.WrappedApiException) {
-      ServerStreamingAttemptCallable.WrappedApiException wrapper = (ServerStreamingAttemptCallable.WrappedApiException)prevThrowable;
+    if (prevThrowable instanceof ServerStreamingAttemptException) {
+      ServerStreamingAttemptException wrapper = (ServerStreamingAttemptException) prevThrowable;
+      prevThrowable = prevThrowable.getCause();
+
       if (!wrapper.canResume()) {
         return false;
       }
-      prevThrowable = prevThrowable.getCause();
     }
+
     return super.shouldRetry(prevThrowable, prevResponse, nextAttemptSettings);
   }
 }

--- a/gax/src/main/java/com/google/api/gax/retrying/StreamingRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/StreamingRetryAlgorithm.java
@@ -1,0 +1,50 @@
+package com.google.api.gax.retrying;
+
+import com.google.api.core.InternalApi;
+import com.google.api.gax.rpc.ServerStreamingAttemptCallable;
+import java.util.concurrent.CancellationException;
+
+/**
+ *
+ * @param <ResponseT>
+ */
+@InternalApi("For internal use only")
+public class StreamingRetryAlgorithm<ResponseT> extends RetryAlgorithm<ResponseT> {
+  public StreamingRetryAlgorithm(
+      ResultRetryAlgorithm<ResponseT> resultAlgorithm,
+      TimedRetryAlgorithm timedAlgorithm) {
+    super(resultAlgorithm, timedAlgorithm);
+  }
+
+  @Override
+  public TimedAttemptSettings createNextAttempt(Throwable prevThrowable, ResponseT prevResponse,
+      TimedAttemptSettings prevSettings) {
+
+    if (prevThrowable instanceof ServerStreamingAttemptCallable.WrappedApiException) {
+      ServerStreamingAttemptCallable.WrappedApiException wrapper = (ServerStreamingAttemptCallable.WrappedApiException) prevThrowable;
+
+      // Unwrap
+      prevThrowable = prevThrowable.getCause();
+
+      // If we have made progress in the last attempt, then reset the delays
+      if (wrapper.hasSeenSuccessSinceLastError()) {
+        prevSettings = createFirstAttempt().toBuilder()
+            .setFirstAttemptStartTimeNanos(prevSettings.getFirstAttemptStartTimeNanos())
+            .build();
+      }
+    }
+
+    return super.createNextAttempt(prevThrowable, prevResponse, prevSettings);
+  }
+
+  @Override
+  public boolean shouldRetry(Throwable prevThrowable, ResponseT prevResponse,
+      TimedAttemptSettings nextAttemptSettings) throws CancellationException {
+
+    // Unwrap
+    if (prevThrowable instanceof ServerStreamingAttemptCallable.WrappedApiException) {
+      prevThrowable = prevThrowable.getCause();
+    }
+    return super.shouldRetry(prevThrowable, prevResponse, nextAttemptSettings);
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/retrying/StreamingRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/StreamingRetryAlgorithm.java
@@ -43,6 +43,10 @@ public class StreamingRetryAlgorithm<ResponseT> extends RetryAlgorithm<ResponseT
 
     // Unwrap
     if (prevThrowable instanceof ServerStreamingAttemptCallable.WrappedApiException) {
+      ServerStreamingAttemptCallable.WrappedApiException wrapper = (ServerStreamingAttemptCallable.WrappedApiException)prevThrowable;
+      if (!wrapper.canResume()) {
+        return false;
+      }
       prevThrowable = prevThrowable.getCause();
     }
     return super.shouldRetry(prevThrowable, prevResponse, nextAttemptSettings);

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -78,6 +78,12 @@ public class Callables {
       ServerStreamingCallSettings<RequestT, ResponseT> callSettings,
       ClientContext clientContext) {
 
+    if (callSettings.getRetryableCodes().isEmpty()
+        || callSettings.getRetrySettings().getMaxAttempts() <= 1) {
+
+      return innerCallable;
+    }
+
     StreamingRetryAlgorithm<Void> retryAlgorithm =
         new StreamingRetryAlgorithm<>(
             new ApiResultRetryAlgorithm<Void>(),

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -72,20 +72,17 @@ public class Callables {
       ServerStreamingCallSettings<RequestT, ResponseT> callSettings,
       ClientContext clientContext) {
 
-    StreamingRetryAlgorithm<Void> retryAlgorithm = new StreamingRetryAlgorithm<>(
-        new ApiResultRetryAlgorithm<Void>(),
-        new ExponentialRetryAlgorithm(callSettings.getRetrySettings(), clientContext.getClock())
-    );
+    StreamingRetryAlgorithm<Void> retryAlgorithm =
+        new StreamingRetryAlgorithm<>(
+            new ApiResultRetryAlgorithm<Void>(),
+            new ExponentialRetryAlgorithm(
+                callSettings.getRetrySettings(), clientContext.getClock()));
 
-    ScheduledRetryingExecutor<Void> executor = new ScheduledRetryingExecutor<>(
-        retryAlgorithm,
-        clientContext.getExecutor()
-    );
+    ScheduledRetryingExecutor<Void> executor =
+        new ScheduledRetryingExecutor<>(retryAlgorithm, clientContext.getExecutor());
 
     return new RetryingServerStreamingCallable<>(
-        innerCallable,
-        executor,
-        callSettings.getResumptionStrategy());
+        innerCallable, executor, callSettings.getResumptionStrategy());
   }
 
   /**

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -55,12 +55,6 @@ public class Callables {
       UnaryCallSettings<?, ?> callSettings,
       ClientContext clientContext) {
 
-    // Short circuit the callable if it's unconfigured.
-    if (callSettings.getRetryableCodes().isEmpty()
-        || callSettings.getRetrySettings().getMaxAttempts() <= 1) {
-      return innerCallable;
-    }
-
     RetryAlgorithm<ResponseT> retryAlgorithm =
         new RetryAlgorithm<>(
             new ApiResultRetryAlgorithm<ResponseT>(),

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -55,6 +55,12 @@ public class Callables {
       UnaryCallSettings<?, ?> callSettings,
       ClientContext clientContext) {
 
+    // Short circuit the callable if it's unconfigured.
+    if (callSettings.getRetryableCodes().isEmpty()
+        || callSettings.getRetrySettings().getMaxAttempts() <= 1) {
+      return innerCallable;
+    }
+
     RetryAlgorithm<ResponseT> retryAlgorithm =
         new RetryAlgorithm<>(
             new ApiResultRetryAlgorithm<ResponseT>(),

--- a/gax/src/main/java/com/google/api/gax/rpc/RetryingServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/RetryingServerStreamingCallable.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.retrying.RetryingFuture;
+import com.google.api.gax.retrying.ScheduledRetryingExecutor;
+import com.google.api.gax.retrying.StreamResumptionStrategy;
+
+/**
+ * A ServerStreamingCallable that will keep issuing calls to an inner callable until it succeeds or
+ * times out. On error, the stream can be resumed from where it left off via a {@link
+ * StreamResumptionStrategy}.
+ *
+ * <p>Package-private for internal use.
+ */
+class RetryingServerStreamingCallable<RequestT, ResponseT>
+    extends ServerStreamingCallable<RequestT, ResponseT> {
+
+  private final ServerStreamingCallable<RequestT, ResponseT> innerCallable;
+  private final ScheduledRetryingExecutor<Void> executor;
+  private final StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategyPrototype;
+
+  RetryingServerStreamingCallable(
+      ServerStreamingCallable<RequestT, ResponseT> innerCallable,
+      ScheduledRetryingExecutor<Void> executor,
+      StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategyPrototype) {
+    this.innerCallable = innerCallable;
+    this.executor = executor;
+    this.resumptionStrategyPrototype = resumptionStrategyPrototype;
+  }
+
+  @Override
+  public void call(
+      RequestT request, final ResponseObserver<ResponseT> responseObserver, ApiCallContext context) {
+
+    ServerStreamingAttemptCallable<RequestT, ResponseT> attemptCallable = new ServerStreamingAttemptCallable<>(
+        innerCallable,
+        resumptionStrategyPrototype.createNew(),
+        request,
+        context,
+        responseObserver
+    );
+
+    RetryingFuture<Void> retryingFuture = executor.createFuture(attemptCallable);
+    attemptCallable.setExternalFuture(retryingFuture);
+    attemptCallable.start();
+
+    // Bridge the future result back to the external responseObserver
+    ApiFutures.addCallback(retryingFuture, new ApiFutureCallback<Void>() {
+      @Override
+      public void onFailure(Throwable throwable) {
+        if (throwable instanceof ServerStreamingAttemptCallable.WrappedCancellationException) {
+          throwable = throwable.getCause();
+        } else if (throwable instanceof ServerStreamingAttemptCallable.WrappedApiException) {
+          throwable = throwable.getCause();
+        }
+        responseObserver.onError(throwable);
+      }
+
+      @Override
+      public void onSuccess(Void ignored) {
+        responseObserver.onComplete();
+      }
+    });
+  }
+
+
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/RetryingServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/RetryingServerStreamingCallable.java
@@ -62,14 +62,17 @@ import com.google.api.gax.retrying.StreamResumptionStrategy;
 final class RetryingServerStreamingCallable<RequestT, ResponseT>
     extends ServerStreamingCallable<RequestT, ResponseT> {
 
+  private final Watchdog<ResponseT> watchdog;
   private final ServerStreamingCallable<RequestT, ResponseT> innerCallable;
   private final ScheduledRetryingExecutor<Void> executor;
   private final StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategyPrototype;
 
   RetryingServerStreamingCallable(
+      Watchdog<ResponseT> watchdog,
       ServerStreamingCallable<RequestT, ResponseT> innerCallable,
       ScheduledRetryingExecutor<Void> executor,
       StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategyPrototype) {
+    this.watchdog = watchdog;
     this.innerCallable = innerCallable;
     this.executor = executor;
     this.resumptionStrategyPrototype = resumptionStrategyPrototype;
@@ -83,6 +86,7 @@ final class RetryingServerStreamingCallable<RequestT, ResponseT>
 
     ServerStreamingAttemptCallable<RequestT, ResponseT> attemptCallable =
         new ServerStreamingAttemptCallable<>(
+            watchdog,
             innerCallable,
             resumptionStrategyPrototype.createNew(),
             request,

--- a/gax/src/main/java/com/google/api/gax/rpc/RetryingServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/RetryingServerStreamingCallable.java
@@ -41,16 +41,7 @@ import com.google.api.gax.retrying.StreamResumptionStrategy;
  *
  * <p>Wraps a request, a {@link ResponseObserver} and an inner {@link ServerStreamingCallable} and
  * coordinates retries between them. When the inner callable throws an error, this class will
- * schedule retries using the configured {@link ScheduledRetryingExecutor}. The executor's
- * interpretation of {@link com.google.api.gax.retrying.RetrySettings} differs from the unary {@link
- * com.google.api.gax.rpc.RetryingCallable}:
- *
- * <ul>
- *   <li>timers are reset as soon as a response is received.
- *   <li>RPC timeouts apply to the time interval between caller demanding more responses via {@link
- *       StreamController#request(int)} and the {@link ResponseObserver} receiving the message.
- *   <li>totalTimeout still applies to the entire stream.
- * </ul>
+ * schedule retries using the configured {@link ScheduledRetryingExecutor}.
  *
  * <p>Streams can be resumed using a {@link StreamResumptionStrategy}. The {@link
  * StreamResumptionStrategy} is notified of incoming responses and is expected to track the progress

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
@@ -208,7 +208,7 @@ final class ServerStreamingAttemptCallable<RequestT, ResponseT> implements Calla
     Preconditions.checkState(isStarted, "Must be started first");
 
     RequestT request =
-        (numAttempts == 0) ? initialRequest : resumptionStrategy.getResumeRequest(initialRequest);
+        (++numAttempts == 1) ? initialRequest : resumptionStrategy.getResumeRequest(initialRequest);
 
     // Should never happen. onAttemptError will check if ResumptionStrategy can create a resume request,
     // which the RetryingFuture/StreamResumptionStrategy should respect.

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
@@ -217,7 +217,6 @@ final class ServerStreamingAttemptCallable<RequestT, ResponseT> implements Calla
     innerAttemptFuture = new NonCancellableFuture<>();
     seenSuccessSinceLastError = false;
 
-    // TODO: watchdog
     innerCallable.call(
         request,
         watchdog.watch(

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
@@ -1,0 +1,249 @@
+package com.google.api.gax.rpc;
+
+import com.google.api.core.InternalApi;
+import com.google.api.gax.retrying.NonCancellableFuture;
+import com.google.api.gax.retrying.RetryingFuture;
+import com.google.api.gax.retrying.StreamResumptionStrategy;
+import com.google.common.base.Preconditions;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import javax.annotation.concurrent.GuardedBy;
+import org.threeten.bp.Duration;
+
+@InternalApi
+class ServerStreamingAttemptCallable<RequestT, ResponseT> implements Callable<Void> {
+  private final Object lock = new Object();
+  private final ServerStreamingCallable<RequestT, ResponseT> innerCallable;
+
+  private final StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategy;
+  private final RequestT initialRequest;
+  private ApiCallContext context;
+
+  private final ResponseObserver<ResponseT> outerObserver;
+
+  // Start state
+  private boolean autoFlowControl = true;
+  private boolean isStarted;
+
+  // Outer state
+  @GuardedBy("lock")
+  private Throwable cancellationCause;
+
+  @GuardedBy("lock")
+  private int pendingRequests;
+
+  RetryingFuture<Void> externalFuture;
+
+  // Internal retry state
+  @GuardedBy("lock")
+  private StreamController innerController;
+  private boolean seenSuccessSinceLastError;
+
+  public ServerStreamingAttemptCallable(
+      ServerStreamingCallable<RequestT, ResponseT> innerCallable,
+      StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategy,
+      RequestT initialRequest,
+      ApiCallContext context,
+      ResponseObserver<ResponseT> outerObserver) {
+    this.innerCallable = innerCallable;
+    this.resumptionStrategy = resumptionStrategy;
+    this.initialRequest = initialRequest;
+    this.context = context;
+    this.outerObserver = outerObserver;
+  }
+
+  public void setExternalFuture(RetryingFuture<Void> externalFuture) {
+    this.externalFuture = externalFuture;
+  }
+
+  /**
+   * Starts the initial call. The call is attempted on the caller's thread. Further call attempts
+   * will be made by the executor.
+   */
+  public void start() {
+    Preconditions.checkState(!isStarted, "Already started");
+
+    // Initialize the outer observer
+    outerObserver.onStart(
+        new StreamController() {
+          @Override
+          public void disableAutoInboundFlowControl() {
+            Preconditions.checkState(
+                !isStarted, "Can't disable auto flow control once the stream is started");
+            autoFlowControl = false;
+          }
+
+          @Override
+          public void request(int count) {
+            onRequest(count);
+          }
+
+          @Override
+          public void cancel() {
+            onCancel();
+          }
+        });
+    isStarted = true;
+    if (autoFlowControl) {
+      pendingRequests = Integer.MAX_VALUE;
+    }
+
+    // Propagate the totalTimeout as the overall stream deadline.
+    Duration totalTimeout = externalFuture.getAttemptSettings().getGlobalSettings().getTotalTimeout();
+    if (totalTimeout != null) {
+      context = context.withTimeout(totalTimeout);
+    }
+
+    // Call the inner callable
+    call();
+  }
+
+  @Override
+  public Void call() {
+    Preconditions.checkState(isStarted, "Must be started first");
+
+    RequestT request = resumptionStrategy.getResumeRequest(initialRequest);
+    Preconditions.checkState(request != null, "ResumptionStrategy returned a null request.");
+
+    final NonCancellableFuture<Void> attemptFuture = new NonCancellableFuture<>();
+    seenSuccessSinceLastError = false;
+
+    // TODO: watchdog
+    innerCallable.call(
+        request,
+        new StateCheckingResponseObserver<ResponseT>() {
+          @Override
+          public void onStartImpl(StreamController controller) {
+            onAttemptStart(controller);
+          }
+
+          @Override
+          public void onResponseImpl(ResponseT response) {
+            seenSuccessSinceLastError = true;
+            resumptionStrategy.onProgress(response);
+            outerObserver.onResponse(response);
+          }
+
+          @Override
+          public void onErrorImpl(Throwable t) {
+            if (cancellationCause != null) {
+              attemptFuture.setExceptionPrivately(cancellationCause);
+            } else {
+              attemptFuture.setExceptionPrivately(
+                  new WrappedApiException(seenSuccessSinceLastError, t)
+              );
+            }
+          }
+
+          @Override
+          public void onCompleteImpl() {
+            attemptFuture.setPrivately(null);
+          }
+        },
+        context);
+
+    externalFuture.setAttemptFuture(attemptFuture);
+
+    return null;
+  }
+
+  /**
+   * Called by the inner {@link ServerStreamingCallable} when the call is about to start. This will
+   * transfer unfinished state from the previous attempt.
+   *
+   * @see ResponseObserver#onStart(StreamController)
+   */
+  private void onAttemptStart(StreamController controller) {
+    if (!autoFlowControl) {
+      controller.disableAutoInboundFlowControl();
+    }
+
+    Throwable localCancellationCause;
+    int numToRequest = 0;
+
+    synchronized (lock) {
+      innerController = controller;
+
+      localCancellationCause = this.cancellationCause;
+
+      if (!autoFlowControl) {
+        numToRequest = pendingRequests;
+      }
+    }
+
+    if (localCancellationCause != null) {
+      controller.cancel();
+    } else if (numToRequest > 0) {
+      controller.request(numToRequest);
+    }
+  }
+
+  /**
+   * Called when the outer {@link ResponseObserver} is ready for more data.
+   *
+   * @see StreamController#request(int)
+   */
+  private void onRequest(int count) {
+    Preconditions.checkState(!autoFlowControl, "Automatic flow control is enabled");
+    Preconditions.checkArgument(count > 0, "Count must be > 0");
+
+    final StreamController localInnerController;
+
+    synchronized (lock) {
+      int maxInc = Integer.MAX_VALUE - pendingRequests;
+      count = Math.min(maxInc, count);
+
+      pendingRequests += count;
+      localInnerController = this.innerController;
+    }
+
+    // Note: there is a race condition here where the count might go to the previous attempt's
+    // StreamController after it failed. But it doesn't matter, because the controller will just
+    // ignore it and the current controller will pick it up onStart.
+    if (localInnerController != null) {
+      localInnerController.request(count);
+    }
+  }
+
+  /**
+   * Called when the outer {@link ResponseObserver} wants to prematurely cancel the stream.
+   *
+   * @see StreamController#cancel()
+   */
+  private void onCancel() {
+    StreamController localInnerController;
+
+    synchronized (lock) {
+      if (cancellationCause != null) {
+        return;
+      }
+      cancellationCause = new WrappedCancellationException("User cancelled stream");
+      localInnerController = innerController;
+    }
+
+    if (localInnerController != null) {
+      localInnerController.cancel();
+    }
+  }
+
+  public static class WrappedCancellationException extends RuntimeException {
+    public WrappedCancellationException(String message) {
+      super(new CancellationException(message));
+    }
+  }
+
+  public static class WrappedApiException extends RuntimeException {
+    private final boolean seenSuccessSinceLastError;
+
+
+    public WrappedApiException(boolean seenSuccessSinceLastError, Throwable t) {
+      super(t);
+      this.seenSuccessSinceLastError = seenSuccessSinceLastError;
+    }
+
+    public boolean hasSeenSuccessSinceLastError() {
+      return seenSuccessSinceLastError;
+    }
+  }
+}
+

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -60,7 +60,6 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
   private final RetrySettings retrySettings;
   private final StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategy;
 
-
   private ServerStreamingCallSettings(Builder<RequestT, ResponseT> builder) {
     this.retryableCodes = ImmutableSet.copyOf(builder.retryableCodes);
     this.retrySettings = builder.retrySettings;

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -52,6 +52,19 @@ import org.threeten.bp.Duration;
  * codes indicate which codes cause a retry to occur, the retry settings configure the retry logic
  * when the retry needs to happen, and the stream resumption strategy composes the request to resume
  * the stream. To turn off retries, set the retryable codes to the empty set.
+ *
+ * <p>The retry settings have slightly different semantics here:
+ *
+ * <ul>
+ *   <li>retry delays are reset to initial value as soon as a response is received.
+ *   <li>RPC timeouts are reset to initial value as soon as a response is received.
+ *   <li>RPC timeouts apply to the time interval between caller demanding more responses via {@link
+ *       StreamController#request(int)} and the {@link ResponseObserver} receiving the message.
+ *   <li>RPC timeouts are best effort and are checked once every {@link #timeoutCheckInterval}.
+ *   <li>Attempt counts are reset as soon as a response is received. So max attempts is the maximum
+ *       number of failures in a row.
+ *   <li>totalTimeout still applies to the entire stream.
+ * </ul>
  */
 @BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public final class ServerStreamingCallSettings<RequestT, ResponseT>

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -47,7 +47,7 @@ import org.threeten.bp.Duration;
  * <p>This class includes settings that are applicable to all server streaming calls, which
  * currently just includes retries.
  *
- * <p>Retry configuration allows for the stream to be restarted and resumed. it is composed of 3
+ * <p>Retry configuration allows for the stream to be restarted and resumed. It is composed of 3
  * parts: the retryable codes, the retry settings and the stream resumption strategy. The retryable
  * codes indicate which codes cause a retry to occur, the retry settings configure the retry logic
  * when the retry needs to happen, and the stream resumption strategy composes the request to resume
@@ -56,13 +56,13 @@ import org.threeten.bp.Duration;
  * <p>The retry settings have slightly different semantics when compared to unary RPCs:
  *
  * <ul>
- *   <li>retry delays are reset to initial value as soon as a response is received.
- *   <li>RPC timeouts are reset to initial value as soon as a response is received.
+ *   <li>retry delays are reset to the initial value as soon as a response is received.
+ *   <li>RPC timeouts are reset to the initial value as soon as a response is received.
  *   <li>RPC timeouts apply to the time interval between caller demanding more responses via {@link
  *       StreamController#request(int)} and the {@link ResponseObserver} receiving the message.
  *   <li>RPC timeouts are best effort and are checked once every {@link #timeoutCheckInterval}.
- *   <li>Attempt counts are reset as soon as a response is received. So max attempts is the maximum
- *       number of failures in a row.
+ *   <li>Attempt counts are reset as soon as a response is received. This means that max attempts is
+ *       the maximum number of failures in a row.
  *   <li>totalTimeout still applies to the entire stream.
  * </ul>
  */

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -53,7 +53,7 @@ import org.threeten.bp.Duration;
  * when the retry needs to happen, and the stream resumption strategy composes the request to resume
  * the stream. To turn off retries, set the retryable codes to the empty set.
  *
- * <p>The retry settings have slightly different semantics here:
+ * <p>The retry settings have slightly different semantics when compared to unary RPCs:
  *
  * <ul>
  *   <li>retry delays are reset to initial value as soon as a response is received.

--- a/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.ApiClock;
+import com.google.api.core.InternalApi;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.concurrent.GuardedBy;
+import org.threeten.bp.Duration;
+
+/**
+ * Prevents the streams from hanging indefinitely. This middleware garbage collects idle streams in
+ * case the user forgot to close a ServerStream or if a connection is reset and GRPC does not get
+ * notified.
+ *
+ * <p>For every {@code checkInterval}, this class checks two thresholds:
+ *
+ * <ul>
+ *   <li>waitingTimeout: the amount of time to wait for a response (after the caller signaled
+ *       demand) before forcefully closing the stream. Duration.ZERO disables the timeout.
+ *   <li>idleTimeout: the amount of time to wait before assuming that the caller forgot to close the
+ *       stream and forcefully closing the stream. This is measured from the last time the caller
+ *       had no outstanding demand. Duration.ZERO disables the timeout.
+ * </ul>
+ *
+ * @param <ResponseT> The type of the response.
+ */
+@InternalApi
+public class Watchdog<ResponseT> {
+  // Dummy value to convert the ConcurrentHashMap into a Set
+  private static Object VALUE_MARKER = new Object();
+  private final ConcurrentHashMap<WatchdogStream, Object> openStreams = new ConcurrentHashMap<>();
+
+  private final ScheduledExecutorService executor;
+  private final ApiClock clock;
+  private final Duration checkInterval;
+  private final Duration idleTimeout;
+
+  public Watchdog(
+      ScheduledExecutorService executor,
+      ApiClock clock,
+      Duration checkInterval,
+      Duration idleTimeout) {
+
+    Preconditions.checkNotNull(executor, "executor can't be null");
+    Preconditions.checkNotNull(clock, "clock can't be null");
+    Preconditions.checkNotNull(checkInterval, "checkInterval can't be null");
+    Preconditions.checkNotNull(idleTimeout, "checkInterval can't be null");
+
+    Preconditions.checkArgument(
+        Duration.ZERO.compareTo(checkInterval) < 0, "checkInterval must be > 0");
+
+    Preconditions.checkArgument(
+        Duration.ZERO.compareTo(idleTimeout) <= 0, "idleTimeout must be >= 0");
+
+    this.executor = executor;
+    this.clock = clock;
+    this.checkInterval = checkInterval;
+    this.idleTimeout = idleTimeout;
+  }
+
+  /** Schedules the timeout check thread. */
+  public void start() {
+    executor.scheduleAtFixedRate(
+        new Runnable() {
+          @Override
+          public void run() {
+            checkAll();
+          }
+        },
+        checkInterval.toMillis(),
+        checkInterval.toMillis(),
+        TimeUnit.MILLISECONDS);
+  }
+
+  /** Wraps the target observer with timing constraints. */
+  public ResponseObserver<ResponseT> watch(
+      ResponseObserver<ResponseT> innerObserver, Duration waitTimeout) {
+    Preconditions.checkNotNull(innerObserver, "innerObserver can't be null");
+    Preconditions.checkArgument(Duration.ZERO.compareTo(waitTimeout) <= 0, "waitTimeout must >= 0");
+
+    WatchdogStream stream = new WatchdogStream(innerObserver, waitTimeout);
+    openStreams.put(stream, VALUE_MARKER);
+    return stream;
+  }
+
+  @VisibleForTesting
+  void checkAll() {
+    Iterator<Entry<WatchdogStream, Object>> it = openStreams.entrySet().iterator();
+
+    while (it.hasNext()) {
+      WatchdogStream stream = it.next().getKey();
+      if (stream.cancelIfStale()) {
+        it.remove();
+      }
+    }
+  }
+
+  enum State {
+    /** Stream has been started, but doesn't have any outstanding requests. */
+    IDLE,
+    /** Stream is awaiting a response from upstream. */
+    WAITING,
+    /**
+     * Stream received a response from upstream, and is awaiting outerResponseObserver processing.
+     */
+    DELIVERING
+  }
+
+  class WatchdogStream extends StateCheckingResponseObserver<ResponseT> {
+    private final Object lock = new Object();
+
+    private final Duration waitTimeout;
+    private boolean hasStarted;
+    private boolean autoAutoFlowControl = true;
+
+    private final ResponseObserver<ResponseT> outerResponseObserver;
+    private StreamController innerController;
+
+    @GuardedBy("lock")
+    private State state = State.IDLE;
+
+    @GuardedBy("lock")
+    private int pendingCount = 0;
+
+    @GuardedBy("lock")
+    private long lastActivityAt = clock.millisTime();
+
+    private volatile Throwable error;
+
+    WatchdogStream(ResponseObserver<ResponseT> responseObserver, Duration waitTimeout) {
+      this.waitTimeout = waitTimeout;
+      this.outerResponseObserver = responseObserver;
+    }
+
+    @Override
+    public void onStartImpl(StreamController controller) {
+      this.innerController = controller;
+      outerResponseObserver.onStart(
+          new StreamController() {
+            @Override
+            public void disableAutoInboundFlowControl() {
+              Preconditions.checkState(
+                  !hasStarted, "Can't disable automatic flow control after the stream has started");
+              autoAutoFlowControl = false;
+              innerController.disableAutoInboundFlowControl();
+            }
+
+            @Override
+            public void request(int count) {
+              WatchdogStream.this.onRequest(count);
+            }
+
+            @Override
+            public void cancel() {
+              WatchdogStream.this.onCancel();
+            }
+          });
+
+      hasStarted = true;
+    }
+
+    private void onRequest(int count) {
+      Preconditions.checkArgument(count > 0, "count must be > 0");
+      Preconditions.checkState(!autoAutoFlowControl, "Auto flow control is enabled");
+
+      // Only reset the request water mark if there are no outstanding requests.
+      synchronized (lock) {
+        if (state == State.IDLE) {
+          state = State.WAITING;
+          lastActivityAt = clock.millisTime();
+        }
+
+        // Increment the request count without overflow
+        int maxIncrement = Integer.MAX_VALUE - pendingCount;
+        count = Math.min(maxIncrement, count);
+        pendingCount += count;
+      }
+      innerController.request(count);
+    }
+
+    private void onCancel() {
+      error = new CancellationException("User cancelled stream");
+      innerController.cancel();
+    }
+
+    @Override
+    public void onResponseImpl(ResponseT response) {
+      synchronized (lock) {
+        state = State.DELIVERING;
+      }
+
+      outerResponseObserver.onResponse(response);
+
+      synchronized (lock) {
+        pendingCount--;
+        lastActivityAt = clock.millisTime();
+
+        if (autoAutoFlowControl || pendingCount > 0) {
+          state = State.WAITING;
+        } else {
+          state = State.IDLE;
+        }
+      }
+    }
+
+    @Override
+    public void onErrorImpl(Throwable t) {
+      // Overlay the cancellation errors (either user or idle)
+      if (this.error != null) {
+        t = this.error;
+      }
+      openStreams.remove(this);
+      outerResponseObserver.onError(t);
+    }
+
+    @Override
+    public void onCompleteImpl() {
+      openStreams.remove(this);
+      outerResponseObserver.onComplete();
+    }
+
+    /**
+     * Checks if this stream has overrun any of its timeouts and cancels it if it does.
+     *
+     * @return True if the stream was canceled.
+     */
+    boolean cancelIfStale() {
+      Throwable myError = null;
+
+      synchronized (lock) {
+        long waitTime = clock.millisTime() - lastActivityAt;
+
+        switch (this.state) {
+          case IDLE:
+            if (!idleTimeout.isZero() && waitTime >= idleTimeout.toMillis()) {
+              myError = new IdleConnectionException("Canceled due to idle connection", false);
+            }
+            break;
+          case WAITING:
+            if (!waitTimeout.isZero() && waitTime >= waitTimeout.toMillis()) {
+              myError =
+                  new IdleConnectionException(
+                      "Canceled due to timeout waiting for next response", true);
+            }
+            break;
+        }
+      }
+
+      if (myError != null) {
+        this.error = myError;
+        innerController.cancel();
+        return true;
+      }
+      return false;
+    }
+  }
+
+  /** The marker exception thrown when a timeout is exceeded. */
+  public static class IdleConnectionException extends ApiException {
+    private static final long serialVersionUID = -777463630112442085L;
+
+    IdleConnectionException(String message, boolean retry) {
+      super(message, null, LOCAL_ABORTED_STATUS_CODE, retry);
+    }
+  }
+
+  public static final StatusCode LOCAL_ABORTED_STATUS_CODE =
+      new StatusCode() {
+        @Override
+        public Code getCode() {
+          return Code.ABORTED;
+        }
+
+        @Override
+        public Object getTransportCode() {
+          return null;
+        }
+      };
+}

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingAttemptCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingAttemptCallableTest.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.AbstractApiFuture;
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.retrying.RetryingFuture;
+import com.google.api.gax.retrying.ServerStreamingAttemptException;
+import com.google.api.gax.retrying.StreamResumptionStrategy;
+import com.google.api.gax.retrying.TimedAttemptSettings;
+import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.api.gax.rpc.testing.FakeApiException;
+import com.google.api.gax.rpc.testing.FakeCallContext;
+import com.google.api.gax.rpc.testing.MockStreamingApi.MockServerStreamingCall;
+import com.google.api.gax.rpc.testing.MockStreamingApi.MockServerStreamingCallable;
+import com.google.common.collect.Queues;
+import com.google.common.truth.Truth;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.threeten.bp.Duration;
+
+@RunWith(JUnit4.class)
+public class ServerStreamingAttemptCallableTest {
+  private Watchdog<String> watchdog;
+  private MockServerStreamingCallable<String, String> innerCallable;
+  private AccumulatingObserver observer;
+  private FakeRetryingFuture fakeRetryingFuture;
+  private StreamResumptionStrategy<String, String> resumptionStrategy;
+
+  @Before
+  public void setUp() {
+    watchdog = createNoopWatchdog();
+    innerCallable = new MockServerStreamingCallable<>();
+    observer = new AccumulatingObserver(true);
+    resumptionStrategy = new MyStreamResumptionStrategy();
+  }
+
+  private ServerStreamingAttemptCallable<String, String> createCallable() {
+    ServerStreamingAttemptCallable<String, String> callable =
+        new ServerStreamingAttemptCallable<>(
+            watchdog,
+            innerCallable,
+            resumptionStrategy,
+            "request",
+            FakeCallContext.createDefault(),
+            observer);
+
+    fakeRetryingFuture = new FakeRetryingFuture(callable);
+    callable.setExternalFuture(fakeRetryingFuture);
+
+    return callable;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> Watchdog<T> createNoopWatchdog() {
+    Watchdog<T> watchdog = Mockito.mock(Watchdog.class);
+
+    Mockito.when(watchdog.watch(Mockito.any(ResponseObserver.class), Mockito.any(Duration.class)))
+        .thenAnswer(
+            new Answer<ResponseObserver<T>>() {
+              @Override
+              public ResponseObserver<T> answer(InvocationOnMock invocation) {
+                return (ResponseObserver<T>) invocation.getArguments()[0];
+              }
+            });
+    return watchdog;
+  }
+
+  @Test
+  public void testNoErrorsAutoFlow() throws Exception {
+    ServerStreamingAttemptCallable<String, String> callable = createCallable();
+    callable.start();
+
+    // Should notify outer observer
+    Truth.assertThat(observer.controller).isNotNull();
+
+    // Should configure the inner controller correctly.
+    MockServerStreamingCall<String, String> call = innerCallable.popLastCall();
+    Truth.assertThat(call.getController().isAutoFlowControlEnabled()).isTrue();
+    Truth.assertThat(call.getRequest()).isEqualTo("request");
+
+    // Send a response in auto flow mode.
+    call.getController().getObserver().onResponse("response1");
+    call.getController().getObserver().onResponse("response2");
+    call.getController().getObserver().onComplete();
+
+    // Make sure the responses are received
+    Truth.assertThat(observer.responses).containsExactly("response1", "response2").inOrder();
+    fakeRetryingFuture.assertSuccess();
+  }
+
+  @Test
+  public void testNoErrorsManualFlow() throws Exception {
+    observer = new AccumulatingObserver(false);
+    ServerStreamingAttemptCallable<String, String> callable = createCallable();
+    callable.start();
+
+    // Should notify outer observer.
+    Truth.assertThat(observer.controller).isNotNull();
+
+    // Should configure the inner controller correctly.
+    MockServerStreamingCall<String, String> call = innerCallable.popLastCall();
+    Truth.assertThat(call.getController().isAutoFlowControlEnabled()).isFalse();
+    Truth.assertThat(call.getRequest()).isEqualTo("request");
+
+    // Request and send message 1.
+    observer.controller.request(1);
+    Truth.assertThat(call.getController().popLastPull()).isEqualTo(1);
+    call.getController().getObserver().onResponse("response1");
+
+    // Request & send message 1.
+    observer.controller.request(1);
+    Truth.assertThat(call.getController().popLastPull()).isEqualTo(1);
+    call.getController().getObserver().onResponse("response2");
+
+    call.getController().getObserver().onComplete();
+
+    // Make sure the responses are received
+    Truth.assertThat(observer.responses).containsExactly("response1", "response2").inOrder();
+    fakeRetryingFuture.assertSuccess();
+  }
+
+  @Test
+  @SuppressWarnings("ConstantConditions")
+  public void testInitialRetry() throws Exception {
+    resumptionStrategy = new MyStreamResumptionStrategy();
+    ServerStreamingAttemptCallable<String, String> callable = createCallable();
+    callable.start();
+
+    MockServerStreamingCall<String, String> call = innerCallable.popLastCall();
+
+    // Send initial error
+    FakeApiException initialError = new FakeApiException(null, Code.UNAVAILABLE, true);
+    call.getController().getObserver().onError(initialError);
+
+    // Should notify the outer future
+    Throwable outerError = null;
+    try {
+      fakeRetryingFuture.getAttemptResult().get(1, TimeUnit.SECONDS);
+    } catch (ExecutionException e) {
+      outerError = e.getCause();
+    } catch (Throwable e) {
+      outerError = e;
+    }
+    Truth.assertThat(outerError).isInstanceOf(ServerStreamingAttemptException.class);
+    Truth.assertThat(((ServerStreamingAttemptException) outerError).hasSeenResponses()).isFalse();
+    Truth.assertThat(((ServerStreamingAttemptException) outerError).canResume()).isTrue();
+    Truth.assertThat(outerError.getCause()).isEqualTo(initialError);
+
+    // Make the retry call
+    callable.call();
+    call = innerCallable.popLastCall();
+
+    // Verify the request and send a response
+    Truth.assertThat(call.getRequest()).isEqualTo("request > 0");
+  }
+
+  @Test
+  @SuppressWarnings("ConstantConditions")
+  public void testMidRetry() throws Exception {
+    resumptionStrategy = new MyStreamResumptionStrategy();
+    ServerStreamingAttemptCallable<String, String> callable = createCallable();
+    callable.start();
+
+    MockServerStreamingCall<String, String> call = innerCallable.popLastCall();
+
+    // Respond to the initial request with a coupple responses and an error.
+    Truth.assertThat(call.getRequest()).isEqualTo("request");
+    call.getController().getObserver().onResponse("response1");
+    call.getController().getObserver().onResponse("response2");
+
+    FakeApiException innerError = new FakeApiException(null, Code.UNAVAILABLE, true);
+    call.getController().getObserver().onError(innerError);
+
+    // Should notify the outer future
+    Throwable outerError = null;
+    try {
+      fakeRetryingFuture.getAttemptResult().get(1, TimeUnit.SECONDS);
+    } catch (ExecutionException e) {
+      outerError = e.getCause();
+    } catch (Throwable e) {
+      outerError = e;
+    }
+    Truth.assertThat(outerError).isInstanceOf(ServerStreamingAttemptException.class);
+    Truth.assertThat(((ServerStreamingAttemptException) outerError).hasSeenResponses()).isTrue();
+    Truth.assertThat(((ServerStreamingAttemptException) outerError).canResume()).isTrue();
+    Truth.assertThat(outerError.getCause()).isEqualTo(innerError);
+
+    // Make the retry call
+    callable.call();
+    call = innerCallable.popLastCall();
+
+    // Verify that the request was narrowed and send a response
+    Truth.assertThat(call.getRequest()).isEqualTo("request > 2");
+    call.getController().getObserver().onResponse("response3");
+    Truth.assertThat(observer.responses)
+        .containsExactly("response1", "response2", "response3")
+        .inOrder();
+  }
+
+  @Test
+  public void testRequestCountIsPreserved() throws Exception {
+    observer = new AccumulatingObserver(false);
+    ServerStreamingAttemptCallable<String, String> callable = createCallable();
+    callable.start();
+
+    observer.controller.request(5);
+
+    Truth.assertThat(observer.controller).isNotNull();
+    MockServerStreamingCall<String, String> call = innerCallable.popLastCall();
+    Truth.assertThat(call).isNotNull();
+    Truth.assertThat(call.getController().isAutoFlowControlEnabled()).isFalse();
+
+    Truth.assertThat(call.getController().popLastPull()).isEqualTo(5);
+    // decrement
+    call.getController().getObserver().onResponse("response");
+    // and then error
+    call.getController()
+        .getObserver()
+        .onError(new FakeApiException(null, Code.UNAUTHENTICATED, true));
+
+    // Make the retry call
+    callable.call();
+    call = innerCallable.popLastCall();
+
+    // Verify that the count is correct
+    Truth.assertThat(call.getController().popLastPull()).isEqualTo(4);
+  }
+
+  @Test
+  public void testCancel() throws Exception {
+    observer = new AccumulatingObserver(false);
+    ServerStreamingAttemptCallable<String, String> callable = createCallable();
+    callable.start();
+
+    observer.controller.request(1);
+
+    Truth.assertThat(observer.controller).isNotNull();
+    MockServerStreamingCall<String, String> call = innerCallable.popLastCall();
+    Truth.assertThat(call).isNotNull();
+    Truth.assertThat(call.getController().isAutoFlowControlEnabled()).isFalse();
+
+    observer.controller.cancel();
+
+    // Check upstream is cancelled
+    Truth.assertThat(call.getController().isCancelled()).isTrue();
+
+    // and after upstream cancellation is processed, downstream is cancelled, but the cause is replaced
+    RuntimeException innerException =
+        new RuntimeException("Some internal representation of cancel");
+    call.getController().getObserver().onError(innerException);
+
+    Throwable outerError = null;
+    try {
+      fakeRetryingFuture.getAttemptResult().get(1, TimeUnit.SECONDS);
+    } catch (ExecutionException e) {
+      outerError = e.getCause();
+    } catch (Throwable e) {
+      outerError = e;
+    }
+
+    Truth.assertThat(outerError).isInstanceOf(ServerStreamingAttemptException.class);
+    Truth.assertThat(outerError.getCause()).isInstanceOf(CancellationException.class);
+
+    // Make sure that the stack trace of the cancellation is preserved
+    boolean includesMeInStackTrace = false;
+    for (StackTraceElement e : outerError.getCause().getStackTrace()) {
+      if (ServerStreamingAttemptCallableTest.class.getName().equals(e.getClassName())) {
+        includesMeInStackTrace = true;
+        break;
+      }
+    }
+    Truth.assertWithMessage("Cancel caller included in stack trace")
+        .that(includesMeInStackTrace)
+        .isTrue();
+  }
+
+  static class MyStreamResumptionStrategy implements StreamResumptionStrategy<String, String> {
+    private int responseCount;
+
+    @Override
+    public StreamResumptionStrategy<String, String> createNew() {
+      return new MyStreamResumptionStrategy();
+    }
+
+    @Override
+    public void onProgress(String response) {
+      responseCount++;
+    }
+
+    @Override
+    public String getResumeRequest(String originalRequest) {
+      return originalRequest + " > " + responseCount;
+    }
+
+    @Override
+    public boolean canResume() {
+      return true;
+    }
+  }
+
+  static class AccumulatingObserver implements ResponseObserver<String> {
+    final boolean autoFlow;
+    StreamController controller;
+    final BlockingDeque<String> responses = Queues.newLinkedBlockingDeque();
+    private Throwable error;
+    private boolean complete;
+
+    AccumulatingObserver(boolean autoFlow) {
+      this.autoFlow = autoFlow;
+    }
+
+    @Override
+    public void onStart(StreamController controller) {
+      this.controller = controller;
+      if (!autoFlow) {
+        controller.disableAutoInboundFlowControl();
+      }
+    }
+
+    @Override
+    public void onResponse(String response) {
+      responses.add(response);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      this.error = t;
+    }
+
+    @Override
+    public void onComplete() {
+      this.complete = true;
+    }
+  }
+
+  private static class FakeRetryingFuture extends AbstractApiFuture<Void>
+      implements RetryingFuture<Void> {
+    private final ServerStreamingAttemptCallable<String, String> attemptCallable;
+    private ApiFuture<Void> attemptFuture;
+    private TimedAttemptSettings attemptSettings;
+
+    FakeRetryingFuture(ServerStreamingAttemptCallable<String, String> attemptCallable) {
+      this.attemptCallable = attemptCallable;
+      attemptSettings =
+          TimedAttemptSettings.newBuilder()
+              .setGlobalSettings(
+                  RetrySettings.newBuilder().setTotalTimeout(Duration.ofHours(1)).build())
+              .setFirstAttemptStartTimeNanos(0)
+              .setAttemptCount(0)
+              .setRandomizedRetryDelay(Duration.ofMillis(1))
+              .setRetryDelay(Duration.ofMillis(1))
+              .setRpcTimeout(Duration.ofMinutes(1))
+              .build();
+    }
+
+    @Override
+    public void setAttemptFuture(ApiFuture<Void> attemptFuture) {
+      this.attemptFuture = attemptFuture;
+    }
+
+    @Override
+    public ServerStreamingAttemptCallable<String, String> getCallable() {
+      return attemptCallable;
+    }
+
+    @Override
+    public TimedAttemptSettings getAttemptSettings() {
+      return attemptSettings;
+    }
+
+    @Override
+    public ApiFuture<Void> peekAttemptResult() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ApiFuture<Void> getAttemptResult() {
+      return attemptFuture;
+    }
+
+    void assertSuccess() {
+      Throwable actualError = null;
+      try {
+        attemptFuture.get(1, TimeUnit.SECONDS);
+      } catch (Throwable t) {
+        actualError = t;
+      }
+      Truth.assertThat(actualError).isNull();
+    }
+  }
+}

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallSettingsTest.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.rpc;
 
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.truth.Truth;
@@ -36,6 +37,8 @@ import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class ServerStreamingCallSettingsTest {
@@ -58,5 +61,45 @@ public class ServerStreamingCallSettingsTest {
         ServerStreamingCallSettings.newBuilder().setRetryableCodes(Code.UNKNOWN, Code.ABORTED);
 
     Truth.assertThat(builder.getRetryableCodes()).containsExactly(Code.UNKNOWN, Code.ABORTED);
+  }
+
+  @Test
+  public void retryableSettingsAreNotLost() {
+    RetrySettings retrySettings = Mockito.mock(RetrySettings.class);
+
+    ServerStreamingCallSettings.Builder<Object, Object> builder =
+        ServerStreamingCallSettings.newBuilder();
+    builder.setRetrySettings(retrySettings);
+
+    Truth.assertThat(builder.getRetrySettings()).isSameAs(retrySettings);
+    Truth.assertThat(builder.build().getRetrySettings()).isSameAs(retrySettings);
+    Truth.assertThat(builder.build().toBuilder().getRetrySettings()).isSameAs(retrySettings);
+  }
+
+  @Test
+  public void checkIntervalIsNotLost() {
+    Duration checkInterval = Duration.ofSeconds(5);
+
+    ServerStreamingCallSettings.Builder<Object, Object> builder =
+        ServerStreamingCallSettings.newBuilder();
+    builder.setTimeoutCheckInterval(checkInterval);
+
+    Truth.assertThat(builder.getTimeoutCheckInterval()).isEqualTo(checkInterval);
+    Truth.assertThat(builder.build().getTimeoutCheckInterval()).isEqualTo(checkInterval);
+    Truth.assertThat(builder.build().toBuilder().getTimeoutCheckInterval())
+        .isEqualTo(checkInterval);
+  }
+
+  @Test
+  public void idleTimeoutIsNotLost() {
+    Duration idleTimeout = Duration.ofSeconds(5);
+
+    ServerStreamingCallSettings.Builder<Object, Object> builder =
+        ServerStreamingCallSettings.newBuilder();
+    builder.setIdleTimeout(idleTimeout);
+
+    Truth.assertThat(builder.getIdleTimeout()).isEqualTo(idleTimeout);
+    Truth.assertThat(builder.build().getIdleTimeout()).isEqualTo(idleTimeout);
+    Truth.assertThat(builder.build().toBuilder().getIdleTimeout()).isEqualTo(idleTimeout);
   }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/WatchdogTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/WatchdogTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.core.FakeApiClock;
+import com.google.api.gax.rpc.Watchdog.IdleConnectionException;
+import com.google.api.gax.rpc.testing.MockStreamingApi.MockServerStreamingCall;
+import com.google.api.gax.rpc.testing.MockStreamingApi.MockServerStreamingCallable;
+import com.google.common.collect.Queues;
+import com.google.common.truth.Truth;
+import java.util.Queue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+import org.threeten.bp.Duration;
+
+@RunWith(JUnit4.class)
+public class WatchdogTest {
+  private FakeApiClock clock;
+  private Duration waitTime = Duration.ofSeconds(10);
+  private Duration idleTime = Duration.ofMinutes(5);
+  private Duration checkInterval = Duration.ofSeconds(5);
+
+  private Watchdog<String> watchdog;
+  private MockServerStreamingCallable<String, String> callable;
+  private AccumulatingObserver<String> innerObserver;
+  private MockServerStreamingCall<String, String> call;
+
+  @Before
+  public void setUp() throws Exception {
+    clock = new FakeApiClock(0);
+    ScheduledExecutorService executor = Mockito.mock(ScheduledExecutorService.class);
+    watchdog = new Watchdog<>(executor, clock, checkInterval, idleTime);
+
+    callable = new MockServerStreamingCallable<>();
+    innerObserver = new AccumulatingObserver<>();
+    callable.call("request", watchdog.watch(innerObserver, waitTime));
+    call = callable.popLastCall();
+  }
+
+  @Test
+  public void testRequestPassthrough() throws Exception {
+    innerObserver.controller.get().request(1);
+    Truth.assertThat(call.getController().popLastPull()).isEqualTo(1);
+  }
+
+  @Test
+  public void testWaitTimeout() throws Exception {
+    innerObserver.controller.get(1, TimeUnit.MILLISECONDS).request(1);
+
+    clock.incrementNanoTime(waitTime.toNanos() - 1);
+    watchdog.checkAll();
+    Truth.assertThat(call.getController().isCancelled()).isFalse();
+
+    clock.incrementNanoTime(1);
+    watchdog.checkAll();
+    Truth.assertThat(call.getController().isCancelled()).isTrue();
+    call.getController()
+        .getObserver()
+        .onError(new RuntimeException("Some upstream exception representing cancellation"));
+
+    Throwable actualError = null;
+    try {
+      innerObserver.done.get();
+    } catch (ExecutionException t) {
+      actualError = t.getCause();
+    }
+    Truth.assertThat(actualError).isInstanceOf(IdleConnectionException.class);
+  }
+
+  @Test
+  public void testIdleTimeout() throws InterruptedException {
+    clock.incrementNanoTime(idleTime.toNanos() - 1);
+    watchdog.checkAll();
+    Truth.assertThat(call.getController().isCancelled()).isFalse();
+
+    clock.incrementNanoTime(1);
+    watchdog.checkAll();
+    Truth.assertThat(call.getController().isCancelled()).isTrue();
+    call.getController()
+        .getObserver()
+        .onError(new RuntimeException("Some upstream exception representing cancellation"));
+
+    Throwable actualError = null;
+    try {
+      innerObserver.done.get();
+    } catch (ExecutionException t) {
+      actualError = t.getCause();
+    }
+    Truth.assertThat(actualError).isInstanceOf(IdleConnectionException.class);
+  }
+
+  @Test
+  public void testMultiple() throws InterruptedException, ExecutionException, TimeoutException {
+    // Start stream1
+    AccumulatingObserver<String> downstreamObserver1 = new AccumulatingObserver<>();
+    callable.call("request", watchdog.watch(downstreamObserver1, waitTime));
+    MockServerStreamingCall<String, String> call1 = callable.popLastCall();
+    downstreamObserver1.controller.get().request(1);
+
+    // Start stream2
+    AccumulatingObserver<String> downstreamObserver2 = new AccumulatingObserver<>();
+    callable.call("req2", watchdog.watch(downstreamObserver2, waitTime));
+    MockServerStreamingCall<String, String> call2 = callable.popLastCall();
+    downstreamObserver2.controller.get().request(1);
+
+    // Give stream1 a response at the last possible moment
+    clock.incrementNanoTime(waitTime.toNanos());
+    call1.getController().getObserver().onResponse("resp1");
+
+    // run the callable
+    watchdog.checkAll();
+
+    // Call1 should be ok
+    Truth.assertThat(call1.getController().isCancelled()).isFalse();
+    // Should not throw
+    Truth.assertThat(downstreamObserver1.done.isDone()).isFalse();
+
+    // Call2 should be timed out
+    Truth.assertThat(call2.getController().isCancelled()).isTrue();
+    call2.getController().getObserver().onError(new CancellationException("User cancelled"));
+    Throwable error = null;
+    try {
+      downstreamObserver2.done.get();
+    } catch (ExecutionException t) {
+      error = t.getCause();
+    }
+    Truth.assertThat(error).isInstanceOf(IdleConnectionException.class);
+  }
+
+  static class AccumulatingObserver<T> implements ResponseObserver<T> {
+    SettableApiFuture<StreamController> controller = SettableApiFuture.create();
+    Queue<T> responses = Queues.newLinkedBlockingDeque();
+    SettableApiFuture<Void> done = SettableApiFuture.create();
+
+    @Override
+    public void onStart(StreamController controller) {
+      controller.disableAutoInboundFlowControl();
+      this.controller.set(controller);
+    }
+
+    @Override
+    public void onResponse(T response) {
+      responses.add(response);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      done.setException(t);
+    }
+
+    @Override
+    public void onComplete() {
+      done.set(null);
+    }
+  }
+}


### PR DESCRIPTION
Add retries and resume support. 
This is re-write of #449 and the last part of #433

Conceptually, retries for streams can be split into 2 phases: before the first response is observed and after. Before the first response is observed, retries can be handled automatically similar to unary RPCs. After the first response is observed, manual work needs to done to recalculate the retry request. This work is delegated to a StreamResumptionStrategy, which is notified of incoming responses and can be asked to build a resume request on failure. Gax should offer out of box support for the first kind of retries and allow client developers to manually add support for resumes via handwritten code. I envision the workflow for client developers as: add retry codes & settings to GAPIC yaml to enable simple retries, then implement a StreamTracker and set it on the ServerStreamingCallSettings.

This PR also implements timeouts for RPCs. The existing concepts of RPC & total timeouts are extended: RPC timeout now limits the time interval between a consumer signaling demand for the next response via StreamController#request() and receiving a response in ResponseObserver#onResponse. Total timeout limits the total duration of the stream from the initial call() until the last onComplete/onError of the last retry attempt. Furthermore, the concept of idle timeout is added to streams with manual flow control, this limits the time between last observed consumer activity (the time between finishing processing a response in onResponse to the next call to request). This is meant to address the possibility of the caller forgetting to cancel a partially read stream.

Since GRPC does not implement the concept of RPC timeouts for streams, this PR implements it as  a watchdog helper. The helper tracks activity per stream and schedules periodic garbage collection sweeps. So stream RPC timeouts are a lot looser than their unary counterparts. Furthermore, the helper needs to receive more information from its callers than is currently available: it needs to be able to accept both an rpc timeout and a total stream deadline. I couldn't figure out how to generalize this and extend the ApiContext to carry this information.  So the watchdog helper steps outside the callable chain pattern and is implemented as a factory for ResponseObserver decorators.

