### PR TITLE
Watchdog: move to client context

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -45,6 +45,7 @@ import io.grpc.Status;
 import io.grpc.auth.MoreCallCredentials;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
 /**
@@ -60,20 +61,28 @@ import org.threeten.bp.Duration;
 public final class GrpcCallContext implements ApiCallContext {
   private final Channel channel;
   private final CallOptions callOptions;
+  @Nullable private final Duration streamWaitTimeout;
+  @Nullable private final Duration streamIdleTimeout;
 
   /** Returns an empty instance with a null channel and default {@link CallOptions}. */
   public static GrpcCallContext createDefault() {
-    return new GrpcCallContext(null, CallOptions.DEFAULT);
+    return new GrpcCallContext(null, CallOptions.DEFAULT, null, null);
   }
 
   /** Returns an instance with the given channel and {@link CallOptions}. */
   public static GrpcCallContext of(Channel channel, CallOptions callOptions) {
-    return new GrpcCallContext(channel, callOptions);
+    return new GrpcCallContext(channel, callOptions, null, null);
   }
 
-  private GrpcCallContext(Channel channel, CallOptions callOptions) {
+  private GrpcCallContext(
+      Channel channel,
+      CallOptions callOptions,
+      @Nullable Duration streamWaitTimeout,
+      @Nullable Duration streamIdleTimeout) {
     this.channel = channel;
     this.callOptions = Preconditions.checkNotNull(callOptions);
+    this.streamWaitTimeout = streamWaitTimeout;
+    this.streamIdleTimeout = streamIdleTimeout;
   }
 
   /**
@@ -140,6 +149,24 @@ public final class GrpcCallContext implements ApiCallContext {
   }
 
   @Override
+  public GrpcCallContext withStreamWaitTimeout(Duration streamWaitTimeout) {
+    if (streamWaitTimeout != null) {
+      Preconditions.checkArgument(
+          streamWaitTimeout.compareTo(Duration.ZERO) > 0, "Invalid timeout: <= 0 s");
+    }
+    return new GrpcCallContext(channel, callOptions, streamWaitTimeout, streamIdleTimeout);
+  }
+
+  @Override
+  public GrpcCallContext withStreamIdleTimeout(Duration streamIdleTimeout) {
+    if (streamIdleTimeout != null) {
+      Preconditions.checkArgument(
+          streamIdleTimeout.compareTo(Duration.ZERO) > 0, "Invalid timeout: <= 0 s");
+    }
+    return new GrpcCallContext(channel, callOptions, streamWaitTimeout, streamIdleTimeout);
+  }
+
+  @Override
   public ApiCallContext merge(ApiCallContext inputCallContext) {
     if (inputCallContext == null) {
       return this;
@@ -166,9 +193,21 @@ public final class GrpcCallContext implements ApiCallContext {
       newCallCredentials = this.callOptions.getCredentials();
     }
 
+    Duration newStreamWaitTimeout = grpcCallContext.streamWaitTimeout;
+    if (newStreamWaitTimeout == null) {
+      newStreamWaitTimeout = this.streamWaitTimeout;
+    }
+
+    Duration newStreamIdleTimeout = grpcCallContext.streamIdleTimeout;
+    if (newStreamIdleTimeout == null) {
+      newStreamIdleTimeout = this.streamIdleTimeout;
+    }
+
     CallOptions newCallOptions =
         this.callOptions.withCallCredentials(newCallCredentials).withDeadline(newDeadline);
-    return new GrpcCallContext(newChannel, newCallOptions);
+
+    return new GrpcCallContext(
+        newChannel, newCallOptions, newStreamWaitTimeout, newStreamIdleTimeout);
   }
 
   /** The {@link Channel} set on this context. */
@@ -181,14 +220,38 @@ public final class GrpcCallContext implements ApiCallContext {
     return callOptions;
   }
 
+  /**
+   * The stream wait timeout set for this context.
+   *
+   * @see ApiCallContext#withStreamWaitTimeout(Duration)
+   */
+  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+  @Nullable
+  public Duration getStreamWaitTimeout() {
+    return streamWaitTimeout;
+  }
+
+  /**
+   * The stream idle timeout set for this context.
+   *
+   * @see ApiCallContext#withStreamIdleTimeout(Duration)
+   */
+  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+  @Nullable
+  public Duration getStreamIdleTimeout() {
+    return streamIdleTimeout;
+  }
+
   /** Returns a new instance with the channel set to the given channel. */
   public GrpcCallContext withChannel(Channel newChannel) {
-    return new GrpcCallContext(newChannel, this.callOptions);
+    return new GrpcCallContext(
+        newChannel, this.callOptions, this.streamWaitTimeout, this.streamIdleTimeout);
   }
 
   /** Returns a new instance with the call options set to the given call options. */
   public GrpcCallContext withCallOptions(CallOptions newCallOptions) {
-    return new GrpcCallContext(this.channel, newCallOptions);
+    return new GrpcCallContext(
+        this.channel, newCallOptions, this.streamWaitTimeout, this.streamIdleTimeout);
   }
 
   public GrpcCallContext withRequestParamsDynamicHeaderOption(String requestParams) {
@@ -213,11 +276,14 @@ public final class GrpcCallContext implements ApiCallContext {
     }
 
     GrpcCallContext that = (GrpcCallContext) o;
-    return Objects.equals(channel, that.channel) && Objects.equals(callOptions, that.callOptions);
+    return Objects.equals(channel, that.channel)
+        && Objects.equals(callOptions, that.callOptions)
+        && Objects.equals(streamWaitTimeout, that.streamWaitTimeout)
+        && Objects.equals(streamIdleTimeout, that.streamIdleTimeout);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(channel, callOptions);
+    return Objects.hash(channel, callOptions, streamWaitTimeout, streamIdleTimeout);
   }
 }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -45,7 +45,6 @@ import io.grpc.Status;
 import io.grpc.auth.MoreCallCredentials;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
@@ -150,19 +149,21 @@ public final class GrpcCallContext implements ApiCallContext {
   }
 
   @Override
-  public GrpcCallContext withStreamWaitTimeout(@Nonnull Duration streamWaitTimeout) {
-    Preconditions.checkNotNull(streamWaitTimeout);
-    Preconditions.checkArgument(
-        streamWaitTimeout.compareTo(Duration.ZERO) >= 0, "Invalid timeout: < 0 s");
+  public GrpcCallContext withStreamWaitTimeout(@Nullable Duration streamWaitTimeout) {
+    if (streamWaitTimeout != null) {
+      Preconditions.checkArgument(
+          streamWaitTimeout.compareTo(Duration.ZERO) >= 0, "Invalid timeout: < 0 s");
+    }
 
     return new GrpcCallContext(channel, callOptions, streamWaitTimeout, streamIdleTimeout);
   }
 
   @Override
-  public GrpcCallContext withStreamIdleTimeout(@Nonnull Duration streamIdleTimeout) {
-    Preconditions.checkNotNull(streamIdleTimeout);
-    Preconditions.checkArgument(
-        streamIdleTimeout.compareTo(Duration.ZERO) >= 0, "Invalid timeout: < 0 s");
+  public GrpcCallContext withStreamIdleTimeout(@Nullable Duration streamIdleTimeout) {
+    if (streamIdleTimeout != null) {
+      Preconditions.checkArgument(
+          streamIdleTimeout.compareTo(Duration.ZERO) >= 0, "Invalid timeout: < 0 s");
+    }
 
     return new GrpcCallContext(channel, callOptions, streamWaitTimeout, streamIdleTimeout);
   }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -45,6 +45,7 @@ import io.grpc.Status;
 import io.grpc.auth.MoreCallCredentials;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
@@ -149,20 +150,20 @@ public final class GrpcCallContext implements ApiCallContext {
   }
 
   @Override
-  public GrpcCallContext withStreamWaitTimeout(Duration streamWaitTimeout) {
-    if (streamWaitTimeout != null) {
-      Preconditions.checkArgument(
-          streamWaitTimeout.compareTo(Duration.ZERO) > 0, "Invalid timeout: <= 0 s");
-    }
+  public GrpcCallContext withStreamWaitTimeout(@Nonnull Duration streamWaitTimeout) {
+    Preconditions.checkNotNull(streamWaitTimeout);
+    Preconditions.checkArgument(
+        streamWaitTimeout.compareTo(Duration.ZERO) >= 0, "Invalid timeout: < 0 s");
+
     return new GrpcCallContext(channel, callOptions, streamWaitTimeout, streamIdleTimeout);
   }
 
   @Override
-  public GrpcCallContext withStreamIdleTimeout(Duration streamIdleTimeout) {
-    if (streamIdleTimeout != null) {
-      Preconditions.checkArgument(
-          streamIdleTimeout.compareTo(Duration.ZERO) > 0, "Invalid timeout: <= 0 s");
-    }
+  public GrpcCallContext withStreamIdleTimeout(@Nonnull Duration streamIdleTimeout) {
+    Preconditions.checkNotNull(streamIdleTimeout);
+    Preconditions.checkArgument(
+        streamIdleTimeout.compareTo(Duration.ZERO) >= 0, "Invalid timeout: < 0 s");
+
     return new GrpcCallContext(channel, callOptions, streamWaitTimeout, streamIdleTimeout);
   }
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -239,6 +239,10 @@ public class GrpcCallableFactory {
         new GrpcExceptionServerStreamingCallable<>(
             callable, streamingCallSettings.getRetryableCodes());
 
+    if (clientContext.getWatchdog() != null) {
+      callable = Callables.watched(callable, streamingCallSettings, clientContext);
+    }
+
     callable = Callables.retrying(callable, streamingCallSettings, clientContext);
 
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -239,7 +239,7 @@ public class GrpcCallableFactory {
         new GrpcExceptionServerStreamingCallable<>(
             callable, streamingCallSettings.getRetryableCodes());
 
-    if (clientContext.getWatchdog() != null) {
+    if (clientContext.getStreamWatchdog() != null) {
       callable = Callables.watched(callable, streamingCallSettings, clientContext);
     }
 

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -126,18 +126,19 @@ public class GrpcCallContextTest {
     Truth.assertThat(context.getStreamWaitTimeout()).isEqualTo(timeout);
   }
 
+  @SuppressWarnings("ConstantConditions")
   @Test
   public void testWithNullStreamingWaitTimeout() {
-    Duration timeout = null;
-    GrpcCallContext context = GrpcCallContext.createDefault().withStreamWaitTimeout(timeout);
-    Truth.assertThat(context.getStreamWaitTimeout()).isEqualTo(timeout);
+    thrown.expect(NullPointerException.class);
+    GrpcCallContext.createDefault().withStreamWaitTimeout(null);
   }
 
   @Test
   public void testWithZeroStreamingWaitTimeout() {
     Duration timeout = Duration.ZERO;
-    thrown.expect(IllegalArgumentException.class);
-    GrpcCallContext.createDefault().withStreamWaitTimeout(timeout);
+    Truth.assertThat(
+            GrpcCallContext.createDefault().withStreamWaitTimeout(timeout).getStreamWaitTimeout())
+        .isEqualTo(timeout);
   }
 
   @Test
@@ -156,18 +157,19 @@ public class GrpcCallContextTest {
     Truth.assertThat(context.getStreamIdleTimeout()).isEqualTo(timeout);
   }
 
+  @SuppressWarnings("ConstantConditions")
   @Test
   public void testWithNullStreamingIdleTimeout() {
-    Duration timeout = null;
-    GrpcCallContext context = GrpcCallContext.createDefault().withStreamIdleTimeout(timeout);
-    Truth.assertThat(context.getStreamIdleTimeout()).isEqualTo(timeout);
+    thrown.expect(NullPointerException.class);
+    GrpcCallContext.createDefault().withStreamIdleTimeout(null);
   }
 
   @Test
   public void testWithZeroStreamingIdleTimeout() {
     Duration timeout = Duration.ZERO;
-    thrown.expect(IllegalArgumentException.class);
-    GrpcCallContext.createDefault().withStreamIdleTimeout(timeout);
+    Truth.assertThat(
+            GrpcCallContext.createDefault().withStreamIdleTimeout(timeout).getStreamIdleTimeout())
+        .isEqualTo(timeout);
   }
 
   @Test

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -126,11 +126,18 @@ public class GrpcCallContextTest {
     Truth.assertThat(context.getStreamWaitTimeout()).isEqualTo(timeout);
   }
 
-  @SuppressWarnings("ConstantConditions")
   @Test
-  public void testWithNullStreamingWaitTimeout() {
-    thrown.expect(NullPointerException.class);
-    GrpcCallContext.createDefault().withStreamWaitTimeout(null);
+  public void testMergeWithNullStreamingWaitTimeout() {
+    Duration timeout = Duration.ofSeconds(10);
+    GrpcCallContext baseContext = GrpcCallContext.createDefault().withStreamWaitTimeout(timeout);
+
+    GrpcCallContext defaultOverlay = GrpcCallContext.createDefault();
+    Truth.assertThat(baseContext.merge(defaultOverlay).getStreamWaitTimeout()).isEqualTo(timeout);
+
+    GrpcCallContext explicitNullOverlay =
+        GrpcCallContext.createDefault().withStreamWaitTimeout(null);
+    Truth.assertThat(baseContext.merge(explicitNullOverlay).getStreamWaitTimeout())
+        .isEqualTo(timeout);
   }
 
   @Test
@@ -157,11 +164,18 @@ public class GrpcCallContextTest {
     Truth.assertThat(context.getStreamIdleTimeout()).isEqualTo(timeout);
   }
 
-  @SuppressWarnings("ConstantConditions")
   @Test
-  public void testWithNullStreamingIdleTimeout() {
-    thrown.expect(NullPointerException.class);
-    GrpcCallContext.createDefault().withStreamIdleTimeout(null);
+  public void testMergeWithNullStreamingIdleTimeout() {
+    Duration timeout = Duration.ofSeconds(10);
+    GrpcCallContext baseContext = GrpcCallContext.createDefault().withStreamIdleTimeout(timeout);
+
+    GrpcCallContext defaultOverlay = GrpcCallContext.createDefault();
+    Truth.assertThat(baseContext.merge(defaultOverlay).getStreamIdleTimeout()).isEqualTo(timeout);
+
+    GrpcCallContext explicitNullOverlay =
+        GrpcCallContext.createDefault().withStreamIdleTimeout(null);
+    Truth.assertThat(baseContext.merge(explicitNullOverlay).getStreamIdleTimeout())
+        .isEqualTo(timeout);
   }
 
   @Test

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -44,9 +44,12 @@ import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 import org.threeten.bp.Duration;
 
+@RunWith(JUnit4.class)
 public class GrpcCallContextTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
@@ -114,5 +117,65 @@ public class GrpcCallContextTest {
   public void testWithZeroTimeout() {
     thrown.expect(DeadlineExceededException.class);
     GrpcCallContext.createDefault().withTimeout(Duration.ofSeconds(0L));
+  }
+
+  @Test
+  public void testWithStreamingWaitTimeout() {
+    Duration timeout = Duration.ofSeconds(15);
+    GrpcCallContext context = GrpcCallContext.createDefault().withStreamWaitTimeout(timeout);
+    Truth.assertThat(context.getStreamWaitTimeout()).isEqualTo(timeout);
+  }
+
+  @Test
+  public void testWithNullStreamingWaitTimeout() {
+    Duration timeout = null;
+    GrpcCallContext context = GrpcCallContext.createDefault().withStreamWaitTimeout(timeout);
+    Truth.assertThat(context.getStreamWaitTimeout()).isEqualTo(timeout);
+  }
+
+  @Test
+  public void testWithZeroStreamingWaitTimeout() {
+    Duration timeout = Duration.ZERO;
+    thrown.expect(IllegalArgumentException.class);
+    GrpcCallContext.createDefault().withStreamWaitTimeout(timeout);
+  }
+
+  @Test
+  public void testMergeWithStreamingWaitTimeout() {
+    Duration timeout = Duration.ofSeconds(19);
+    GrpcCallContext ctx1 = GrpcCallContext.createDefault();
+    GrpcCallContext ctx2 = GrpcCallContext.createDefault().withStreamWaitTimeout(timeout);
+
+    Truth.assertThat(ctx1.merge(ctx2).getStreamWaitTimeout()).isEqualTo(timeout);
+  }
+
+  @Test
+  public void testWithStreamingIdleTimeout() {
+    Duration timeout = Duration.ofSeconds(15);
+    GrpcCallContext context = GrpcCallContext.createDefault().withStreamIdleTimeout(timeout);
+    Truth.assertThat(context.getStreamIdleTimeout()).isEqualTo(timeout);
+  }
+
+  @Test
+  public void testWithNullStreamingIdleTimeout() {
+    Duration timeout = null;
+    GrpcCallContext context = GrpcCallContext.createDefault().withStreamIdleTimeout(timeout);
+    Truth.assertThat(context.getStreamIdleTimeout()).isEqualTo(timeout);
+  }
+
+  @Test
+  public void testWithZeroStreamingIdleTimeout() {
+    Duration timeout = Duration.ZERO;
+    thrown.expect(IllegalArgumentException.class);
+    GrpcCallContext.createDefault().withStreamIdleTimeout(timeout);
+  }
+
+  @Test
+  public void testMergeWithStreamingIdleTimeout() {
+    Duration timeout = Duration.ofSeconds(19);
+    GrpcCallContext ctx1 = GrpcCallContext.createDefault();
+    GrpcCallContext ctx2 = GrpcCallContext.createDefault().withStreamIdleTimeout(timeout);
+
+    Truth.assertThat(ctx1.merge(ctx2).getStreamIdleTimeout()).isEqualTo(timeout);
   }
 }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/SettingsTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/SettingsTest.java
@@ -41,6 +41,7 @@ import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.BatchingDescriptor;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.ClientSettings;
+import com.google.api.gax.rpc.FixedWatchdogProvider;
 import com.google.api.gax.rpc.NoHeaderProvider;
 import com.google.api.gax.rpc.PagedCallSettings;
 import com.google.api.gax.rpc.PagedListResponseFactory;
@@ -212,6 +213,7 @@ public class SettingsTest {
         builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
         builder.setHeaderProvider(new NoHeaderProvider());
         builder.setInternalHeaderProvider(defaultGoogleServiceHeaderProviderBuilder().build());
+        builder.setWatchdogProvider(FixedWatchdogProvider.create(null));
 
         builder
             .fakeMethodSimple()
@@ -544,6 +546,7 @@ public class SettingsTest {
           "headerProvider",
           "internalHeaderProvider",
           "transportChannelProvider",
+          "watchdogProvider"
         });
     assertIsReflectionEqual(settingsA.getExecutorProvider(), settingsB.getExecutorProvider());
     assertIsReflectionEqual(settingsA.getCredentialsProvider(), settingsB.getCredentialsProvider());

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/SettingsTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/SettingsTest.java
@@ -213,7 +213,7 @@ public class SettingsTest {
         builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
         builder.setHeaderProvider(new NoHeaderProvider());
         builder.setInternalHeaderProvider(defaultGoogleServiceHeaderProviderBuilder().build());
-        builder.setWatchdogProvider(FixedWatchdogProvider.create(null));
+        builder.setStreamWatchdogProvider(FixedWatchdogProvider.create(null));
 
         builder
             .fakeMethodSimple()
@@ -546,7 +546,7 @@ public class SettingsTest {
           "headerProvider",
           "internalHeaderProvider",
           "transportChannelProvider",
-          "watchdogProvider"
+          "streamWatchdogProvider"
         });
     assertIsReflectionEqual(settingsA.getExecutorProvider(), settingsB.getExecutorProvider());
     assertIsReflectionEqual(settingsA.getCredentialsProvider(), settingsB.getCredentialsProvider());

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -36,6 +36,7 @@ import com.google.api.gax.rpc.TransportChannel;
 import com.google.auth.Credentials;
 import com.google.common.base.Preconditions;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 import org.threeten.bp.Instant;
@@ -149,7 +150,7 @@ public final class HttpJsonCallContext implements ApiCallContext {
   }
 
   @Override
-  public ApiCallContext withStreamWaitTimeout(@Nullable Duration streamWaitTimeout) {
+  public ApiCallContext withStreamWaitTimeout(@Nonnull Duration streamWaitTimeout) {
     throw new UnsupportedOperationException("Http/json transport does not support streaming");
   }
 
@@ -160,7 +161,7 @@ public final class HttpJsonCallContext implements ApiCallContext {
   }
 
   @Override
-  public ApiCallContext withStreamIdleTimeout(@Nullable Duration streamIdleTimeout) {
+  public ApiCallContext withStreamIdleTimeout(@Nonnull Duration streamIdleTimeout) {
     throw new UnsupportedOperationException("Http/json transport does not support streaming");
   }
 

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -36,6 +36,7 @@ import com.google.api.gax.rpc.TransportChannel;
 import com.google.auth.Credentials;
 import com.google.common.base.Preconditions;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 import org.threeten.bp.Instant;
 
@@ -145,6 +146,28 @@ public final class HttpJsonCallContext implements ApiCallContext {
       return this;
     }
     return nextContext;
+  }
+
+  @Override
+  public ApiCallContext withStreamWaitTimeout(@Nullable Duration streamWaitTimeout) {
+    throw new UnsupportedOperationException("Http does not support streaming");
+  }
+
+  @Nullable
+  @Override
+  public Duration getStreamWaitTimeout() {
+    throw new UnsupportedOperationException("Http does not support streaming");
+  }
+
+  @Override
+  public ApiCallContext withStreamIdleTimeout(@Nullable Duration streamIdleTimeout) {
+    throw new UnsupportedOperationException("Http does not support streaming");
+  }
+
+  @Nullable
+  @Override
+  public Duration getStreamIdleTimeout() {
+    throw new UnsupportedOperationException("Http does not support streaming");
   }
 
   public HttpJsonChannel getChannel() {

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -150,24 +150,24 @@ public final class HttpJsonCallContext implements ApiCallContext {
 
   @Override
   public ApiCallContext withStreamWaitTimeout(@Nullable Duration streamWaitTimeout) {
-    throw new UnsupportedOperationException("Http does not support streaming");
+    throw new UnsupportedOperationException("Http/json transport does not support streaming");
   }
 
   @Nullable
   @Override
   public Duration getStreamWaitTimeout() {
-    throw new UnsupportedOperationException("Http does not support streaming");
+    throw new UnsupportedOperationException("Http/json transport does not support streaming");
   }
 
   @Override
   public ApiCallContext withStreamIdleTimeout(@Nullable Duration streamIdleTimeout) {
-    throw new UnsupportedOperationException("Http does not support streaming");
+    throw new UnsupportedOperationException("Http/json transport does not support streaming");
   }
 
   @Nullable
   @Override
   public Duration getStreamIdleTimeout() {
-    throw new UnsupportedOperationException("Http does not support streaming");
+    throw new UnsupportedOperationException("Http/json transport does not support streaming");
   }
 
   public HttpJsonChannel getChannel() {

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -32,7 +32,6 @@ package com.google.api.gax.rpc;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
 import com.google.auth.Credentials;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
@@ -71,11 +70,14 @@ public interface ApiCallContext {
    * server or connection stalls. When the timeout has been reached, the stream will be closed with
    * a retryable {@link WatchdogTimeoutException} and a status of {@link StatusCode.Code#ABORTED}.
    *
+   * <p>A value of {@link Duration#ZERO}, disables the streaming wait timeout and a null value will
+   * use the default in the callable.
+   *
    * <p>Please note that this timeout is best effort and the maximum resolution is configured in
    * {@link StubSettings#getStreamWatchdogCheckInterval()}.
    */
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")
-  ApiCallContext withStreamWaitTimeout(@Nonnull Duration streamWaitTimeout);
+  ApiCallContext withStreamWaitTimeout(@Nullable Duration streamWaitTimeout);
 
   /**
    * Return the stream wait timeout set for this context.
@@ -97,9 +99,15 @@ public interface ApiCallContext {
    * to clean up streams that were partially read but never closed. When the timeout has been
    * reached, the stream will be closed with a nonretryable {@link WatchdogTimeoutException} and a
    * status of {@link StatusCode.Code#ABORTED}.
+   *
+   * <p>A value of {@link Duration#ZERO}, disables the streaming idle timeout and a null value will
+   * use the default in the callable.
+   *
+   * <p>Please note that this timeout is best effort and the maximum resolution is configured in
+   * {@link StubSettings#getStreamWatchdogCheckInterval()}.
    */
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")
-  ApiCallContext withStreamIdleTimeout(@Nonnull Duration streamIdleTimeout);
+  ApiCallContext withStreamIdleTimeout(@Nullable Duration streamIdleTimeout);
 
   /**
    * The stream idle timeout set for this context.

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -32,6 +32,7 @@ package com.google.api.gax.rpc;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
 import com.google.auth.Credentials;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
@@ -74,7 +75,7 @@ public interface ApiCallContext {
    * {@link StubSettings#getStreamWatchdogCheckInterval()}.
    */
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")
-  ApiCallContext withStreamWaitTimeout(@Nullable Duration streamWaitTimeout);
+  ApiCallContext withStreamWaitTimeout(@Nonnull Duration streamWaitTimeout);
 
   /**
    * Return the stream wait timeout set for this context.
@@ -98,7 +99,7 @@ public interface ApiCallContext {
    * status of {@link StatusCode.Code#ABORTED}.
    */
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")
-  ApiCallContext withStreamIdleTimeout(@Nullable Duration streamIdleTimeout);
+  ApiCallContext withStreamIdleTimeout(@Nonnull Duration streamIdleTimeout);
 
   /**
    * The stream idle timeout set for this context.

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -29,8 +29,10 @@
  */
 package com.google.api.gax.rpc;
 
+import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
 import com.google.auth.Credentials;
+import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
 /**
@@ -56,6 +58,56 @@ public interface ApiCallContext {
    * taken will be much higher.
    */
   ApiCallContext withTimeout(Duration rpcTimeout);
+
+  /**
+   * Returns a new ApiCallContext with the given timeout set.
+   *
+   * <p>This timeout only applies to a {@link ServerStreamingCallable}s. It limits the maximum
+   * amount of timeout that can pass between demand being signaled via {@link
+   * StreamController#request(int)} and actual message delivery to {@link
+   * ResponseObserver#onResponse(Object)}. Or, in the case of automatic flow control, since the last
+   * message was delivered to {@link ResponseObserver#onResponse(Object)}. This is useful to detect
+   * server or connection stalls. When the timeout has been reached, the stream will be closed with
+   * a retryable {@link WatchdogTimeoutException} and a status of {@link StatusCode.Code#ABORTED}.
+   *
+   * <p>Please note that this timeout is best effort and the maximum resolution is configured in
+   * {@link StubSettings#getWatchdogCheckInterval()}.
+   */
+  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+  ApiCallContext withStreamWaitTimeout(@Nullable Duration streamWaitTimeout);
+
+  /**
+   * Return the stream wait timeout set for this context.
+   *
+   * @see #withStreamWaitTimeout(Duration)
+   */
+  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+  @Nullable
+  Duration getStreamWaitTimeout();
+
+  /**
+   * Returns a new ApiCallContext with the given timeout set.
+   *
+   * <p>This timeout only applies to a {@link ServerStreamingCallable}s. It limits the maximum
+   * amount of timeout that can pass between a message being received by {@link
+   * ResponseObserver#onResponse(Object)} and demand being signaled via {@link
+   * StreamController#request(int)}. Please note that this timeout is best effort and the maximum
+   * resolution configured in {@link StubSettings#getWatchdogCheckInterval()}. This is useful to
+   * clean up streams that were partially read but never closed. When the timeout has been reached,
+   * the stream will be closed with a nonretryable {@link WatchdogTimeoutException} and a status of
+   * {@link StatusCode.Code#ABORTED}.
+   */
+  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+  ApiCallContext withStreamIdleTimeout(@Nullable Duration streamIdleTimeout);
+
+  /**
+   * The stream idle timeout set for this context.
+   *
+   * @see #withStreamIdleTimeout(Duration)
+   */
+  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+  @Nullable
+  Duration getStreamIdleTimeout();
 
   /** If inputContext is not null, returns it; if it is null, returns the present instance. */
   ApiCallContext nullToSelf(ApiCallContext inputContext);

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -60,7 +60,7 @@ public interface ApiCallContext {
   ApiCallContext withTimeout(Duration rpcTimeout);
 
   /**
-   * Returns a new ApiCallContext with the given timeout set.
+   * Returns a new ApiCallContext with the given stream timeout set.
    *
    * <p>This timeout only applies to a {@link ServerStreamingCallable}s. It limits the maximum
    * amount of timeout that can pass between demand being signaled via {@link
@@ -71,7 +71,7 @@ public interface ApiCallContext {
    * a retryable {@link WatchdogTimeoutException} and a status of {@link StatusCode.Code#ABORTED}.
    *
    * <p>Please note that this timeout is best effort and the maximum resolution is configured in
-   * {@link StubSettings#getWatchdogCheckInterval()}.
+   * {@link StubSettings#getStreamWatchdogCheckInterval()}.
    */
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   ApiCallContext withStreamWaitTimeout(@Nullable Duration streamWaitTimeout);
@@ -86,16 +86,16 @@ public interface ApiCallContext {
   Duration getStreamWaitTimeout();
 
   /**
-   * Returns a new ApiCallContext with the given timeout set.
+   * Returns a new ApiCallContext with the given stream idel timeout set.
    *
    * <p>This timeout only applies to a {@link ServerStreamingCallable}s. It limits the maximum
    * amount of timeout that can pass between a message being received by {@link
    * ResponseObserver#onResponse(Object)} and demand being signaled via {@link
    * StreamController#request(int)}. Please note that this timeout is best effort and the maximum
-   * resolution configured in {@link StubSettings#getWatchdogCheckInterval()}. This is useful to
-   * clean up streams that were partially read but never closed. When the timeout has been reached,
-   * the stream will be closed with a nonretryable {@link WatchdogTimeoutException} and a status of
-   * {@link StatusCode.Code#ABORTED}.
+   * resolution configured in {@link StubSettings#getStreamWatchdogCheckInterval()}. This is useful
+   * to clean up streams that were partially read but never closed. When the timeout has been
+   * reached, the stream will be closed with a nonretryable {@link WatchdogTimeoutException} and a
+   * status of {@link StatusCode.Code#ABORTED}.
    */
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   ApiCallContext withStreamIdleTimeout(@Nullable Duration streamIdleTimeout);

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -86,7 +86,7 @@ public interface ApiCallContext {
   Duration getStreamWaitTimeout();
 
   /**
-   * Returns a new ApiCallContext with the given stream idel timeout set.
+   * Returns a new ApiCallContext with the given stream idle timeout set.
    *
    * <p>This timeout only applies to a {@link ServerStreamingCallable}s. It limits the maximum
    * amount of timeout that can pass between a message being received by {@link

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -99,13 +99,11 @@ public class Callables {
 
     callable = new WatchdogServerStreamingCallable<>(callable, clientContext.getStreamWatchdog());
 
-    if (callSettings.getIdleTimeout() != null) {
-      callable =
-          callable.withDefaultCallContext(
-              clientContext
-                  .getDefaultCallContext()
-                  .withStreamIdleTimeout(callSettings.getIdleTimeout()));
-    }
+    callable =
+        callable.withDefaultCallContext(
+            clientContext
+                .getDefaultCallContext()
+                .withStreamIdleTimeout(callSettings.getIdleTimeout()));
 
     return callable;
   }

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -113,6 +113,25 @@ public class Callables {
         callSettings.getResumptionStrategy());
   }
 
+  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+  public static <RequestT, ResponseT> ServerStreamingCallable<RequestT, ResponseT> watched(
+      ServerStreamingCallable<RequestT, ResponseT> callable,
+      ServerStreamingCallSettings<RequestT, ResponseT> callSettings,
+      ClientContext clientContext) {
+
+    callable = new WatchdogServerStreamingCallable<>(callable, clientContext.getWatchdog());
+
+    if (callSettings.getIdleTimeout() != null) {
+      callable =
+          callable.withDefaultCallContext(
+              clientContext
+                  .getDefaultCallContext()
+                  .withStreamIdleTimeout(callSettings.getIdleTimeout()));
+    }
+
+    return callable;
+  }
+
   /**
    * Create a callable object that represents a batching API method. Designed for use by generated
    * code.

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -97,7 +97,7 @@ public class Callables {
       ServerStreamingCallSettings<RequestT, ResponseT> callSettings,
       ClientContext clientContext) {
 
-    callable = new WatchdogServerStreamingCallable<>(callable, clientContext.getWatchdog());
+    callable = new WatchdogServerStreamingCallable<>(callable, clientContext.getStreamWatchdog());
 
     if (callSettings.getIdleTimeout() != null) {
       callable =

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -38,7 +38,6 @@ import com.google.api.gax.retrying.RetryAlgorithm;
 import com.google.api.gax.retrying.RetryingExecutor;
 import com.google.api.gax.retrying.ScheduledRetryingExecutor;
 import com.google.api.gax.retrying.StreamingRetryAlgorithm;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Class with utility methods to create callable objects using provided settings.
@@ -88,29 +87,8 @@ public class Callables {
     ScheduledRetryingExecutor<Void> retryingExecutor =
         new ScheduledRetryingExecutor<>(retryAlgorithm, clientContext.getExecutor());
 
-    // NOTE: This creates a Watchdog per streaming API method. Ideally, there should only be a
-    // single Watchdog for the entire process, however that change would be fairly invasive and
-    // the cost of multiple Watchdogs is fairly small, since they all use the same executor. If this
-    // becomes an issue, the watchdog can be moved to ClientContext.
-    Watchdog watchdog = null;
-    if (!callSettings.getTimeoutCheckInterval().isZero()) {
-      watchdog = new Watchdog(clientContext.getClock());
-
-      clientContext
-          .getExecutor()
-          .scheduleAtFixedRate(
-              watchdog,
-              callSettings.getTimeoutCheckInterval().toMillis(),
-              callSettings.getTimeoutCheckInterval().toMillis(),
-              TimeUnit.MILLISECONDS);
-    }
-
     return new RetryingServerStreamingCallable<>(
-        watchdog,
-        callSettings.getIdleTimeout(),
-        innerCallable,
-        retryingExecutor,
-        callSettings.getResumptionStrategy());
+        innerCallable, retryingExecutor, callSettings.getResumptionStrategy());
   }
 
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -84,11 +84,11 @@ public abstract class ClientContext {
 
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nullable
-  public abstract Watchdog getWatchdog();
+  public abstract Watchdog getStreamWatchdog();
 
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nonnull
-  public abstract Duration getWatchdogCheckInterval();
+  public abstract Duration getStreamWatchdogCheckInterval();
 
   @Nullable
   public abstract String getEndpoint();
@@ -100,8 +100,8 @@ public abstract class ClientContext {
         .setHeaders(Collections.<String, String>emptyMap())
         .setInternalHeaders(Collections.<String, String>emptyMap())
         .setClock(NanoClock.getDefaultClock())
-        .setWatchdog(null)
-        .setWatchdogCheckInterval(Duration.ZERO);
+        .setStreamWatchdog(null)
+        .setStreamWatchdogCheckInterval(Duration.ZERO);
   }
 
   public Builder toBuilder() {
@@ -159,12 +159,13 @@ public abstract class ClientContext {
       defaultCallContext = defaultCallContext.withCredentials(credentials);
     }
 
-    WatchdogProvider watchdogProvider = settings.getWatchdogProvider();
+    WatchdogProvider watchdogProvider = settings.getStreamWatchdogProvider();
     @Nullable Watchdog watchdog = null;
 
     if (watchdogProvider != null) {
       if (watchdogProvider.needsCheckInterval()) {
-        watchdogProvider = watchdogProvider.withCheckInterval(settings.getWatchdogCheckInterval());
+        watchdogProvider =
+            watchdogProvider.withCheckInterval(settings.getStreamWatchdogCheckInterval());
       }
       if (watchdogProvider.needsClock()) {
         watchdogProvider = watchdogProvider.withClock(clock);
@@ -185,8 +186,8 @@ public abstract class ClientContext {
         .setClock(clock)
         .setDefaultCallContext(defaultCallContext)
         .setEndpoint(settings.getEndpoint())
-        .setWatchdog(watchdog)
-        .setWatchdogCheckInterval(settings.getWatchdogCheckInterval())
+        .setStreamWatchdog(watchdog)
+        .setStreamWatchdogCheckInterval(settings.getStreamWatchdogCheckInterval())
         .build();
   }
 
@@ -214,10 +215,10 @@ public abstract class ClientContext {
     public abstract Builder setEndpoint(String endpoint);
 
     @BetaApi("The surface for streaming is not stable yet and may change in the future.")
-    public abstract Builder setWatchdog(Watchdog watchdog);
+    public abstract Builder setStreamWatchdog(Watchdog watchdog);
 
     @BetaApi("The surface for streaming is not stable yet and may change in the future.")
-    public abstract Builder setWatchdogCheckInterval(Duration duration);
+    public abstract Builder setStreamWatchdogCheckInterval(Duration duration);
 
     public abstract ClientContext build();
   }

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientSettings.java
@@ -36,6 +36,9 @@ import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.ExecutorProvider;
 import com.google.common.base.MoreObjects;
 import java.io.IOException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.threeten.bp.Duration;
 
 /**
  * A base settings class to configure a client class.
@@ -90,6 +93,18 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
     return stubSettings.getEndpoint();
   }
 
+  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+  @Nullable
+  public final WatchdogProvider getWatchdogProvider() {
+    return stubSettings.getWatchdogProvider();
+  }
+
+  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+  @Nonnull
+  public final Duration getWatchdogCheckInterval() {
+    return stubSettings.getWatchdogCheckInterval();
+  }
+
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("executorProvider", getExecutorProvider())
@@ -99,6 +114,8 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
         .add("internalHeaderProvider", getInternalHeaderProvider())
         .add("clock", getClock())
         .add("endpoint", getEndpoint())
+        .add("watchdogProvider", getWatchdogProvider())
+        .add("watchdogCheckInterval", getWatchdogCheckInterval())
         .toString();
   }
 
@@ -199,6 +216,18 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
       return self();
     }
 
+    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+    public B setWatchdogProvider(@Nullable WatchdogProvider watchdogProvider) {
+      stubSettings.setWatchdogProvider(watchdogProvider);
+      return self();
+    }
+
+    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+    public B setWatchdogCheckInterval(@Nullable Duration checkInterval) {
+      stubSettings.setWatchdogCheckInterval(checkInterval);
+      return self();
+    }
+
     /** Gets the ExecutorProvider that was previously set on this Builder. */
     public ExecutorProvider getExecutorProvider() {
       return stubSettings.getExecutorProvider();
@@ -235,6 +264,18 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
       return stubSettings.getEndpoint();
     }
 
+    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+    @Nullable
+    public WatchdogProvider getWatchdogProvider() {
+      return stubSettings.getWatchdogProvider();
+    }
+
+    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+    @Nullable
+    public Duration getWatchdogCheckInterval() {
+      return stubSettings.getWatchdogCheckInterval();
+    }
+
     /** Applies the given settings updater function to the given method settings builders. */
     protected static void applyToAllUnaryMethods(
         Iterable<UnaryCallSettings.Builder<?, ?>> methodSettingsBuilders,
@@ -254,6 +295,8 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
           .add("internalHeaderProvider", getInternalHeaderProvider())
           .add("clock", getClock())
           .add("endpoint", getEndpoint())
+          .add("watchdogProvider", getWatchdogProvider())
+          .add("watchdogCheckInterval", getWatchdogCheckInterval())
           .toString();
     }
   }

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientSettings.java
@@ -96,13 +96,13 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nullable
   public final WatchdogProvider getWatchdogProvider() {
-    return stubSettings.getWatchdogProvider();
+    return stubSettings.getStreamWatchdogProvider();
   }
 
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nonnull
   public final Duration getWatchdogCheckInterval() {
-    return stubSettings.getWatchdogCheckInterval();
+    return stubSettings.getStreamWatchdogCheckInterval();
   }
 
   public String toString() {
@@ -218,13 +218,13 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
 
     @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     public B setWatchdogProvider(@Nullable WatchdogProvider watchdogProvider) {
-      stubSettings.setWatchdogProvider(watchdogProvider);
+      stubSettings.setStreamWatchdogProvider(watchdogProvider);
       return self();
     }
 
     @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     public B setWatchdogCheckInterval(@Nullable Duration checkInterval) {
-      stubSettings.setWatchdogCheckInterval(checkInterval);
+      stubSettings.setStreamWatchdogCheckInterval(checkInterval);
       return self();
     }
 
@@ -267,13 +267,13 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
     @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     @Nullable
     public WatchdogProvider getWatchdogProvider() {
-      return stubSettings.getWatchdogProvider();
+      return stubSettings.getStreamWatchdogProvider();
     }
 
     @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     @Nullable
     public Duration getWatchdogCheckInterval() {
-      return stubSettings.getWatchdogCheckInterval();
+      return stubSettings.getStreamWatchdogCheckInterval();
     }
 
     /** Applies the given settings updater function to the given method settings builders. */

--- a/gax/src/main/java/com/google/api/gax/rpc/FixedWatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FixedWatchdogProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Google LLC All rights reserved.
+ * Copyright 2018 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/gax/src/main/java/com/google/api/gax/rpc/FixedWatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FixedWatchdogProvider.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.ApiClock;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.threeten.bp.Duration;
+
+public class FixedWatchdogProvider implements WatchdogProvider {
+  @Nullable private final Watchdog watchdog;
+
+  public static WatchdogProvider create(Watchdog watchdog) {
+    return new FixedWatchdogProvider(watchdog);
+  }
+
+  private FixedWatchdogProvider(Watchdog watchdog) {
+    this.watchdog = watchdog;
+  }
+
+  @Override
+  public WatchdogProvider withClock(@Nonnull ApiClock clock) {
+    throw new UnsupportedOperationException("FixedWatchdogProvider doesn't need a clock");
+  }
+
+  @Override
+  public boolean needsClock() {
+    return false;
+  }
+
+  @Override
+  public WatchdogProvider withCheckInterval(Duration checkInterval) {
+    throw new UnsupportedOperationException("FixedWatchdogProvider doesn't need a checkInterval");
+  }
+
+  @Override
+  public boolean needsCheckInterval() {
+    return false;
+  }
+
+  @Override
+  public WatchdogProvider withExecutor(ScheduledExecutorService executor) {
+    throw new UnsupportedOperationException("FixedWatchdogProvider doesn't need an executor");
+  }
+
+  @Override
+  public boolean needsExecutor() {
+    return false;
+  }
+
+  @Override
+  public Watchdog getWatchdog() {
+    return watchdog;
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/FixedWatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FixedWatchdogProvider.java
@@ -30,11 +30,13 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.ApiClock;
+import com.google.api.core.BetaApi;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public class FixedWatchdogProvider implements WatchdogProvider {
   @Nullable private final Watchdog watchdog;
 
@@ -47,12 +49,17 @@ public class FixedWatchdogProvider implements WatchdogProvider {
   }
 
   @Override
+  public boolean needsClock() {
+    return false;
+  }
+
+  @Override
   public WatchdogProvider withClock(@Nonnull ApiClock clock) {
     throw new UnsupportedOperationException("FixedWatchdogProvider doesn't need a clock");
   }
 
   @Override
-  public boolean needsClock() {
+  public boolean needsCheckInterval() {
     return false;
   }
 
@@ -62,18 +69,13 @@ public class FixedWatchdogProvider implements WatchdogProvider {
   }
 
   @Override
-  public boolean needsCheckInterval() {
+  public boolean needsExecutor() {
     return false;
   }
 
   @Override
   public WatchdogProvider withExecutor(ScheduledExecutorService executor) {
     throw new UnsupportedOperationException("FixedWatchdogProvider doesn't need an executor");
-  }
-
-  @Override
-  public boolean needsExecutor() {
-    return false;
   }
 
   @Override

--- a/gax/src/main/java/com/google/api/gax/rpc/InstantiatingWatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/InstantiatingWatchdogProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Google LLC All rights reserved.
+ * Copyright 2018 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/gax/src/main/java/com/google/api/gax/rpc/InstantiatingWatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/InstantiatingWatchdogProvider.java
@@ -58,14 +58,19 @@ public final class InstantiatingWatchdogProvider implements WatchdogProvider {
   }
 
   @Override
+  public boolean needsClock() {
+    return clock == null;
+  }
+
+  @Override
   public WatchdogProvider withClock(@Nonnull ApiClock clock) {
     return new InstantiatingWatchdogProvider(
         Preconditions.checkNotNull(clock), executor, checkInterval);
   }
 
   @Override
-  public boolean needsClock() {
-    return clock == null;
+  public boolean needsCheckInterval() {
+    return checkInterval == null;
   }
 
   @Override
@@ -75,19 +80,14 @@ public final class InstantiatingWatchdogProvider implements WatchdogProvider {
   }
 
   @Override
-  public boolean needsCheckInterval() {
-    return checkInterval == null;
+  public boolean needsExecutor() {
+    return executor == null;
   }
 
   @Override
   public WatchdogProvider withExecutor(ScheduledExecutorService executor) {
     return new InstantiatingWatchdogProvider(
         clock, Preconditions.checkNotNull(executor), checkInterval);
-  }
-
-  @Override
-  public boolean needsExecutor() {
-    return executor == null;
   }
 
   @SuppressWarnings("ConstantConditions")

--- a/gax/src/main/java/com/google/api/gax/rpc/InstantiatingWatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/InstantiatingWatchdogProvider.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.ApiClock;
+import com.google.api.core.BetaApi;
+import com.google.common.base.Preconditions;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.threeten.bp.Duration;
+
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
+public final class InstantiatingWatchdogProvider implements WatchdogProvider {
+  @Nullable private final ApiClock clock;
+  @Nullable private final ScheduledExecutorService executor;
+  @Nullable private final Duration checkInterval;
+
+  public static WatchdogProvider create() {
+    return new InstantiatingWatchdogProvider(null, null, null);
+  }
+
+  private InstantiatingWatchdogProvider(
+      @Nullable ApiClock clock,
+      @Nullable ScheduledExecutorService executor,
+      @Nullable Duration checkInterval) {
+    this.clock = clock;
+    this.executor = executor;
+    this.checkInterval = checkInterval;
+  }
+
+  @Override
+  public WatchdogProvider withClock(@Nonnull ApiClock clock) {
+    return new InstantiatingWatchdogProvider(
+        Preconditions.checkNotNull(clock), executor, checkInterval);
+  }
+
+  @Override
+  public boolean needsClock() {
+    return clock == null;
+  }
+
+  @Override
+  public WatchdogProvider withCheckInterval(@Nonnull Duration checkInterval) {
+    return new InstantiatingWatchdogProvider(
+        clock, executor, Preconditions.checkNotNull(checkInterval));
+  }
+
+  @Override
+  public boolean needsCheckInterval() {
+    return checkInterval == null;
+  }
+
+  @Override
+  public WatchdogProvider withExecutor(ScheduledExecutorService executor) {
+    return new InstantiatingWatchdogProvider(
+        clock, Preconditions.checkNotNull(executor), checkInterval);
+  }
+
+  @Override
+  public boolean needsExecutor() {
+    return executor == null;
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  @Nullable
+  @Override
+  public Watchdog getWatchdog() {
+    Preconditions.checkState(!needsClock(), "A clock is needed");
+    Preconditions.checkState(!needsCheckInterval(), "A check interval is needed");
+    Preconditions.checkState(!needsExecutor(), "An executor is needed");
+
+    // Watchdog is disabled
+    if (checkInterval.isZero()) {
+      return null;
+    }
+
+    Watchdog watchdog = new Watchdog(clock);
+    executor.scheduleAtFixedRate(
+        watchdog, checkInterval.toMillis(), checkInterval.toMillis(), TimeUnit.MILLISECONDS);
+
+    return watchdog;
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/RetryingServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/RetryingServerStreamingCallable.java
@@ -35,8 +35,6 @@ import com.google.api.gax.retrying.RetryingFuture;
 import com.google.api.gax.retrying.ScheduledRetryingExecutor;
 import com.google.api.gax.retrying.ServerStreamingAttemptException;
 import com.google.api.gax.retrying.StreamResumptionStrategy;
-import javax.annotation.Nullable;
-import org.threeten.bp.Duration;
 
 /**
  * A ServerStreamingCallable that implements resumable retries.
@@ -55,20 +53,14 @@ import org.threeten.bp.Duration;
 final class RetryingServerStreamingCallable<RequestT, ResponseT>
     extends ServerStreamingCallable<RequestT, ResponseT> {
 
-  private final @Nullable Watchdog watchdog;
-  private final Duration idleTimeout;
   private final ServerStreamingCallable<RequestT, ResponseT> innerCallable;
   private final ScheduledRetryingExecutor<Void> executor;
   private final StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategyPrototype;
 
   RetryingServerStreamingCallable(
-      @Nullable Watchdog watchdog,
-      Duration idleTimeout,
       ServerStreamingCallable<RequestT, ResponseT> innerCallable,
       ScheduledRetryingExecutor<Void> executor,
       StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategyPrototype) {
-    this.watchdog = watchdog;
-    this.idleTimeout = idleTimeout;
     this.innerCallable = innerCallable;
     this.executor = executor;
     this.resumptionStrategyPrototype = resumptionStrategyPrototype;
@@ -82,8 +74,6 @@ final class RetryingServerStreamingCallable<RequestT, ResponseT>
 
     ServerStreamingAttemptCallable<RequestT, ResponseT> attemptCallable =
         new ServerStreamingAttemptCallable<>(
-            watchdog,
-            idleTimeout,
             innerCallable,
             resumptionStrategyPrototype.createNew(),
             request,

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -64,7 +64,8 @@ import org.threeten.bp.Duration;
  *   <li>RPC timeouts are reset to the initial value as soon as a response is received.
  *   <li>RPC timeouts apply to the time interval between caller demanding more responses via {@link
  *       StreamController#request(int)} and the {@link ResponseObserver} receiving the message.
- *   <li>RPC timeouts are best effort and are checked once every {@link #timeoutCheckInterval}.
+ *   <li>RPC timeouts are best effort and are checked once every {@link
+ *       StubSettings#getWatchdogCheckInterval()}.
  *   <li>Attempt counts are reset as soon as a response is received. This means that max attempts is
  *       the maximum number of failures in a row.
  *   <li>totalTimeout still applies to the entire stream.
@@ -78,14 +79,12 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
   @Nonnull private final RetrySettings retrySettings;
   @Nonnull private final StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategy;
 
-  @Nonnull private final Duration timeoutCheckInterval;
   @Nonnull private final Duration idleTimeout;
 
   private ServerStreamingCallSettings(Builder<RequestT, ResponseT> builder) {
     this.retryableCodes = ImmutableSet.copyOf(builder.retryableCodes);
     this.retrySettings = builder.retrySettings;
     this.resumptionStrategy = builder.resumptionStrategy;
-    this.timeoutCheckInterval = builder.timeoutCheckInterval;
     this.idleTimeout = builder.idleTimeout;
   }
 
@@ -118,16 +117,7 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
 
   /**
    * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
-   * the {@link #timeoutCheckInterval} does.
-   */
-  @Nonnull
-  public Duration getTimeoutCheckInterval() {
-    return timeoutCheckInterval;
-  }
-
-  /**
-   * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
-   * the {@link #timeoutCheckInterval} does.
+   * the {@link #idleTimeout} does.
    */
   @Nonnull
   public Duration getIdleTimeout() {
@@ -148,8 +138,7 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
     @Nonnull private RetrySettings retrySettings;
     @Nonnull private StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategy;
 
-    private Duration timeoutCheckInterval;
-    private Duration idleTimeout;
+    @Nonnull private Duration idleTimeout;
 
     /** Initialize the builder with default settings */
     private Builder() {
@@ -157,7 +146,6 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
       this.retrySettings = RetrySettings.newBuilder().build();
       this.resumptionStrategy = new SimpleStreamResumptionStrategy<>();
 
-      this.timeoutCheckInterval = Duration.ZERO;
       this.idleTimeout = Duration.ZERO;
     }
 
@@ -167,7 +155,6 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
       this.retrySettings = settings.retrySettings;
       this.resumptionStrategy = settings.resumptionStrategy;
 
-      this.timeoutCheckInterval = settings.timeoutCheckInterval;
       this.idleTimeout = settings.idleTimeout;
     }
 
@@ -242,23 +229,6 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
     @Nonnull
     public StreamResumptionStrategy<RequestT, ResponseT> getResumptionStrategy() {
       return resumptionStrategy;
-    }
-
-    @Nonnull
-    public Duration getTimeoutCheckInterval() {
-      return timeoutCheckInterval;
-    }
-
-    /**
-     * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
-     * the {@link #timeoutCheckInterval} does. {@link Duration#ZERO} disables both idle checks and
-     * rpc timeouts.
-     */
-    public Builder<RequestT, ResponseT> setTimeoutCheckInterval(
-        @Nonnull Duration timeoutCheckInterval) {
-      Preconditions.checkNotNull(timeoutCheckInterval);
-      this.timeoutCheckInterval = Preconditions.checkNotNull(timeoutCheckInterval);
-      return this;
     }
 
     @Nonnull

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -65,7 +65,7 @@ import org.threeten.bp.Duration;
  *   <li>RPC timeouts apply to the time interval between caller demanding more responses via {@link
  *       StreamController#request(int)} and the {@link ResponseObserver} receiving the message.
  *   <li>RPC timeouts are best effort and are checked once every {@link
- *       StubSettings#getWatchdogCheckInterval()}.
+ *       StubSettings#getStreamWatchdogCheckInterval()}.
  *   <li>Attempt counts are reset as soon as a response is received. This means that max attempts is
  *       the maximum number of failures in a row.
  *   <li>totalTimeout still applies to the entire stream.

--- a/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -42,6 +42,9 @@ import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.threeten.bp.Duration;
 
 /**
  * A base settings class to configure a client stub class.
@@ -62,6 +65,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
   private final TransportChannelProvider transportChannelProvider;
   private final ApiClock clock;
   private final String endpoint;
+  @Nullable private final WatchdogProvider watchdogProvider;
+  @Nonnull private final Duration watchdogCheckInterval;
 
   /** Constructs an instance of StubSettings. */
   protected StubSettings(Builder builder) {
@@ -72,6 +77,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     this.internalHeaderProvider = builder.internalHeaderProvider;
     this.clock = builder.clock;
     this.endpoint = builder.endpoint;
+    this.watchdogProvider = builder.watchdogProvider;
+    this.watchdogCheckInterval = builder.watchdogCheckInterval;
   }
 
   public final ExecutorProvider getExecutorProvider() {
@@ -104,6 +111,18 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     return endpoint;
   }
 
+  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+  @Nullable
+  public final WatchdogProvider getWatchdogProvider() {
+    return watchdogProvider;
+  }
+
+  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+  @Nonnull
+  public final Duration getWatchdogCheckInterval() {
+    return watchdogCheckInterval;
+  }
+
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("executorProvider", executorProvider)
@@ -113,6 +132,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         .add("internalHeaderProvider", internalHeaderProvider)
         .add("clock", clock)
         .add("endpoint", endpoint)
+        .add("watchdogProvider", watchdogProvider)
+        .add("watchdogCheckInterval", watchdogCheckInterval)
         .toString();
   }
 
@@ -128,6 +149,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     private TransportChannelProvider transportChannelProvider;
     private ApiClock clock;
     private String endpoint;
+    @Nullable private WatchdogProvider watchdogProvider;
+    @Nonnull private Duration watchdogCheckInterval;
 
     /** Create a builder from a StubSettings object. */
     protected Builder(StubSettings settings) {
@@ -138,6 +161,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       this.internalHeaderProvider = settings.internalHeaderProvider;
       this.clock = settings.clock;
       this.endpoint = settings.endpoint;
+      this.watchdogProvider = settings.watchdogProvider;
+      this.watchdogCheckInterval = settings.watchdogCheckInterval;
     }
 
     protected Builder(ClientContext clientContext) {
@@ -149,6 +174,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         this.internalHeaderProvider = new NoHeaderProvider();
         this.clock = NanoClock.getDefaultClock();
         this.endpoint = null;
+        this.watchdogProvider = InstantiatingWatchdogProvider.create();
+        this.watchdogCheckInterval = Duration.ofSeconds(10);
       } else {
         this.executorProvider = FixedExecutorProvider.create(clientContext.getExecutor());
         this.transportChannelProvider =
@@ -159,6 +186,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
             FixedHeaderProvider.create(clientContext.getInternalHeaders());
         this.clock = clientContext.getClock();
         this.endpoint = clientContext.getEndpoint();
+        this.watchdogProvider = FixedWatchdogProvider.create(clientContext.getWatchdog());
+        this.watchdogCheckInterval = clientContext.getWatchdogCheckInterval();
       }
     }
 
@@ -224,6 +253,17 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     }
 
     /**
+     * Sets the {@link WatchdogProvider} to use for streaming RPC.
+     *
+     * <p>This will default to a {@link InstantiatingWatchdogProvider} if it is not set.
+     */
+    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+    public B setWatchdogProvider(@Nullable WatchdogProvider watchdogProvider) {
+      this.watchdogProvider = watchdogProvider;
+      return self();
+    }
+
+    /**
      * Sets the clock to use for retry logic.
      *
      * <p>This will default to a system clock if it is not set.
@@ -235,6 +275,17 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
 
     public B setEndpoint(String endpoint) {
       this.endpoint = endpoint;
+      return self();
+    }
+
+    /**
+     * Sets how often the {@link Watchdog} will check ongoing streaming RPCs. Defaults to 10 secs.
+     * Use {@link Duration#ZERO} to disable.
+     */
+    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+    public B setWatchdogCheckInterval(@Nonnull Duration checkInterval) {
+      Preconditions.checkNotNull(checkInterval);
+      this.watchdogCheckInterval = checkInterval;
       return self();
     }
 
@@ -265,6 +316,13 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       return internalHeaderProvider;
     }
 
+    /** Gets the {@link WatchdogProvider }that was previously set on this Builder. */
+    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+    @Nullable
+    public WatchdogProvider getWatchdogProvider() {
+      return watchdogProvider;
+    }
+
     /** Gets the ApiClock that was previously set on this Builder. */
     public ApiClock getClock() {
       return clock;
@@ -272,6 +330,12 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
 
     public String getEndpoint() {
       return endpoint;
+    }
+
+    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+    @Nonnull
+    public Duration getWatchdogCheckInterval() {
+      return watchdogCheckInterval;
     }
 
     /** Applies the given settings updater function to the given method settings builders. */
@@ -295,6 +359,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
           .add("internalHeaderProvider", internalHeaderProvider)
           .add("clock", clock)
           .add("endpoint", endpoint)
+          .add("watchdogProvider", watchdogProvider)
+          .add("watchdogCheckInterval", watchdogCheckInterval)
           .toString();
     }
   }

--- a/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -65,8 +65,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
   private final TransportChannelProvider transportChannelProvider;
   private final ApiClock clock;
   private final String endpoint;
-  @Nullable private final WatchdogProvider watchdogProvider;
-  @Nonnull private final Duration watchdogCheckInterval;
+  @Nullable private final WatchdogProvider streamWatchdogProvider;
+  @Nonnull private final Duration streamWatchdogCheckInterval;
 
   /** Constructs an instance of StubSettings. */
   protected StubSettings(Builder builder) {
@@ -77,8 +77,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     this.internalHeaderProvider = builder.internalHeaderProvider;
     this.clock = builder.clock;
     this.endpoint = builder.endpoint;
-    this.watchdogProvider = builder.watchdogProvider;
-    this.watchdogCheckInterval = builder.watchdogCheckInterval;
+    this.streamWatchdogProvider = builder.streamWatchdogProvider;
+    this.streamWatchdogCheckInterval = builder.streamWatchdogCheckInterval;
   }
 
   public final ExecutorProvider getExecutorProvider() {
@@ -113,14 +113,14 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
 
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nullable
-  public final WatchdogProvider getWatchdogProvider() {
-    return watchdogProvider;
+  public final WatchdogProvider getStreamWatchdogProvider() {
+    return streamWatchdogProvider;
   }
 
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nonnull
-  public final Duration getWatchdogCheckInterval() {
-    return watchdogCheckInterval;
+  public final Duration getStreamWatchdogCheckInterval() {
+    return streamWatchdogCheckInterval;
   }
 
   public String toString() {
@@ -132,8 +132,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         .add("internalHeaderProvider", internalHeaderProvider)
         .add("clock", clock)
         .add("endpoint", endpoint)
-        .add("watchdogProvider", watchdogProvider)
-        .add("watchdogCheckInterval", watchdogCheckInterval)
+        .add("streamWatchdogProvider", streamWatchdogProvider)
+        .add("streamWatchdogCheckInterval", streamWatchdogCheckInterval)
         .toString();
   }
 
@@ -149,8 +149,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     private TransportChannelProvider transportChannelProvider;
     private ApiClock clock;
     private String endpoint;
-    @Nullable private WatchdogProvider watchdogProvider;
-    @Nonnull private Duration watchdogCheckInterval;
+    @Nullable private WatchdogProvider streamWatchdogProvider;
+    @Nonnull private Duration streamWatchdogCheckInterval;
 
     /** Create a builder from a StubSettings object. */
     protected Builder(StubSettings settings) {
@@ -161,8 +161,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       this.internalHeaderProvider = settings.internalHeaderProvider;
       this.clock = settings.clock;
       this.endpoint = settings.endpoint;
-      this.watchdogProvider = settings.watchdogProvider;
-      this.watchdogCheckInterval = settings.watchdogCheckInterval;
+      this.streamWatchdogProvider = settings.streamWatchdogProvider;
+      this.streamWatchdogCheckInterval = settings.streamWatchdogCheckInterval;
     }
 
     protected Builder(ClientContext clientContext) {
@@ -174,8 +174,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         this.internalHeaderProvider = new NoHeaderProvider();
         this.clock = NanoClock.getDefaultClock();
         this.endpoint = null;
-        this.watchdogProvider = InstantiatingWatchdogProvider.create();
-        this.watchdogCheckInterval = Duration.ofSeconds(10);
+        this.streamWatchdogProvider = InstantiatingWatchdogProvider.create();
+        this.streamWatchdogCheckInterval = Duration.ofSeconds(10);
       } else {
         this.executorProvider = FixedExecutorProvider.create(clientContext.getExecutor());
         this.transportChannelProvider =
@@ -186,8 +186,9 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
             FixedHeaderProvider.create(clientContext.getInternalHeaders());
         this.clock = clientContext.getClock();
         this.endpoint = clientContext.getEndpoint();
-        this.watchdogProvider = FixedWatchdogProvider.create(clientContext.getWatchdog());
-        this.watchdogCheckInterval = clientContext.getWatchdogCheckInterval();
+        this.streamWatchdogProvider =
+            FixedWatchdogProvider.create(clientContext.getStreamWatchdog());
+        this.streamWatchdogCheckInterval = clientContext.getStreamWatchdogCheckInterval();
       }
     }
 
@@ -258,8 +259,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
      * <p>This will default to a {@link InstantiatingWatchdogProvider} if it is not set.
      */
     @BetaApi("The surface for streaming is not stable yet and may change in the future.")
-    public B setWatchdogProvider(@Nullable WatchdogProvider watchdogProvider) {
-      this.watchdogProvider = watchdogProvider;
+    public B setStreamWatchdogProvider(@Nullable WatchdogProvider streamWatchdogProvider) {
+      this.streamWatchdogProvider = streamWatchdogProvider;
       return self();
     }
 
@@ -283,9 +284,9 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
      * Use {@link Duration#ZERO} to disable.
      */
     @BetaApi("The surface for streaming is not stable yet and may change in the future.")
-    public B setWatchdogCheckInterval(@Nonnull Duration checkInterval) {
+    public B setStreamWatchdogCheckInterval(@Nonnull Duration checkInterval) {
       Preconditions.checkNotNull(checkInterval);
-      this.watchdogCheckInterval = checkInterval;
+      this.streamWatchdogCheckInterval = checkInterval;
       return self();
     }
 
@@ -319,8 +320,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     /** Gets the {@link WatchdogProvider }that was previously set on this Builder. */
     @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     @Nullable
-    public WatchdogProvider getWatchdogProvider() {
-      return watchdogProvider;
+    public WatchdogProvider getStreamWatchdogProvider() {
+      return streamWatchdogProvider;
     }
 
     /** Gets the ApiClock that was previously set on this Builder. */
@@ -334,8 +335,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
 
     @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     @Nonnull
-    public Duration getWatchdogCheckInterval() {
-      return watchdogCheckInterval;
+    public Duration getStreamWatchdogCheckInterval() {
+      return streamWatchdogCheckInterval;
     }
 
     /** Applies the given settings updater function to the given method settings builders. */
@@ -359,8 +360,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
           .add("internalHeaderProvider", internalHeaderProvider)
           .add("clock", clock)
           .add("endpoint", endpoint)
-          .add("watchdogProvider", watchdogProvider)
-          .add("watchdogCheckInterval", watchdogCheckInterval)
+          .add("streamWatchdogProvider", streamWatchdogProvider)
+          .add("streamWatchdogCheckInterval", streamWatchdogCheckInterval)
           .toString();
     }
   }

--- a/gax/src/main/java/com/google/api/gax/rpc/WatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/WatchdogProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Google LLC All rights reserved.
+ * Copyright 2018 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/gax/src/main/java/com/google/api/gax/rpc/WatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/WatchdogProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.ApiClock;
+import com.google.api.core.BetaApi;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.annotation.Nonnull;
+import org.threeten.bp.Duration;
+
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
+public interface WatchdogProvider {
+  WatchdogProvider withClock(@Nonnull ApiClock clock);
+
+  boolean needsClock();
+
+  WatchdogProvider withCheckInterval(Duration checkInterval);
+
+  boolean needsCheckInterval();
+
+  WatchdogProvider withExecutor(ScheduledExecutorService executor);
+
+  boolean needsExecutor();
+
+  Watchdog getWatchdog();
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/WatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/WatchdogProvider.java
@@ -37,17 +37,17 @@ import org.threeten.bp.Duration;
 
 @BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public interface WatchdogProvider {
-  WatchdogProvider withClock(@Nonnull ApiClock clock);
-
   boolean needsClock();
 
-  WatchdogProvider withCheckInterval(Duration checkInterval);
+  WatchdogProvider withClock(@Nonnull ApiClock clock);
 
   boolean needsCheckInterval();
 
-  WatchdogProvider withExecutor(ScheduledExecutorService executor);
+  WatchdogProvider withCheckInterval(Duration checkInterval);
 
   boolean needsExecutor();
+
+  WatchdogProvider withExecutor(ScheduledExecutorService executor);
 
   Watchdog getWatchdog();
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/WatchdogServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/WatchdogServerStreamingCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Google LLC All rights reserved.
+ * Copyright 2018 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/gax/src/main/java/com/google/api/gax/rpc/WatchdogServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/WatchdogServerStreamingCallable.java
@@ -32,7 +32,7 @@ package com.google.api.gax.rpc;
 import com.google.common.base.Preconditions;
 
 /**
- * Integration {@link ServerStreamingCallable} for the {@link Watchdog}.
+ * A callable that uses the {@link Watchdog} to monitor streams.
  *
  * <p>It extracts the {@code StreamWaitTimeout} and the {@code StreamIdleTimeout} from the {@link
  * ApiCallContext} and applies then to the stream using the {@link Watchdog}.

--- a/gax/src/main/java/com/google/api/gax/rpc/WatchdogServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/WatchdogServerStreamingCallable.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Integration {@link ServerStreamingCallable} for the {@link Watchdog}.
+ *
+ * <p>It extracts the {@code StreamWaitTimeout} and the {@code StreamIdleTimeout} from the {@link
+ * ApiCallContext} and applies then to the stream using the {@link Watchdog}.
+ *
+ * <p>Package-private for internal use.
+ *
+ * @see Watchdog for more details
+ */
+class WatchdogServerStreamingCallable<RequestT, ResponseT>
+    extends ServerStreamingCallable<RequestT, ResponseT> {
+  private final ServerStreamingCallable<RequestT, ResponseT> inner;
+  private final Watchdog watchdog;
+
+  WatchdogServerStreamingCallable(
+      ServerStreamingCallable<RequestT, ResponseT> inner, Watchdog watchdog) {
+    Preconditions.checkNotNull(inner);
+    Preconditions.checkNotNull(watchdog);
+
+    this.inner = inner;
+    this.watchdog = watchdog;
+  }
+
+  @Override
+  public void call(
+      RequestT request, ResponseObserver<ResponseT> responseObserver, ApiCallContext context) {
+    responseObserver =
+        watchdog.watch(
+            responseObserver, context.getStreamWaitTimeout(), context.getStreamIdleTimeout());
+    inner.call(request, responseObserver, context);
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/WatchdogServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/WatchdogServerStreamingCallable.java
@@ -32,7 +32,7 @@ package com.google.api.gax.rpc;
 import com.google.common.base.Preconditions;
 
 /**
- * A callable that uses the {@link Watchdog} to monitor streams.
+ * A callable that uses a {@link Watchdog} to monitor streams.
  *
  * <p>It extracts the {@code StreamWaitTimeout} and the {@code StreamIdleTimeout} from the {@link
  * ApiCallContext} and applies then to the stream using the {@link Watchdog}.

--- a/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
@@ -47,6 +47,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
+import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class ClientContextTest {
@@ -197,10 +198,14 @@ public class ClientContextTest {
             needHeaders ? null : headers);
     Credentials credentials = Mockito.mock(Credentials.class);
     ApiClock clock = Mockito.mock(ApiClock.class);
+    Watchdog watchdog = Mockito.mock(Watchdog.class);
+    Duration watchdogCheckInterval = Duration.ofSeconds(11);
 
     builder.setExecutorProvider(executorProvider);
     builder.setTransportChannelProvider(transportProvider);
     builder.setCredentialsProvider(FixedCredentialsProvider.create(credentials));
+    builder.setWatchdogProvider(FixedWatchdogProvider.create(watchdog));
+    builder.setWatchdogCheckInterval(watchdogCheckInterval);
     builder.setClock(clock);
 
     HeaderProvider headerProvider = Mockito.mock(HeaderProvider.class);
@@ -226,6 +231,8 @@ public class ClientContextTest {
     Truth.assertThat(actualChannel.getHeaders()).isEqualTo(headers);
     Truth.assertThat(clientContext.getCredentials()).isSameAs(credentials);
     Truth.assertThat(clientContext.getClock()).isSameAs(clock);
+    Truth.assertThat(clientContext.getWatchdog()).isSameAs(watchdog);
+    Truth.assertThat(clientContext.getWatchdogCheckInterval()).isEqualTo(watchdogCheckInterval);
 
     Truth.assertThat(clientContext.getHeaders()).isEqualTo(ImmutableMap.of("k1", "v1"));
     Truth.assertThat(clientContext.getInternalHeaders()).isEqualTo(ImmutableMap.of("k2", "v2"));

--- a/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
@@ -231,8 +231,9 @@ public class ClientContextTest {
     Truth.assertThat(actualChannel.getHeaders()).isEqualTo(headers);
     Truth.assertThat(clientContext.getCredentials()).isSameAs(credentials);
     Truth.assertThat(clientContext.getClock()).isSameAs(clock);
-    Truth.assertThat(clientContext.getWatchdog()).isSameAs(watchdog);
-    Truth.assertThat(clientContext.getWatchdogCheckInterval()).isEqualTo(watchdogCheckInterval);
+    Truth.assertThat(clientContext.getStreamWatchdog()).isSameAs(watchdog);
+    Truth.assertThat(clientContext.getStreamWatchdogCheckInterval())
+        .isEqualTo(watchdogCheckInterval);
 
     Truth.assertThat(clientContext.getHeaders()).isEqualTo(ImmutableMap.of("k1", "v1"));
     Truth.assertThat(clientContext.getInternalHeaders()).isEqualTo(ImmutableMap.of("k2", "v2"));

--- a/gax/src/test/java/com/google/api/gax/rpc/ClientSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ClientSettingsTest.java
@@ -51,6 +51,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
+import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class ClientSettingsTest {
@@ -65,6 +66,9 @@ public class ClientSettingsTest {
     Truth.assertThat(builder.getClock()).isInstanceOf(NanoClock.class);
     Truth.assertThat(builder.getHeaderProvider()).isInstanceOf(NoHeaderProvider.class);
     Truth.assertThat(builder.getInternalHeaderProvider()).isInstanceOf(NoHeaderProvider.class);
+    Truth.assertThat(builder.getWatchdogProvider())
+        .isInstanceOf(InstantiatingWatchdogProvider.class);
+    Truth.assertThat(builder.getWatchdogCheckInterval()).isGreaterThan(Duration.ZERO);
 
     FakeClientSettings settings = builder.build();
     Truth.assertThat(settings.getExecutorProvider()).isSameAs(builder.getExecutorProvider());
@@ -75,6 +79,9 @@ public class ClientSettingsTest {
     Truth.assertThat(settings.getHeaderProvider()).isSameAs(builder.getHeaderProvider());
     Truth.assertThat(settings.getInternalHeaderProvider())
         .isSameAs(builder.getInternalHeaderProvider());
+    Truth.assertThat(settings.getWatchdogProvider())
+        .isInstanceOf(InstantiatingWatchdogProvider.class);
+    Truth.assertThat(settings.getWatchdogCheckInterval()).isGreaterThan(Duration.ZERO);
 
     String settingsString = settings.toString();
     Truth.assertThat(settingsString).contains("executorProvider");
@@ -82,6 +89,8 @@ public class ClientSettingsTest {
     Truth.assertThat(settingsString).contains("credentialsProvider");
     Truth.assertThat(settingsString).contains("clock");
     Truth.assertThat(settingsString).contains("headerProvider");
+    Truth.assertThat(settingsString).contains("watchdogProvider");
+    Truth.assertThat(settingsString).contains("watchdogCheckInterval");
   }
 
   @Test
@@ -94,6 +103,8 @@ public class ClientSettingsTest {
     ApiClock clock = Mockito.mock(ApiClock.class);
     HeaderProvider headerProvider = Mockito.mock(HeaderProvider.class);
     HeaderProvider internalHeaderProvider = Mockito.mock(HeaderProvider.class);
+    WatchdogProvider watchdogProvider = Mockito.mock(WatchdogProvider.class);
+    Duration watchdogCheckInterval = Duration.ofSeconds(13);
 
     builder.setExecutorProvider(executorProvider);
     builder.setTransportChannelProvider(transportProvider);
@@ -101,6 +112,8 @@ public class ClientSettingsTest {
     builder.setHeaderProvider(headerProvider);
     builder.setInternalHeaderProvider(internalHeaderProvider);
     builder.setClock(clock);
+    builder.setWatchdogProvider(watchdogProvider);
+    builder.setWatchdogCheckInterval(watchdogCheckInterval);
 
     Truth.assertThat(builder.getExecutorProvider()).isSameAs(executorProvider);
     Truth.assertThat(builder.getTransportChannelProvider()).isSameAs(transportProvider);
@@ -108,6 +121,8 @@ public class ClientSettingsTest {
     Truth.assertThat(builder.getClock()).isSameAs(clock);
     Truth.assertThat(builder.getHeaderProvider()).isSameAs(headerProvider);
     Truth.assertThat(builder.getInternalHeaderProvider()).isSameAs(internalHeaderProvider);
+    Truth.assertThat(builder.getWatchdogProvider()).isSameAs(watchdogProvider);
+    Truth.assertThat(builder.getWatchdogCheckInterval()).isSameAs(watchdogCheckInterval);
 
     String builderString = builder.toString();
     Truth.assertThat(builderString).contains("executorProvider");
@@ -116,6 +131,8 @@ public class ClientSettingsTest {
     Truth.assertThat(builderString).contains("clock");
     Truth.assertThat(builderString).contains("headerProvider");
     Truth.assertThat(builderString).contains("internalHeaderProvider");
+    Truth.assertThat(builderString).contains("watchdogProvider");
+    Truth.assertThat(builderString).contains("watchdogCheckInterval");
   }
 
   @Test
@@ -123,6 +140,8 @@ public class ClientSettingsTest {
     ApiClock clock = Mockito.mock(ApiClock.class);
     ApiCallContext callContext = FakeCallContext.createDefault();
     Map<String, String> headers = Collections.singletonMap("spiffykey", "spiffyvalue");
+    Watchdog watchdog = Mockito.mock(Watchdog.class);
+    Duration watchdogCheckInterval = Duration.ofSeconds(12);
 
     ClientContext clientContext =
         ClientContext.newBuilder()
@@ -132,6 +151,8 @@ public class ClientSettingsTest {
             .setClock(clock)
             .setDefaultCallContext(callContext)
             .setHeaders(headers)
+            .setWatchdog(watchdog)
+            .setWatchdogCheckInterval(watchdogCheckInterval)
             .build();
 
     FakeClientSettings.Builder builder = new FakeClientSettings.Builder(clientContext);
@@ -143,6 +164,9 @@ public class ClientSettingsTest {
     Truth.assertThat(builder.getClock()).isSameAs(clock);
     Truth.assertThat(builder.getHeaderProvider().getHeaders())
         .containsEntry("spiffykey", "spiffyvalue");
+    Truth.assertThat(builder.getWatchdogProvider()).isInstanceOf(FixedWatchdogProvider.class);
+    Truth.assertThat(builder.getWatchdogProvider().getWatchdog()).isSameAs(watchdog);
+    Truth.assertThat(builder.getWatchdogCheckInterval()).isEqualTo(watchdogCheckInterval);
   }
 
   @Test
@@ -155,6 +179,8 @@ public class ClientSettingsTest {
     ApiClock clock = Mockito.mock(ApiClock.class);
     HeaderProvider headerProvider = Mockito.mock(HeaderProvider.class);
     HeaderProvider internalHeaderProvider = Mockito.mock(HeaderProvider.class);
+    WatchdogProvider watchdogProvider = Mockito.mock(WatchdogProvider.class);
+    Duration watchdogCheckInterval = Duration.ofSeconds(14);
 
     builder.setExecutorProvider(executorProvider);
     builder.setTransportChannelProvider(transportProvider);
@@ -162,6 +188,8 @@ public class ClientSettingsTest {
     builder.setClock(clock);
     builder.setHeaderProvider(headerProvider);
     builder.setInternalHeaderProvider(internalHeaderProvider);
+    builder.setWatchdogProvider(watchdogProvider);
+    builder.setWatchdogCheckInterval(watchdogCheckInterval);
 
     FakeClientSettings settings = builder.build();
     FakeClientSettings.Builder newBuilder = new FakeClientSettings.Builder(settings);
@@ -172,6 +200,8 @@ public class ClientSettingsTest {
     Truth.assertThat(newBuilder.getClock()).isSameAs(clock);
     Truth.assertThat(newBuilder.getHeaderProvider()).isSameAs(headerProvider);
     Truth.assertThat(newBuilder.getInternalHeaderProvider()).isSameAs(internalHeaderProvider);
+    Truth.assertThat(newBuilder.getWatchdogProvider()).isSameAs(watchdogProvider);
+    Truth.assertThat(newBuilder.getWatchdogCheckInterval()).isEqualTo(watchdogCheckInterval);
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/rpc/ClientSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ClientSettingsTest.java
@@ -151,8 +151,8 @@ public class ClientSettingsTest {
             .setClock(clock)
             .setDefaultCallContext(callContext)
             .setHeaders(headers)
-            .setWatchdog(watchdog)
-            .setWatchdogCheckInterval(watchdogCheckInterval)
+            .setStreamWatchdog(watchdog)
+            .setStreamWatchdogCheckInterval(watchdogCheckInterval)
             .build();
 
     FakeClientSettings.Builder builder = new FakeClientSettings.Builder(clientContext);

--- a/gax/src/test/java/com/google/api/gax/rpc/FixedWatchdogProviderTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/FixedWatchdogProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Google LLC All rights reserved.
+ * Copyright 2018 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/gax/src/test/java/com/google/api/gax/rpc/FixedWatchdogProviderTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/FixedWatchdogProviderTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.core.ApiClock;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+import org.threeten.bp.Duration;
+
+@RunWith(JUnit4.class)
+public class FixedWatchdogProviderTest {
+  @Test
+  public void testNull() {
+    WatchdogProvider provider = FixedWatchdogProvider.create(null);
+    assertThat(provider.getWatchdog()).isNull();
+  }
+
+  @Test
+  public void testSameInstance() {
+    Watchdog watchdog = Mockito.mock(Watchdog.class);
+    WatchdogProvider provider = FixedWatchdogProvider.create(watchdog);
+    assertThat(provider.getWatchdog()).isSameAs(watchdog);
+  }
+
+  @Test
+  public void testNoModifications() {
+    WatchdogProvider provider = FixedWatchdogProvider.create(Mockito.mock(Watchdog.class));
+
+    assertThat(provider.needsCheckInterval()).isFalse();
+    assertThat(provider.needsClock()).isFalse();
+    assertThat(provider.needsExecutor()).isFalse();
+
+    Throwable actualError = null;
+    try {
+      provider.withCheckInterval(Duration.ofSeconds(10));
+    } catch (Throwable t) {
+      actualError = t;
+    }
+    assertThat(actualError).isInstanceOf(UnsupportedOperationException.class);
+
+    actualError = null;
+    try {
+      provider.withClock(Mockito.mock(ApiClock.class));
+    } catch (Throwable t) {
+      actualError = t;
+    }
+    assertThat(actualError).isInstanceOf(UnsupportedOperationException.class);
+
+    actualError = null;
+    try {
+      provider.withExecutor(Mockito.mock(ScheduledExecutorService.class));
+    } catch (Throwable t) {
+      actualError = t;
+    }
+    assertThat(actualError).isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/gax/src/test/java/com/google/api/gax/rpc/InstantiatingWatchdogProviderTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/InstantiatingWatchdogProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Google LLC All rights reserved.
+ * Copyright 2018 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/gax/src/test/java/com/google/api/gax/rpc/InstantiatingWatchdogProviderTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/InstantiatingWatchdogProviderTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.core.ApiClock;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.threeten.bp.Duration;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InstantiatingWatchdogProviderTest {
+  @Mock private ScheduledExecutorService executor;
+  @Mock private ApiClock clock;
+  private Duration checkInterval = Duration.ofSeconds(11);
+
+  @Test
+  public void happyPath() {
+    WatchdogProvider provider = InstantiatingWatchdogProvider.create();
+
+    assertThat(provider.needsExecutor()).isTrue();
+    provider = provider.withExecutor(executor);
+
+    assertThat(provider.needsClock()).isTrue();
+    provider = provider.withClock(clock);
+
+    assertThat(provider.needsCheckInterval()).isTrue();
+    provider = provider.withCheckInterval(checkInterval);
+
+    Watchdog watchdog = provider.getWatchdog();
+    Mockito.verify(executor)
+        .scheduleAtFixedRate(
+            watchdog, checkInterval.toMillis(), checkInterval.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  public void requiresExecutor() {
+    WatchdogProvider provider =
+        InstantiatingWatchdogProvider.create().withCheckInterval(checkInterval).withClock(clock);
+
+    Throwable actualError = null;
+    try {
+      provider.getWatchdog();
+    } catch (Throwable t) {
+      actualError = t;
+    }
+    assertThat(actualError).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void requiresCheckInterval() {
+    WatchdogProvider provider =
+        InstantiatingWatchdogProvider.create().withExecutor(executor).withClock(clock);
+
+    Throwable actualError = null;
+    try {
+      provider.getWatchdog();
+    } catch (Throwable t) {
+      actualError = t;
+    }
+    assertThat(actualError).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void requiresClock() {
+    WatchdogProvider provider =
+        InstantiatingWatchdogProvider.create()
+            .withExecutor(executor)
+            .withCheckInterval(checkInterval);
+
+    Throwable actualError = null;
+    try {
+      provider.getWatchdog();
+    } catch (Throwable t) {
+      actualError = t;
+    }
+    assertThat(actualError).isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingAttemptCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingAttemptCallableTest.java
@@ -70,8 +70,6 @@ public class ServerStreamingAttemptCallableTest {
   private ServerStreamingAttemptCallable<String, String> createCallable() {
     ServerStreamingAttemptCallable<String, String> callable =
         new ServerStreamingAttemptCallable<>(
-            null,
-            Duration.ofMinutes(1),
             innerCallable,
             resumptionStrategy,
             "request",

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallSettingsTest.java
@@ -77,20 +77,6 @@ public class ServerStreamingCallSettingsTest {
   }
 
   @Test
-  public void checkIntervalIsNotLost() {
-    Duration checkInterval = Duration.ofSeconds(5);
-
-    ServerStreamingCallSettings.Builder<Object, Object> builder =
-        ServerStreamingCallSettings.newBuilder();
-    builder.setTimeoutCheckInterval(checkInterval);
-
-    Truth.assertThat(builder.getTimeoutCheckInterval()).isEqualTo(checkInterval);
-    Truth.assertThat(builder.build().getTimeoutCheckInterval()).isEqualTo(checkInterval);
-    Truth.assertThat(builder.build().toBuilder().getTimeoutCheckInterval())
-        .isEqualTo(checkInterval);
-  }
-
-  @Test
   public void idleTimeoutIsNotLost() {
     Duration idleTimeout = Duration.ofSeconds(5);
 

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
@@ -35,6 +35,7 @@ import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.auth.Credentials;
 import com.google.common.base.Preconditions;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
@@ -173,13 +174,15 @@ public class FakeCallContext implements ApiCallContext {
   }
 
   @Override
-  public ApiCallContext withStreamWaitTimeout(@Nullable Duration streamWaitTimeout) {
+  public ApiCallContext withStreamWaitTimeout(@Nonnull Duration streamWaitTimeout) {
+    Preconditions.checkNotNull(streamWaitTimeout);
     return new FakeCallContext(
         this.credentials, this.channel, this.timeout, streamWaitTimeout, this.streamIdleTimeout);
   }
 
   @Override
-  public ApiCallContext withStreamIdleTimeout(@Nullable Duration streamIdleTimeout) {
+  public ApiCallContext withStreamIdleTimeout(@Nonnull Duration streamIdleTimeout) {
+    Preconditions.checkNotNull(streamIdleTimeout);
     return new FakeCallContext(
         this.credentials, this.channel, this.timeout, this.streamWaitTimeout, streamIdleTimeout);
   }

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
@@ -35,6 +35,7 @@ import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.auth.Credentials;
 import com.google.common.base.Preconditions;
+import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
 @InternalApi("for testing")
@@ -42,15 +43,24 @@ public class FakeCallContext implements ApiCallContext {
   private final Credentials credentials;
   private final FakeChannel channel;
   private final Duration timeout;
+  private final Duration streamWaitTimeout;
+  private final Duration streamIdleTimeout;
 
-  private FakeCallContext(Credentials credentials, FakeChannel channel, Duration timeout) {
+  private FakeCallContext(
+      Credentials credentials,
+      FakeChannel channel,
+      Duration timeout,
+      Duration streamWaitTimeout,
+      Duration streamIdleTimeout) {
     this.credentials = credentials;
     this.channel = channel;
     this.timeout = timeout;
+    this.streamWaitTimeout = streamWaitTimeout;
+    this.streamIdleTimeout = streamIdleTimeout;
   }
 
   public static FakeCallContext createDefault() {
-    return new FakeCallContext(null, null, null);
+    return new FakeCallContext(null, null, null, null, null);
   }
 
   @Override
@@ -96,7 +106,18 @@ public class FakeCallContext implements ApiCallContext {
       newTimeout = timeout;
     }
 
-    return new FakeCallContext(newCallCredentials, newChannel, newTimeout);
+    Duration newStreamWaitTimeout = fakeCallContext.streamWaitTimeout;
+    if (newStreamWaitTimeout == null) {
+      newStreamWaitTimeout = streamWaitTimeout;
+    }
+
+    Duration newStreamIdleTimeout = fakeCallContext.streamIdleTimeout;
+    if (newStreamIdleTimeout == null) {
+      newStreamIdleTimeout = streamIdleTimeout;
+    }
+
+    return new FakeCallContext(
+        newCallCredentials, newChannel, newTimeout, newStreamWaitTimeout, newStreamIdleTimeout);
   }
 
   public Credentials getCredentials() {
@@ -111,9 +132,22 @@ public class FakeCallContext implements ApiCallContext {
     return timeout;
   }
 
+  @Nullable
+  @Override
+  public Duration getStreamWaitTimeout() {
+    return streamWaitTimeout;
+  }
+
+  @Nullable
+  @Override
+  public Duration getStreamIdleTimeout() {
+    return streamIdleTimeout;
+  }
+
   @Override
   public FakeCallContext withCredentials(Credentials credentials) {
-    return new FakeCallContext(credentials, this.channel, this.timeout);
+    return new FakeCallContext(
+        credentials, this.channel, this.timeout, this.streamWaitTimeout, this.streamIdleTimeout);
   }
 
   @Override
@@ -128,12 +162,26 @@ public class FakeCallContext implements ApiCallContext {
   }
 
   public FakeCallContext withChannel(FakeChannel channel) {
-    return new FakeCallContext(this.credentials, channel, this.timeout);
+    return new FakeCallContext(
+        this.credentials, channel, this.timeout, this.streamWaitTimeout, this.streamIdleTimeout);
   }
 
   @Override
   public FakeCallContext withTimeout(Duration timeout) {
-    return new FakeCallContext(this.credentials, this.channel, timeout);
+    return new FakeCallContext(
+        this.credentials, this.channel, timeout, this.streamWaitTimeout, this.streamIdleTimeout);
+  }
+
+  @Override
+  public ApiCallContext withStreamWaitTimeout(@Nullable Duration streamWaitTimeout) {
+    return new FakeCallContext(
+        this.credentials, this.channel, this.timeout, streamWaitTimeout, this.streamIdleTimeout);
+  }
+
+  @Override
+  public ApiCallContext withStreamIdleTimeout(@Nullable Duration streamIdleTimeout) {
+    return new FakeCallContext(
+        this.credentials, this.channel, this.timeout, this.streamWaitTimeout, streamIdleTimeout);
   }
 
   public static FakeCallContext create(ClientContext clientContext) {


### PR DESCRIPTION
This depends on #482, which handles preliminary refactoring to cut down on the noise in this PR.

This is a follow up on the watchdog introduced in #463. It moves it out of the `RetryingServerStreamingCallable` and into the `ClientContext`. The main benefits are:
- Callables can  be stateless again
- There is only one scheduled reaper for all of the callables

Changes:
- Add {Fixed,Instantiating}WatchdogProviders to allow for transitioning from built ClientContexts to StubSettings.Builders and ClientContext.Builders
- Mark the Watchdog as nullable to keep backwards compatibility (to avoid NPEs building ClientContexts from Builders)
- Allow StubSettings to configure both the WatchdogProvider and the WatchdogCheckInterval.
- Enable the watchdog in StubSettings by default with an interval of 10 secs.
- Add WatchdogServerStreamingCallable and plumb timeouts through ApiCallContext
- Use the new WatchdogServerStreamingCallable and decouple RetryingServerStreamingCallable from the Watchdog