### PR TITLE
Update the ResumptionStrategy interface to allow it to modify the incoming response stream.

### DIFF
--- a/gax/src/main/java/com/google/api/gax/retrying/SimpleStreamResumptionStrategy.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/SimpleStreamResumptionStrategy.java
@@ -47,8 +47,9 @@ public final class SimpleStreamResumptionStrategy<RequestT, ResponseT>
   }
 
   @Override
-  public void onProgress(ResponseT response) {
+  public ResponseT processResponse(ResponseT response) {
     seenFirstResponse = true;
+    return response;
   }
 
   @Override

--- a/gax/src/main/java/com/google/api/gax/retrying/StreamResumptionStrategy.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/StreamResumptionStrategy.java
@@ -30,6 +30,8 @@
 package com.google.api.gax.retrying;
 
 import com.google.api.core.BetaApi;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * This is part of the server streaming retry api. Its implementers are responsible for tracking the
@@ -41,23 +43,24 @@ import com.google.api.core.BetaApi;
 public interface StreamResumptionStrategy<RequestT, ResponseT> {
 
   /** Creates a new instance of this StreamResumptionStrategy without accumulated state */
+  @Nonnull
   StreamResumptionStrategy<RequestT, ResponseT> createNew();
 
   /**
    * Called by the {@code ServerStreamingAttemptCallable} when a response has been successfully
-   * received. The subclass can modify the response or return null to suppress it. This method
-   * accomplishes two goals:
+   * received. This method accomplishes two goals:
    *
    * <ol>
-   *   <li>It allows the strategy implementation to update it's internal state so that it can
-   *       compose the resume request
-   *   <li>It allows the strategy to alter the incoming responses to adjust for post resume. For
+   *   <li>It allows the strategy implementation to update its internal state so that it can compose
+   *       the resume request
+   *   <li>It allows the strategy to alter the incoming responses to adjust for after resume. For
    *       example, if the responses are numbered sequentially from the start of the stream, upon
    *       resume, the strategy could rewrite the messages to continue the sequence from where it
    *       left off. Please note that all messages (even for the first attempt) will be passed
    *       through this method.
    * </ol>
    */
+  @Nonnull
   ResponseT processResponse(ResponseT response);
 
   /**
@@ -67,6 +70,7 @@ public interface StreamResumptionStrategy<RequestT, ResponseT> {
    *
    * @return A request that can be used to resume the stream.
    */
+  @Nullable
   RequestT getResumeRequest(RequestT originalRequest);
 
   /** If a resume request can be created. */

--- a/gax/src/main/java/com/google/api/gax/retrying/StreamResumptionStrategy.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/StreamResumptionStrategy.java
@@ -45,14 +45,25 @@ public interface StreamResumptionStrategy<RequestT, ResponseT> {
 
   /**
    * Called by the {@code ServerStreamingAttemptCallable} when a response has been successfully
-   * received.
+   * received. The subclass can modify the response or return null to suppress it. This method
+   * accomplishes two goals:
+   *
+   * <ol>
+   *   <li>It allows the strategy implementation to update it's internal state so that it can
+   *       compose the resume request
+   *   <li>It allows the strategy to alter the incoming responses to adjust for post resume. For
+   *       example, if the responses are numbered sequentially from the start of the stream, upon
+   *       resume, the strategy could rewrite the messages to continue the sequence from where it
+   *       left off. Please note that all messages (even for the first attempt) will be passed
+   *       through this method.
+   * </ol>
    */
-  void onProgress(ResponseT response);
+  ResponseT processResponse(ResponseT response);
 
   /**
    * Called when a stream needs to be restarted, the implementation should generate a request that
    * will yield a new stream whose first response would come right after the last response received
-   * by onProgress.
+   * by processResponse.
    *
    * @return A request that can be used to resume the stream.
    */

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
@@ -335,19 +335,6 @@ final class ServerStreamingAttemptCallable<RequestT, ResponseT> implements Calla
 
   /** Called when the inner callable has responses to deliver. */
   private void onAttemptResponse(ResponseT message) {
-    message = resumptionStrategy.processResponse(message);
-
-    // ResumptionStrategy suppressed the message
-    if (message == null) {
-      // Since the current request is being suppressed, a new one needs to be requested from the
-      // inner callable to replace.
-      if (!autoFlowControl) {
-        innerController.request(1);
-      }
-      return;
-    }
-
-    // There is a new message, account for it and notify the outerObserver
     if (!autoFlowControl) {
       synchronized (lock) {
         pendingRequests--;
@@ -355,6 +342,7 @@ final class ServerStreamingAttemptCallable<RequestT, ResponseT> implements Calla
     }
     // Update local state to allow for future resume.
     seenSuccessSinceLastError = true;
+    message = resumptionStrategy.processResponse(message);
     // Notify the outer observer.
     outerObserver.onResponse(message);
   }

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
@@ -339,7 +339,8 @@ final class ServerStreamingAttemptCallable<RequestT, ResponseT> implements Calla
 
     // ResumptionStrategy suppressed the message
     if (message == null) {
-      // Request the next one and exit
+      // Since the current request is being suppressed, a new one needs to requested from the inner
+      // callable to replace.
       if (!autoFlowControl) {
         innerController.request(1);
       }

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
@@ -339,8 +339,8 @@ final class ServerStreamingAttemptCallable<RequestT, ResponseT> implements Calla
 
     // ResumptionStrategy suppressed the message
     if (message == null) {
-      // Since the current request is being suppressed, a new one needs to requested from the inner
-      // callable to replace.
+      // Since the current request is being suppressed, a new one needs to be requested from the
+      // inner callable to replace.
       if (!autoFlowControl) {
         innerController.request(1);
       }

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingAttemptCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingAttemptCallableTest.java
@@ -313,52 +313,6 @@ public class ServerStreamingAttemptCallableTest {
   }
 
   @Test
-  public void testResponseSuppression() {
-    resumptionStrategy =
-        new MyStreamResumptionStrategy() {
-          boolean afterResume;
-
-          @Override
-          public String processResponse(String response) {
-            // Suppress the first response after a resume
-            if (afterResume) {
-              afterResume = false;
-              return null;
-            }
-            return super.processResponse(response);
-          }
-
-          @Override
-          public String getResumeRequest(String originalRequest) {
-            afterResume = true;
-            return super.getResumeRequest(originalRequest);
-          }
-        };
-
-    observer = new AccumulatingObserver(false);
-    ServerStreamingAttemptCallable<String, String> callable = createCallable();
-    callable.start();
-
-    MockServerStreamingCall<String, String> call = innerCallable.popLastCall();
-
-    // Send initial response & then error
-    call.getController().getObserver().onResponse("first");
-    call.getController().getObserver().onError(new FakeApiException(null, Code.UNAVAILABLE, true));
-
-    // Make the retry call
-    callable.call();
-    call = innerCallable.popLastCall();
-
-    // Send another couple of responses (the first one will be ignored)
-    call.getController().getObserver().onResponse("second");
-    call.getController().getObserver().onResponse("third");
-    call.getController().getObserver().onComplete();
-
-    // Verify the request and send a response
-    Truth.assertThat(observer.responses).containsExactly("first", "third");
-  }
-
-  @Test
   public void testResponseSubstitution() {
     resumptionStrategy =
         new MyStreamResumptionStrategy() {


### PR DESCRIPTION
This will allow the streaming retries to be useful in more scenarios.

The general use cases for this are:

1. If a stream can only be resumed from a particular point, then its strategy will resume from the closest point, suppressing the repeated messages in the retry
2. If the stream elements have sequence numbers relative to the start of the stream, then strategy can re-write the sequence numbers when it performs a retry.

The specific use case is to enable retries for Bigtable's MutateRows RPC. Which has a batch request and streamed responses. Each entry can fail independently of the others. I would like to reuse the streaming retry infrastructure to implement retries. On failure, the strategy will find all of the failed subresponses and compose a new request with them. The responses will have to be rewritten to adjust indexes on the response entries.