### PR TITLE
Watchdog - Refactor

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -38,6 +38,7 @@ import com.google.api.gax.retrying.RetryAlgorithm;
 import com.google.api.gax.retrying.RetryingExecutor;
 import com.google.api.gax.retrying.ScheduledRetryingExecutor;
 import com.google.api.gax.retrying.StreamingRetryAlgorithm;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Class with utility methods to create callable objects using provided settings.
@@ -91,16 +92,22 @@ public class Callables {
     // single Watchdog for the entire process, however that change would be fairly invasive and
     // the cost of multiple Watchdogs is fairly small, since they all use the same executor. If this
     // becomes an issue, the watchdog can be moved to ClientContext.
-    Watchdog<ResponseT> watchdog =
-        new Watchdog<>(
-            clientContext.getExecutor(),
-            clientContext.getClock(),
-            callSettings.getTimeoutCheckInterval(),
-            callSettings.getIdleTimeout());
-    watchdog.start();
+    Watchdog watchdog = new Watchdog(clientContext.getClock());
+
+    clientContext
+        .getExecutor()
+        .scheduleAtFixedRate(
+            watchdog,
+            callSettings.getTimeoutCheckInterval().toMillis(),
+            callSettings.getTimeoutCheckInterval().toMillis(),
+            TimeUnit.MILLISECONDS);
 
     return new RetryingServerStreamingCallable<>(
-        watchdog, innerCallable, retryingExecutor, callSettings.getResumptionStrategy());
+        watchdog,
+        callSettings.getIdleTimeout(),
+        innerCallable,
+        retryingExecutor,
+        callSettings.getResumptionStrategy());
   }
 
   /**

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -92,15 +92,18 @@ public class Callables {
     // single Watchdog for the entire process, however that change would be fairly invasive and
     // the cost of multiple Watchdogs is fairly small, since they all use the same executor. If this
     // becomes an issue, the watchdog can be moved to ClientContext.
-    Watchdog watchdog = new Watchdog(clientContext.getClock());
+    Watchdog watchdog = null;
+    if (!callSettings.getTimeoutCheckInterval().isZero()) {
+      watchdog = new Watchdog(clientContext.getClock());
 
-    clientContext
-        .getExecutor()
-        .scheduleAtFixedRate(
-            watchdog,
-            callSettings.getTimeoutCheckInterval().toMillis(),
-            callSettings.getTimeoutCheckInterval().toMillis(),
-            TimeUnit.MILLISECONDS);
+      clientContext
+          .getExecutor()
+          .scheduleAtFixedRate(
+              watchdog,
+              callSettings.getTimeoutCheckInterval().toMillis(),
+              callSettings.getTimeoutCheckInterval().toMillis(),
+              TimeUnit.MILLISECONDS);
+    }
 
     return new RetryingServerStreamingCallable<>(
         watchdog,

--- a/gax/src/main/java/com/google/api/gax/rpc/RetryingServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/RetryingServerStreamingCallable.java
@@ -35,6 +35,7 @@ import com.google.api.gax.retrying.RetryingFuture;
 import com.google.api.gax.retrying.ScheduledRetryingExecutor;
 import com.google.api.gax.retrying.ServerStreamingAttemptException;
 import com.google.api.gax.retrying.StreamResumptionStrategy;
+import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
 /**
@@ -54,14 +55,14 @@ import org.threeten.bp.Duration;
 final class RetryingServerStreamingCallable<RequestT, ResponseT>
     extends ServerStreamingCallable<RequestT, ResponseT> {
 
-  private final Watchdog watchdog;
+  private final @Nullable Watchdog watchdog;
   private final Duration idleTimeout;
   private final ServerStreamingCallable<RequestT, ResponseT> innerCallable;
   private final ScheduledRetryingExecutor<Void> executor;
   private final StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategyPrototype;
 
   RetryingServerStreamingCallable(
-      Watchdog watchdog,
+      @Nullable Watchdog watchdog,
       Duration idleTimeout,
       ServerStreamingCallable<RequestT, ResponseT> innerCallable,
       ScheduledRetryingExecutor<Void> executor,

--- a/gax/src/main/java/com/google/api/gax/rpc/RetryingServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/RetryingServerStreamingCallable.java
@@ -35,6 +35,7 @@ import com.google.api.gax.retrying.RetryingFuture;
 import com.google.api.gax.retrying.ScheduledRetryingExecutor;
 import com.google.api.gax.retrying.ServerStreamingAttemptException;
 import com.google.api.gax.retrying.StreamResumptionStrategy;
+import org.threeten.bp.Duration;
 
 /**
  * A ServerStreamingCallable that implements resumable retries.
@@ -53,17 +54,20 @@ import com.google.api.gax.retrying.StreamResumptionStrategy;
 final class RetryingServerStreamingCallable<RequestT, ResponseT>
     extends ServerStreamingCallable<RequestT, ResponseT> {
 
-  private final Watchdog<ResponseT> watchdog;
+  private final Watchdog watchdog;
+  private final Duration idleTimeout;
   private final ServerStreamingCallable<RequestT, ResponseT> innerCallable;
   private final ScheduledRetryingExecutor<Void> executor;
   private final StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategyPrototype;
 
   RetryingServerStreamingCallable(
-      Watchdog<ResponseT> watchdog,
+      Watchdog watchdog,
+      Duration idleTimeout,
       ServerStreamingCallable<RequestT, ResponseT> innerCallable,
       ScheduledRetryingExecutor<Void> executor,
       StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategyPrototype) {
     this.watchdog = watchdog;
+    this.idleTimeout = idleTimeout;
     this.innerCallable = innerCallable;
     this.executor = executor;
     this.resumptionStrategyPrototype = resumptionStrategyPrototype;
@@ -78,6 +82,7 @@ final class RetryingServerStreamingCallable<RequestT, ResponseT>
     ServerStreamingAttemptCallable<RequestT, ResponseT> attemptCallable =
         new ServerStreamingAttemptCallable<>(
             watchdog,
+            idleTimeout,
             innerCallable,
             resumptionStrategyPrototype.createNew(),
             request,

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
@@ -216,6 +216,11 @@ final class ServerStreamingAttemptCallable<RequestT, ResponseT> implements Calla
     innerAttemptFuture = SettableApiFuture.create();
     seenSuccessSinceLastError = false;
 
+    Duration rpcTimeout = outerRetryingFuture.getAttemptSettings().getRpcTimeout();
+    if (rpcTimeout.isZero()) {
+      rpcTimeout = null;
+    }
+
     innerCallable.call(
         request,
         watchdog.watch(
@@ -240,7 +245,7 @@ final class ServerStreamingAttemptCallable<RequestT, ResponseT> implements Calla
                 onAttemptComplete();
               }
             },
-            outerRetryingFuture.getAttemptSettings().getRpcTimeout()),
+            rpcTimeout),
         context);
 
     outerRetryingFuture.setAttemptFuture(innerAttemptFuture);

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -157,7 +157,7 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
       this.retrySettings = RetrySettings.newBuilder().build();
       this.resumptionStrategy = new SimpleStreamResumptionStrategy<>();
 
-      this.timeoutCheckInterval = Duration.ofSeconds(10);
+      this.timeoutCheckInterval = Duration.ZERO;
       this.idleTimeout = Duration.ZERO;
     }
 

--- a/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
@@ -31,14 +31,12 @@ package com.google.api.gax.rpc;
 
 import com.google.api.core.ApiClock;
 import com.google.api.core.InternalApi;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import org.threeten.bp.Duration;
 
@@ -56,70 +54,45 @@ import org.threeten.bp.Duration;
  *       stream and forcefully closing the stream. This is measured from the last time the caller
  *       had no outstanding demand. Duration.ZERO disables the timeout.
  * </ul>
- *
- * @param <ResponseT> The type of the response.
  */
 @InternalApi
-public class Watchdog<ResponseT> {
+public class Watchdog implements Runnable {
   // Dummy value to convert the ConcurrentHashMap into a Set
   private static Object VALUE_MARKER = new Object();
   private final ConcurrentHashMap<WatchdogStream, Object> openStreams = new ConcurrentHashMap<>();
 
-  private final ScheduledExecutorService executor;
   private final ApiClock clock;
-  private final Duration checkInterval;
-  private final Duration idleTimeout;
 
-  public Watchdog(
-      ScheduledExecutorService executor,
-      ApiClock clock,
-      Duration checkInterval,
-      Duration idleTimeout) {
-
-    Preconditions.checkNotNull(executor, "executor can't be null");
-    Preconditions.checkNotNull(clock, "clock can't be null");
-    Preconditions.checkNotNull(checkInterval, "checkInterval can't be null");
-    Preconditions.checkNotNull(idleTimeout, "checkInterval can't be null");
-
-    Preconditions.checkArgument(
-        Duration.ZERO.compareTo(checkInterval) < 0, "checkInterval must be > 0");
-
-    Preconditions.checkArgument(
-        Duration.ZERO.compareTo(idleTimeout) <= 0, "idleTimeout must be >= 0");
-
-    this.executor = executor;
-    this.clock = clock;
-    this.checkInterval = checkInterval;
-    this.idleTimeout = idleTimeout;
-  }
-
-  /** Schedules the timeout check thread. */
-  public void start() {
-    executor.scheduleAtFixedRate(
-        new Runnable() {
-          @Override
-          public void run() {
-            checkAll();
-          }
-        },
-        checkInterval.toMillis(),
-        checkInterval.toMillis(),
-        TimeUnit.MILLISECONDS);
+  public Watchdog(ApiClock clock) {
+    this.clock = Preconditions.checkNotNull(clock, "clock can't be null");
   }
 
   /** Wraps the target observer with timing constraints. */
-  public ResponseObserver<ResponseT> watch(
-      ResponseObserver<ResponseT> innerObserver, Duration waitTimeout) {
+  public <ResponseT> ResponseObserver<ResponseT> watch(
+      ResponseObserver<ResponseT> innerObserver, Duration waitTimeout, Duration idleTimeout) {
     Preconditions.checkNotNull(innerObserver, "innerObserver can't be null");
-    Preconditions.checkArgument(Duration.ZERO.compareTo(waitTimeout) <= 0, "waitTimeout must >= 0");
 
-    WatchdogStream stream = new WatchdogStream(innerObserver, waitTimeout);
+    if (waitTimeout != null) {
+      Preconditions.checkArgument(
+          Duration.ZERO.compareTo(waitTimeout) <= 0, "waitTimeout must >= 0");
+    }
+    if (idleTimeout != null) {
+      Preconditions.checkArgument(
+          Duration.ZERO.compareTo(idleTimeout) <= 0, "idleTimeout must be >= 0");
+    }
+
+    if (waitTimeout == null && idleTimeout == null) {
+      return innerObserver;
+    }
+
+    WatchdogStream<ResponseT> stream =
+        new WatchdogStream<>(innerObserver, waitTimeout, idleTimeout);
     openStreams.put(stream, VALUE_MARKER);
     return stream;
   }
 
-  @VisibleForTesting
-  void checkAll() {
+  @Override
+  public void run() {
     Iterator<Entry<WatchdogStream, Object>> it = openStreams.entrySet().iterator();
 
     while (it.hasNext()) {
@@ -141,10 +114,11 @@ public class Watchdog<ResponseT> {
     DELIVERING
   }
 
-  class WatchdogStream extends StateCheckingResponseObserver<ResponseT> {
+  class WatchdogStream<ResponseT> extends StateCheckingResponseObserver<ResponseT> {
     private final Object lock = new Object();
 
-    private final Duration waitTimeout;
+    @Nullable private final Duration waitTimeout;
+    @Nullable private final Duration idleTimeout;
     private boolean hasStarted;
     private boolean autoAutoFlowControl = true;
 
@@ -162,8 +136,12 @@ public class Watchdog<ResponseT> {
 
     private volatile Throwable error;
 
-    WatchdogStream(ResponseObserver<ResponseT> responseObserver, Duration waitTimeout) {
+    WatchdogStream(
+        ResponseObserver<ResponseT> responseObserver,
+        @Nullable Duration waitTimeout,
+        @Nullable Duration idleTimeout) {
       this.waitTimeout = waitTimeout;
+      this.idleTimeout = idleTimeout;
       this.outerResponseObserver = responseObserver;
     }
 
@@ -267,14 +245,14 @@ public class Watchdog<ResponseT> {
 
         switch (this.state) {
           case IDLE:
-            if (!idleTimeout.isZero() && waitTime >= idleTimeout.toMillis()) {
-              myError = new IdleConnectionException("Canceled due to idle connection", false);
+            if (idleTimeout != null && waitTime >= idleTimeout.toMillis()) {
+              myError = new WatchdogTimeoutException("Canceled due to idle connection", false);
             }
             break;
           case WAITING:
-            if (!waitTimeout.isZero() && waitTime >= waitTimeout.toMillis()) {
+            if (waitTimeout != null && waitTime >= waitTimeout.toMillis()) {
               myError =
-                  new IdleConnectionException(
+                  new WatchdogTimeoutException(
                       "Canceled due to timeout waiting for next response", true);
             }
             break;
@@ -289,26 +267,4 @@ public class Watchdog<ResponseT> {
       return false;
     }
   }
-
-  /** The marker exception thrown when a timeout is exceeded. */
-  public static class IdleConnectionException extends ApiException {
-    private static final long serialVersionUID = -777463630112442085L;
-
-    IdleConnectionException(String message, boolean retry) {
-      super(message, null, LOCAL_ABORTED_STATUS_CODE, retry);
-    }
-  }
-
-  public static final StatusCode LOCAL_ABORTED_STATUS_CODE =
-      new StatusCode() {
-        @Override
-        public Code getCode() {
-          return Code.ABORTED;
-        }
-
-        @Override
-        public Object getTransportCode() {
-          return null;
-        }
-      };
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
@@ -58,7 +58,7 @@ import org.threeten.bp.Duration;
 @InternalApi
 public class Watchdog implements Runnable {
   // Dummy value to convert the ConcurrentHashMap into a Set
-  private static Object VALUE_MARKER = new Object();
+  private static Object PRESENT = new Object();
   private final ConcurrentHashMap<WatchdogStream, Object> openStreams = new ConcurrentHashMap<>();
 
   private final ApiClock clock;
@@ -82,7 +82,7 @@ public class Watchdog implements Runnable {
 
     WatchdogStream<ResponseT> stream =
         new WatchdogStream<>(innerObserver, waitTimeout, idleTimeout);
-    openStreams.put(stream, VALUE_MARKER);
+    openStreams.put(stream, PRESENT);
     return stream;
   }
 

--- a/gax/src/main/java/com/google/api/gax/rpc/WatchdogTimeoutException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/WatchdogTimeoutException.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import com.google.api.core.BetaApi;
+
+/**
+ * The marker exception thrown when a timeout is exceeded.
+ *
+ * <p>This error can be thrown under 2 circumstances:
+ *
+ * <ul>
+ *   <li>A wait timeout has exceeded, which means that the client timed out waiting for the next
+ *       message from the server. In this case, {@link #isRetryable()} will be true.
+ *   <li>An idle timeout has exceeded, which means that the stream is using manual flow control and
+ *       the caller has not called {@link StreamController#request(int)} (in case of callback api)
+ *       or next on {@link ServerStream#iterator()} (in case of blocking api).
+ * </ul>
+ */
+@BetaApi("The surface for streaming is not stable yet and may change in the future.")
+public class WatchdogTimeoutException extends ApiException {
+  private static final long serialVersionUID = -777463630112442086L;
+
+  public static final StatusCode LOCAL_ABORTED_STATUS_CODE =
+      new StatusCode() {
+        @Override
+        public Code getCode() {
+          return Code.ABORTED;
+        }
+
+        @Override
+        public Object getTransportCode() {
+          return null;
+        }
+      };
+
+  /** Package private for internal use. */
+  WatchdogTimeoutException(String message, boolean retry) {
+    super(message, null, LOCAL_ABORTED_STATUS_CODE, retry);
+  }
+}

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingAttemptCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingAttemptCallableTest.java
@@ -51,14 +51,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class ServerStreamingAttemptCallableTest {
-  private Watchdog watchdog;
   private MockServerStreamingCallable<String, String> innerCallable;
   private AccumulatingObserver observer;
   private FakeRetryingFuture fakeRetryingFuture;
@@ -66,7 +62,6 @@ public class ServerStreamingAttemptCallableTest {
 
   @Before
   public void setUp() {
-    watchdog = createNoopWatchdog();
     innerCallable = new MockServerStreamingCallable<>();
     observer = new AccumulatingObserver(true);
     resumptionStrategy = new MyStreamResumptionStrategy();
@@ -75,7 +70,7 @@ public class ServerStreamingAttemptCallableTest {
   private ServerStreamingAttemptCallable<String, String> createCallable() {
     ServerStreamingAttemptCallable<String, String> callable =
         new ServerStreamingAttemptCallable<>(
-            watchdog,
+            null,
             Duration.ofMinutes(1),
             innerCallable,
             resumptionStrategy,
@@ -87,25 +82,6 @@ public class ServerStreamingAttemptCallableTest {
     callable.setExternalFuture(fakeRetryingFuture);
 
     return callable;
-  }
-
-  @SuppressWarnings("unchecked")
-  private static Watchdog createNoopWatchdog() {
-    Watchdog watchdog = Mockito.mock(Watchdog.class);
-
-    Mockito.when(
-            watchdog.watch(
-                Mockito.any(ResponseObserver.class),
-                Mockito.any(Duration.class),
-                Mockito.any(Duration.class)))
-        .thenAnswer(
-            new Answer<ResponseObserver>() {
-              @Override
-              public ResponseObserver answer(InvocationOnMock invocation) {
-                return (ResponseObserver) invocation.getArguments()[0];
-              }
-            });
-    return watchdog;
   }
 
   @Test


### PR DESCRIPTION
This is in preparation for #480.

- ~~when the watchdog moves to ClientContext, it will be on by default, so check interval should be nonnull~~
- ~~when the timeouts move to ApiCallContext, they can be disabled via null not zero, so switch to those semantics~~
- explicitly annotate everything else in ServerStreamingCallSetting for good measure
- Convert the watchdog into a Runnable that is scheduled externally
- Make idleTimeout configureable per watch
- Rename Watchdog.IdleConnectionException -> WatchdogTimeoutException and make it toplevel
- pushdown the generics from the Watchdog class to the Watchdog#watch method

Updates:
- When the watchdog moves to ClientContext, it will need to be nullable to retain backward compatibility with existing builder sof ClientContext, so the watchdog needs to be nullable


This is ready for review. @garrettjonesgoogle PTAL