### PR TITLE
Update benchmarks

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -3,14 +3,16 @@ Benchmarking
 
 This sub-project contains micro-benchmarks for commonly used GAX functionalities.
 
+To run all of the benchmarks:
+```
+# Run from project root directory
+./gradlew benchmark:jmh
+```
+
+
 To run a benchmark, run the following command
 ```
 # Run from project root directory
-./gradlew benchmark:run -PcaliperArgs="['com.google.api.gax.grpc.CallableBenchmark']"
+./gradlew benchmark:jmh -Pinclude="['com.google.api.gax.grpc.CallableBenchmark']"
 ```
 substituting any benchmark class for `com.google.api.gax.grpc.CallableBenchmark`.
-
-For help menu explaining various flags,
-```
-./gradlew benchmark:run -PcaliperArgs="['-h']"
-```

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     compile project(':gax-grpc')
     compile "io.grpc:grpc-netty:${grpcVersion}"
 
+    compile 'com.google.api.grpc:grpc-google-cloud-bigtable-v2:0.1.28'
     compile 'com.google.api.grpc:grpc-google-cloud-pubsub-v1:0.1.28'
 }
 

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -1,29 +1,31 @@
+buildscript {
+    repositories {
+        jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "me.champeau.gradle:jmh-gradle-plugin:0.4.4"
+    }
+}
+
+apply plugin: "me.champeau.gradle.jmh"
 apply plugin: 'java'
-apply plugin: 'application'
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    compile 'com.google.caliper:caliper:1.0-beta-2'
-    compile 'com.google.guava:guava:19.0'
+    compile project(':gax')
+    compile project(':gax-grpc')
+    compile "io.grpc:grpc-netty:${grpcVersion}"
 
-    compile('com.google.api.grpc:grpc-google-cloud-pubsub-v1:0.1.5') {
-        exclude group: 'com.google.inject'
-    }
-    compile (project(':gax')) {
-        exclude group: 'com.google.inject'
-    }
-    compile (project(':gax-grpc')) {
-        exclude group: 'com.google.inject'
-    }
+    compile 'com.google.api.grpc:grpc-google-cloud-pubsub-v1:0.1.28'
 }
 
-mainClassName='com.google.caliper.runner.CaliperMain'
-
-run {
-  if (project.hasProperty("caliperArgs")) {
-    args Eval.me(caliperArgs)
-  }
+// Allow command line to target specific test
+if (project.properties.containsKey('include')) {
+    jmh.include = [project.properties.get('include')]
 }

--- a/benchmark/src/jmh/java/com/google/api/gax/grpc/FakeBigtableService.java
+++ b/benchmark/src/jmh/java/com/google/api/gax/grpc/FakeBigtableService.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.grpc;
+
+import com.google.bigtable.v2.BigtableGrpc;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.bigtable.v2.ReadRowsResponse.CellChunk;
+import com.google.common.collect.AbstractIterator;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.StringValue;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class FakeBigtableService extends BigtableGrpc.BigtableImplBase {
+  @Override
+  public void readRows(ReadRowsRequest request, StreamObserver<ReadRowsResponse> responseObserver) {
+    long numRows = Long.MAX_VALUE;
+    if (request.getRowsLimit() > 0) {
+      numRows = request.getRowsLimit();
+    }
+
+    final AtomicBoolean done = new AtomicBoolean();
+
+    final Iterator<ReadRowsResponse> source = new ReadRowsGenerator(numRows);
+    final ServerCallStreamObserver<ReadRowsResponse> target =
+        (ServerCallStreamObserver<ReadRowsResponse>) responseObserver;
+
+    target.setOnReadyHandler(
+        new Runnable() {
+          @Override
+          public void run() {
+            while (target.isReady() && source.hasNext()) {
+              target.onNext(source.next());
+            }
+            if (!source.hasNext() && done.compareAndSet(false, true)) {
+              target.onCompleted();
+            }
+          }
+        });
+  }
+
+  private static class ReadRowsGenerator extends AbstractIterator<ReadRowsResponse> {
+    private final long numResponses;
+    private long numSent;
+
+    ReadRowsGenerator(long numResponses) {
+      this.numResponses = numResponses;
+    }
+
+    @Override
+    protected ReadRowsResponse computeNext() {
+      if (numSent < numResponses) {
+        return buildResponse(numSent++);
+      }
+      return endOfData();
+    }
+
+    private ReadRowsResponse buildResponse(long i) {
+      return ReadRowsResponse.newBuilder()
+          .addChunks(
+              CellChunk.newBuilder()
+                  .setRowKey(ByteString.copyFromUtf8(String.format("user%07d", i)))
+                  .setFamilyName(StringValue.newBuilder().setValue("cf").build())
+                  .setTimestampMicros(1_000)
+                  .setValue(ByteString.copyFromUtf8(String.format("user%07d", i)))
+                  .setCommitRow(true)
+                  .build())
+          .build();
+    }
+  }
+}

--- a/benchmark/src/jmh/java/com/google/api/gax/grpc/ServerStreamingCallableBenchmark.java
+++ b/benchmark/src/jmh/java/com/google/api/gax/grpc/ServerStreamingCallableBenchmark.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.grpc;
+
+import com.google.api.core.CurrentMillisClock;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.RequestParamsExtractor;
+import com.google.api.gax.rpc.ResponseObserver;
+import com.google.api.gax.rpc.ServerStream;
+import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.api.gax.rpc.StreamController;
+import com.google.bigtable.v2.BigtableGrpc;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.Status;
+import io.grpc.stub.ClientCalls;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
+import org.threeten.bp.Duration;
+
+@Fork(value = 1)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@State(Scope.Benchmark)
+@OperationsPerInvocation(100_000)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class ServerStreamingCallableBenchmark {
+  private static final Logger LOG =
+      Logger.getLogger(ServerStreamingCallableBenchmark.class.getName());
+
+  @State(Scope.Benchmark)
+  public static class AsyncSettings {
+    @Param({"true", "false"})
+    private boolean autoFlowControl = true;
+  }
+
+  private ScheduledExecutorService executor;
+  private Server fakeServer;
+  private ManagedChannel grpcChannel;
+  private ClientContext clientContext;
+  private ReadRowsRequest request;
+
+  private ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> directCallable;
+  private ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> baseCallable;
+
+  @Setup
+  public void setup(BenchmarkParams benchmarkParams) throws IOException {
+    executor = Executors.newScheduledThreadPool(4);
+
+    final int availablePort;
+    try (ServerSocket ss = new ServerSocket(0)) {
+      availablePort = ss.getLocalPort();
+    }
+    fakeServer =
+        ServerBuilder.forPort(availablePort).addService(new FakeBigtableService()).build().start();
+
+    grpcChannel =
+        ManagedChannelBuilder.forAddress("localhost", availablePort).usePlaintext(true).build();
+
+    clientContext =
+        ClientContext.newBuilder()
+            .setExecutor(executor)
+            .setClock(CurrentMillisClock.getDefaultClock())
+            .setDefaultCallContext(
+                GrpcCallContext.of(
+                    grpcChannel, CallOptions.DEFAULT.withDeadlineAfter(1, TimeUnit.HOURS)))
+            .setTransportChannel(GrpcTransportChannel.create(grpcChannel))
+            .build();
+
+    request =
+        ReadRowsRequest.newBuilder().setRowsLimit(benchmarkParams.getOpsPerInvocation()).build();
+
+    // Direct Callable
+    directCallable = new GrpcDirectServerStreamingCallable<>(BigtableGrpc.METHOD_READ_ROWS);
+
+    // Base Callable (direct + params extractor + exceptions + retries)
+    GrpcCallSettings<ReadRowsRequest, ReadRowsResponse> grpcCallSettings =
+        GrpcCallSettings.<ReadRowsRequest, ReadRowsResponse>newBuilder()
+            .setMethodDescriptor(BigtableGrpc.METHOD_READ_ROWS)
+            .setParamsExtractor(new FakeRequestParamsExtractor())
+            .build();
+
+    ServerStreamingCallSettings<ReadRowsRequest, ReadRowsResponse> callSettings =
+        ServerStreamingCallSettings.<ReadRowsRequest, ReadRowsResponse>newBuilder()
+            .setRetryableCodes(Code.UNAVAILABLE)
+            .setRetrySettings(
+                RetrySettings.newBuilder()
+                    .setMaxAttempts(10)
+                    .setJittered(true)
+                    .setTotalTimeout(Duration.ofHours(1))
+                    .setInitialRetryDelay(Duration.ofMillis(5))
+                    .setRetryDelayMultiplier(2)
+                    .setMaxRetryDelay(Duration.ofMinutes(1))
+                    .setInitialRpcTimeout(Duration.ofHours(1))
+                    .setRpcTimeoutMultiplier(1)
+                    .setMaxRpcTimeout(Duration.ofHours(1))
+                    .build())
+            .setIdleTimeout(Duration.ofSeconds(1))
+            .setTimeoutCheckInterval(Duration.ofSeconds(1))
+            .build();
+
+    baseCallable =
+        GrpcCallableFactory.createServerStreamingCallable(
+            grpcCallSettings, callSettings, clientContext);
+  }
+
+  @TearDown
+  public void teardown() {
+    try {
+      grpcChannel.shutdown();
+      if (!grpcChannel.awaitTermination(10, TimeUnit.SECONDS)) {
+        throw new TimeoutException();
+      }
+    } catch (Exception e) {
+      LOG.log(Level.SEVERE, "Failed to close the grpc channel", e);
+    }
+
+    try {
+      fakeServer.shutdown();
+      if (!fakeServer.awaitTermination(10, TimeUnit.SECONDS)) {
+        throw new TimeoutException();
+      }
+    } catch (Exception e) {
+      LOG.log(Level.SEVERE, "Failed to shutdown the fake server", e);
+    }
+
+    try {
+      executor.shutdown();
+      if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+        throw new TimeoutException();
+      }
+    } catch (Exception e) {
+      LOG.log(Level.SEVERE, "Failed to shutdown the the executor", e);
+    }
+  }
+
+  // ClientCall.Listener baseline
+  @Benchmark
+  public void asyncGrpcListener(AsyncSettings asyncSettings, Blackhole blackhole)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    ClientCall<ReadRowsRequest, ReadRowsResponse> clientCall =
+        grpcChannel.newCall(BigtableGrpc.METHOD_READ_ROWS, CallOptions.DEFAULT);
+
+    GrpcClientCallListener listener =
+        new GrpcClientCallListener(clientCall, asyncSettings.autoFlowControl, blackhole);
+    clientCall.start(listener, new Metadata());
+    clientCall.sendMessage(request);
+    clientCall.halfClose();
+
+    if (asyncSettings.autoFlowControl) {
+      clientCall.request(Integer.MAX_VALUE);
+    } else {
+      clientCall.request(1);
+    }
+
+    listener.awaitCompletion();
+  }
+
+  @Benchmark
+  public void syncGrpcIterator(Blackhole blackhole) {
+    Iterator<ReadRowsResponse> iterator =
+        ClientCalls.blockingServerStreamingCall(
+            grpcChannel, BigtableGrpc.METHOD_READ_ROWS, CallOptions.DEFAULT, request);
+
+    while (iterator.hasNext()) {
+      ReadRowsResponse response = iterator.next();
+      blackhole.consume(response);
+    }
+  }
+
+  // DirectCallable
+  @Benchmark
+  public void asyncDirectServerStreamingCallable(AsyncSettings asyncSettings, Blackhole blackhole)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    GaxResponseObserver responseObserver =
+        new GaxResponseObserver(asyncSettings.autoFlowControl, blackhole);
+    directCallable.call(request, responseObserver, clientContext.getDefaultCallContext());
+    responseObserver.awaitCompletion();
+  }
+
+  @Benchmark
+  public void syncDirectServerStreamingCallable(Blackhole blackhole) {
+    ServerStream<ReadRowsResponse> results =
+        directCallable.call(request, clientContext.getDefaultCallContext());
+    for (ReadRowsResponse result : results) {
+      blackhole.consume(result);
+    }
+  }
+
+  // BaseCallable
+  @Benchmark
+  public void asyncBaseServerStreamingCallable(AsyncSettings asyncSettings, Blackhole blackhole)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    GaxResponseObserver responseObserver =
+        new GaxResponseObserver(asyncSettings.autoFlowControl, blackhole);
+    baseCallable.call(request, responseObserver);
+    responseObserver.awaitCompletion();
+  }
+
+  @Benchmark
+  public void syncBaseServerStreamingCallable(Blackhole blackhole) {
+    ServerStream<ReadRowsResponse> results = baseCallable.call(request);
+    for (ReadRowsResponse result : results) {
+      blackhole.consume(result);
+    }
+  }
+
+  // Helpers
+  private static class FakeRequestParamsExtractor
+      implements RequestParamsExtractor<ReadRowsRequest> {
+    @Override
+    public Map<String, String> extract(ReadRowsRequest request) {
+      return ImmutableMap.of("table_name", request.getTableName());
+    }
+  }
+
+  static class GrpcClientCallListener extends ClientCall.Listener<ReadRowsResponse> {
+    private final SettableFuture<Void> future = SettableFuture.create();
+    private final ClientCall<ReadRowsRequest, ReadRowsResponse> clientCall;
+    private final boolean autoFlowControl;
+    private final Blackhole blackhole;
+
+    GrpcClientCallListener(
+        ClientCall<ReadRowsRequest, ReadRowsResponse> clientCall,
+        boolean autoFlowControl,
+        Blackhole blackhole) {
+      this.clientCall = clientCall;
+      this.autoFlowControl = autoFlowControl;
+      this.blackhole = blackhole;
+    }
+
+    void awaitCompletion() throws InterruptedException, ExecutionException, TimeoutException {
+      future.get(1, TimeUnit.MINUTES);
+    }
+
+    @Override
+    public void onMessage(ReadRowsResponse message) {
+      blackhole.consume(message);
+      if (!autoFlowControl) {
+        clientCall.request(1);
+      }
+    }
+
+    @Override
+    public void onClose(Status status, Metadata trailers) {
+      if (status.isOk()) {
+        future.set(null);
+      } else {
+        future.setException(status.asRuntimeException(trailers));
+      }
+    }
+  }
+
+  static class GaxResponseObserver implements ResponseObserver<ReadRowsResponse> {
+    private final SettableFuture<Void> future = SettableFuture.create();
+    private final boolean autoFlowControl;
+    private final Blackhole blackhole;
+    private StreamController controller;
+
+    GaxResponseObserver(boolean autoFlowControl, Blackhole blackhole) {
+      this.autoFlowControl = autoFlowControl;
+      this.blackhole = blackhole;
+    }
+
+    void awaitCompletion() throws InterruptedException, ExecutionException, TimeoutException {
+      future.get(1, TimeUnit.HOURS);
+    }
+
+    @Override
+    public void onStart(StreamController controller) {
+      this.controller = controller;
+      if (!autoFlowControl) {
+        controller.disableAutoInboundFlowControl();
+        controller.request(1);
+      }
+    }
+
+    @Override
+    public void onResponse(ReadRowsResponse response) {
+      blackhole.consume(response);
+      if (!autoFlowControl) {
+        controller.request(1);
+      }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      future.setException(t);
+    }
+
+    @Override
+    public void onComplete() {
+      future.set(null);
+    }
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath "net.ltgt.gradle:gradle-apt-plugin:0.9",
+    classpath "net.ltgt.gradle:gradle-apt-plugin:0.10",
       "com.github.jengelman.gradle.plugins:shadow:1.2.4",
       "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.8.0"
 

--- a/gax/src/main/java/com/google/api/gax/rpc/QueuingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/QueuingResponseObserver.java
@@ -31,6 +31,7 @@ package com.google.api.gax.rpc;
 
 import com.google.common.collect.Queues;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A back pressure aware bridge from a {@link ResponseObserver} to a {@link BlockingQueue}. The
@@ -67,7 +68,12 @@ final class QueuingResponseObserver<V> extends StateCheckingResponseObserver<V> 
     if (isCancelled) {
       return EOF_MARKER;
     }
-    return buffer.take();
+
+    while (true) {
+      Object o = buffer.poll(1, TimeUnit.SECONDS);
+      if (o != null) return o;
+      System.out.println(controller.toString());
+    }
   }
 
   boolean isReady() {


### PR DESCRIPTION
- update existing benchmarks to use jmh instead caliper
- add benchmarks for ServerStreamingCallable

I wanted to start benchmarking the ServerStreamingCallable code I've been working on but it seems like the current benchmarks don't run anymore.  It seems like caliper stopped publishing binaries and I couldn't get the version used by gax to work (not to mention that it's extremely old). Instead I ported the benchmarks to JMH.