### PR TITLE
DON'T MERGE: Add some preliminary Batching benchmarks.

### DIFF
--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     compile project(':gax')
     compile project(':gax-grpc')
     compile "io.grpc:grpc-netty:${grpcVersion}"
+    compile 'org.openjdk.jmh:jmh-core:1.17.4'
 
     compile 'com.google.api.grpc:grpc-google-cloud-bigtable-v2:0.1.28'
     compile 'com.google.api.grpc:grpc-google-cloud-pubsub-v1:0.1.28'
@@ -30,3 +31,4 @@ dependencies {
 if (project.properties.containsKey('include')) {
     jmh.include = [project.properties.get('include')]
 }
+jmh.forceGC = true

--- a/benchmark/src/jmh/java/com/google/api/gax/grpc/BatchingBenchmark.java
+++ b/benchmark/src/jmh/java/com/google/api/gax/grpc/BatchingBenchmark.java
@@ -1,0 +1,506 @@
+package com.google.api.gax.grpc;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.CurrentMillisClock;
+import com.google.api.gax.batching.BatchingSettings;
+import com.google.api.gax.batching.FlowControlSettings;
+import com.google.api.gax.batching.FlowController;
+import com.google.api.gax.batching.FlowController.LimitExceededBehavior;
+import com.google.api.gax.batching.PartitionKey;
+import com.google.api.gax.batching.RequestBuilder;
+import com.google.api.gax.batching.ThresholdBatcher;
+import com.google.api.gax.rpc.Batch;
+import com.google.api.gax.rpc.BatchedFuture;
+import com.google.api.gax.rpc.BatchedRequestIssuer;
+import com.google.api.gax.rpc.BatcherFactory;
+import com.google.api.gax.rpc.BatchingCallSettings;
+import com.google.api.gax.rpc.BatchingDescriptor;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PublishRequest;
+import com.google.pubsub.v1.PublishResponse;
+import com.google.pubsub.v1.PublishResponse.Builder;
+import com.google.pubsub.v1.PublisherGrpc;
+import com.google.pubsub.v1.PubsubMessage;
+import io.grpc.CallOptions;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
+import org.threeten.bp.Duration;
+
+/**
+ * Exploratory benchmarks for batching.
+ *
+ * <p>This benchmark tries to measure the overhead of gax's batching infrastructure. It uses a fake
+ * pubsub server to sink the requests. This is done to take netty context switchs into account. It
+ * tries to pin done performance sensitive portions.
+ *
+ * <p>Each iteration will send {@code OperationsPerInvocation} entries, split by {@code
+ * elementsPerBatch}, with at most {@code maxOutstandingElements} elements unsent. When the {@code
+ * maxOutstandingElements} is reached all benchmarks will block.
+ */
+@Fork(value = 1)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 15)
+@Measurement(iterations = 5)
+@State(Scope.Benchmark)
+@OperationsPerInvocation(10_000)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class BatchingBenchmark {
+  private static final Logger LOG = Logger.getLogger(BatchingBenchmark.class.getName());
+  private static final String TOPIC = "projects/fake-project/topics/fake-topic";
+  private static final Random RANDOM = new Random(123);
+
+  @SuppressWarnings("WeakerAccess")
+  @Param("1000")
+  int maxOutstandingElements;
+
+  @SuppressWarnings("WeakerAccess")
+  @Param("100")
+  int elementsPerBatch;
+
+  @SuppressWarnings("WeakerAccess")
+  @Param("1024")
+  int messageSize;
+
+  private ScheduledExecutorService executor;
+  private Server fakeServer;
+  private ManagedChannel grpcChannel;
+  private ClientContext clientContext;
+  private ByteString[] payloads;
+
+  private UnaryCallable<PublishRequest, PublishResponse> baseCallable;
+  private UnaryCallable<PublishRequest, PublishResponse> batchingCallable;
+  private ThresholdBatcher<Batch<PublishRequest, PublishResponse>> pushingBatcher;
+
+  @Setup
+  public void setup(BenchmarkParams benchmarkParams, Blackhole blackhole) throws IOException {
+    Preconditions.checkState(elementsPerBatch <= maxOutstandingElements);
+
+    byte[] buffer = new byte[messageSize];
+    payloads = new ByteString[100];
+    for (int i = 0; i < payloads.length; i++) {
+      RANDOM.nextBytes(buffer);
+      payloads[i] = ByteString.copyFrom(buffer);
+    }
+
+    executor = Executors.newScheduledThreadPool(4);
+
+    final int availablePort;
+    try (ServerSocket ss = new ServerSocket(0)) {
+      availablePort = ss.getLocalPort();
+    }
+    fakeServer =
+        ServerBuilder.forPort(availablePort).addService(new FakePubSub(blackhole)).build().start();
+
+    grpcChannel =
+        ManagedChannelBuilder.forAddress("localhost", availablePort).usePlaintext(true).build();
+
+    clientContext =
+        ClientContext.newBuilder()
+            .setExecutor(executor)
+            .setClock(CurrentMillisClock.getDefaultClock())
+            .setDefaultCallContext(
+                GrpcCallContext.of(
+                    grpcChannel, CallOptions.DEFAULT.withDeadlineAfter(1, TimeUnit.HOURS)))
+            .setTransportChannel(GrpcTransportChannel.create(grpcChannel))
+            .build();
+
+    GrpcCallSettings<PublishRequest, PublishResponse> grpcSettings =
+        GrpcCallSettings.<PublishRequest, PublishResponse>newBuilder()
+            .setMethodDescriptor(PublisherGrpc.METHOD_PUBLISH)
+            .build();
+
+    UnaryCallSettings<PublishRequest, PublishResponse> callSettings =
+        UnaryCallSettings.<PublishRequest, PublishResponse>newUnaryCallSettingsBuilder()
+            .setSimpleTimeoutNoRetries(Duration.ofMinutes(1))
+            .build();
+
+    baseCallable =
+        GrpcCallableFactory.createUnaryCallable(grpcSettings, callSettings, clientContext);
+
+    BatchingCallSettings.Builder<PublishRequest, PublishResponse> batchingCallSettings =
+        BatchingCallSettings.newBuilder(new FakeBatchingDescriptor())
+            .setBatchingSettings(
+                BatchingSettings.newBuilder()
+                    .setIsEnabled(true)
+                    .setFlowControlSettings(
+                        FlowControlSettings.newBuilder()
+                            .setLimitExceededBehavior(LimitExceededBehavior.Block)
+                            .setMaxOutstandingElementCount((long) maxOutstandingElements)
+                            .build())
+                    // Not actually used because we generate messages faster
+                    .setDelayThreshold(Duration.ofSeconds(5))
+                    .setElementCountThreshold((long) elementsPerBatch)
+                    .build());
+    batchingCallSettings.setSimpleTimeoutNoRetries(Duration.ofSeconds(10));
+
+    batchingCallable =
+        GrpcCallableFactory.createBatchingCallable(
+            grpcSettings, batchingCallSettings.build(), clientContext);
+
+    BatcherFactory<PublishRequest, PublishResponse> batcherFactory =
+        new BatcherFactory<>(
+            new FakeBatchingDescriptor(),
+            BatchingSettings.newBuilder()
+                .setIsEnabled(true)
+                .setFlowControlSettings(
+                    FlowControlSettings.newBuilder()
+                        .setLimitExceededBehavior(LimitExceededBehavior.Block)
+                        .setMaxOutstandingElementCount((long) maxOutstandingElements)
+                        .build())
+                // Not actually used because we generate messages faster
+                .setDelayThreshold(Duration.ofSeconds(5))
+                .setElementCountThreshold((long) elementsPerBatch)
+                .build(),
+            executor,
+            new FlowController(
+                FlowControlSettings.newBuilder()
+                    .setLimitExceededBehavior(LimitExceededBehavior.Block)
+                    .setMaxOutstandingElementCount((long) maxOutstandingElements)
+                    .build()));
+    pushingBatcher = batcherFactory.getPushingBatcher(new PartitionKey(TOPIC));
+  }
+
+  @TearDown
+  public void teardown() {
+    try {
+      grpcChannel.shutdown();
+      if (!grpcChannel.awaitTermination(10, TimeUnit.SECONDS)) {
+        throw new TimeoutException();
+      }
+    } catch (Exception e) {
+      LOG.log(Level.SEVERE, "Failed to close the grpc channel", e);
+    }
+
+    try {
+      fakeServer.shutdown();
+      if (!fakeServer.awaitTermination(10, TimeUnit.SECONDS)) {
+        throw new TimeoutException();
+      }
+    } catch (Exception e) {
+      LOG.log(Level.SEVERE, "Failed to shutdown the fake server", e);
+    }
+
+    try {
+      executor.shutdown();
+      if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+        throw new TimeoutException();
+      }
+    } catch (Exception e) {
+      LOG.log(Level.SEVERE, "Failed to shutdown the the executor", e);
+    }
+  }
+
+  /** Simple, direct implementation that should represent minimal overhead */
+  @Benchmark
+  public void manualBaseline(BenchmarkParams benchmarkParams) throws Exception {
+    int messageCount = benchmarkParams.getOpsPerInvocation();
+    final CountDownLatch latch =
+        new CountDownLatch((int) Math.ceil(messageCount / elementsPerBatch));
+
+    final Semaphore outstandingElements = new Semaphore(maxOutstandingElements);
+
+    PublishRequest prototype = PublishRequest.newBuilder().setTopic(TOPIC).build();
+
+    PublishRequest.Builder requestBuilder = prototype.toBuilder();
+    int currentBatchSize = 0;
+
+    for (int i = 0; i < messageCount; i++) {
+      // Fill up the current batch
+      requestBuilder.addMessages(
+          PubsubMessage.newBuilder()
+              .setData(payloads[RANDOM.nextInt(payloads.length)])
+              .setMessageId("message-" + i)
+              .build());
+
+      currentBatchSize++;
+
+      // Respecting the element count flow control
+      outstandingElements.acquire(1);
+
+      // Send the batches when full or if we are about to run out of messages
+      if (currentBatchSize == elementsPerBatch || i == messageCount - 1) {
+        final int currentBatchSizeSnapshot = currentBatchSize;
+        PublishRequest request = requestBuilder.build();
+        // Send the RPC
+        ApiFuture<PublishResponse> future = baseCallable.futureCall(request);
+
+        // Return the tokens back to the flow control
+        future.addListener(
+            new Runnable() {
+              @Override
+              public void run() {
+                outstandingElements.release(currentBatchSizeSnapshot);
+                latch.countDown();
+              }
+            },
+            MoreExecutors.directExecutor());
+
+        // reset for next batch
+        requestBuilder = prototype.toBuilder();
+        currentBatchSize = 0;
+      }
+    }
+
+    if (!latch.await(10, TimeUnit.MINUTES)) {
+      throw new TimeoutException("Timed out waiting for all batches to finish");
+    }
+  }
+
+  /**
+   * The full gax batching stack.
+   *
+   * <p>Note: since gax doesn't support flushing, {@link OperationsPerInvocation} must be a multiple
+   * of {@link #elementsPerBatch}.
+   */
+  @Benchmark
+  public void batchingCallableBenchmark(BenchmarkParams benchmarkParams) throws Exception {
+    int messageCount = benchmarkParams.getOpsPerInvocation();
+
+    // Since the current implement does not support flushing, all messages must be aligned to the batch boundary
+    Preconditions.checkState(
+        messageCount % elementsPerBatch == 0,
+        String.format(
+            "opsPerInvocation (%s) must be a multiple of elementsPerBatch (%d)",
+            messageCount, elementsPerBatch));
+
+    final CountDownLatch latch = new CountDownLatch(messageCount);
+
+    for (int i = 0; i < messageCount; i++) {
+      PublishRequest request =
+          PublishRequest.newBuilder()
+              .setTopic(TOPIC)
+              .addMessages(
+                  PubsubMessage.newBuilder()
+                      .setData(payloads[RANDOM.nextInt(payloads.length)])
+                      .setMessageId("message-" + i)
+                      .build())
+              .build();
+
+      ApiFuture<PublishResponse> future = batchingCallable.futureCall(request);
+      future.addListener(
+          new Runnable() {
+            @Override
+            public void run() {
+              latch.countDown();
+            }
+          },
+          MoreExecutors.directExecutor());
+    }
+
+    if (!latch.await(10, TimeUnit.MINUTES)) {
+      throw new TimeoutException("Timed out waiting for all elements to finish");
+    }
+  }
+
+  /**
+   * One layer down into the gax batching infrastructure: skips the {@link
+   * com.google.api.gax.rpc.BatchingCallable} and the {@link PartitionKey} routing.
+   */
+  @Benchmark
+  public void pushingBatcherBenchmark(BenchmarkParams benchmarkParams) throws Exception {
+    int messageCount = benchmarkParams.getOpsPerInvocation();
+    final CountDownLatch latch = new CountDownLatch(messageCount);
+
+    FakeBatchingDescriptor descriptor = new FakeBatchingDescriptor();
+
+    for (int i = 0; i < messageCount; i++) {
+      PublishRequest request =
+          PublishRequest.newBuilder()
+              .setTopic(TOPIC)
+              .addMessages(
+                  PubsubMessage.newBuilder()
+                      .setData(payloads[RANDOM.nextInt(payloads.length)])
+                      .setMessageId("message-" + i)
+                      .build())
+              .build();
+
+      BatchedFuture<PublishResponse> future = new BatchedFuture<>();
+      pushingBatcher.add(new Batch<>(descriptor, request, baseCallable, future));
+      future.addListener(
+          new Runnable() {
+            @Override
+            public void run() {
+              latch.countDown();
+            }
+          },
+          MoreExecutors.directExecutor());
+    }
+    pushingBatcher.pushCurrentBatch();
+
+    if (!latch.await(10, TimeUnit.MINUTES)) {
+      throw new TimeoutException("Timed out waiting for all elements to finish");
+    }
+  }
+
+  /**
+   * 2 layers deep into the gax batching infrastructure that tries to avoid re-wrapping the request
+   * protos by pre-sizing the batches.
+   */
+  @Benchmark
+  public void pushingBatcher2Benchmark(BenchmarkParams benchmarkParams) throws Exception {
+    int messageCount = benchmarkParams.getOpsPerInvocation();
+    final CountDownLatch latch =
+        new CountDownLatch((int) Math.ceil(messageCount / elementsPerBatch));
+
+    FakeBatchingDescriptor descriptor = new FakeBatchingDescriptor();
+
+    PublishRequest prototype = PublishRequest.newBuilder().setTopic(TOPIC).build();
+
+    PublishRequest.Builder builder = prototype.toBuilder();
+    int currentBatchSize = 0;
+
+    for (int i = 0; i < messageCount; i++) {
+      builder
+          .addMessages(
+              PubsubMessage.newBuilder()
+                  .setData(payloads[RANDOM.nextInt(payloads.length)])
+                  .setMessageId("message-" + i)
+                  .build())
+          .build();
+      currentBatchSize++;
+
+      if (currentBatchSize == elementsPerBatch || i == messageCount - 1) {
+        BatchedFuture<PublishResponse> future = new BatchedFuture<>();
+        pushingBatcher.add(new Batch<>(descriptor, builder.build(), baseCallable, future));
+        future.addListener(
+            new Runnable() {
+              @Override
+              public void run() {
+                latch.countDown();
+              }
+            },
+            MoreExecutors.directExecutor());
+        builder = prototype.toBuilder();
+        currentBatchSize = 0;
+      }
+    }
+    pushingBatcher.pushCurrentBatch();
+
+    if (!latch.await(10, TimeUnit.MINUTES)) {
+      throw new TimeoutException("Timed out waiting for all elements to finish");
+    }
+  }
+
+  // Helpers -------
+  static class FakePubSub extends com.google.pubsub.v1.PublisherGrpc.PublisherImplBase {
+    private final Blackhole blackhole;
+
+    FakePubSub(Blackhole blackhole) {
+      this.blackhole = blackhole;
+    }
+
+    @Override
+    public void publish(PublishRequest request, StreamObserver<PublishResponse> responseObserver) {
+      blackhole.consume(request);
+      Builder responseBuilder = PublishResponse.newBuilder();
+      for (PubsubMessage msg : request.getMessagesList()) {
+        responseBuilder.addMessageIds(msg.getMessageId());
+      }
+
+      responseObserver.onNext(responseBuilder.build());
+      responseObserver.onCompleted();
+    }
+  }
+
+  static class FakeBatchingDescriptor
+      implements BatchingDescriptor<PublishRequest, PublishResponse> {
+    @Override
+    public PartitionKey getBatchPartitionKey(PublishRequest request) {
+      return new PartitionKey(request.getTopic());
+    }
+
+    @Override
+    public RequestBuilder<PublishRequest> getRequestBuilder() {
+      return new RequestBuilder<PublishRequest>() {
+        private PublishRequest.Builder builder;
+
+        @Override
+        public void appendRequest(PublishRequest request) {
+          if (builder == null) {
+            builder = request.toBuilder();
+          } else {
+            builder.addAllMessages(request.getMessagesList());
+          }
+        }
+
+        @Override
+        public PublishRequest build() {
+          return builder.build();
+        }
+      };
+    }
+
+    @Override
+    public void splitResponse(
+        PublishResponse batchResponse,
+        Collection<? extends BatchedRequestIssuer<PublishResponse>> batch) {
+      int batchMessageIndex = 0;
+      for (BatchedRequestIssuer<PublishResponse> responder : batch) {
+        List<String> subresponseElements = new ArrayList<>();
+        long subresponseCount = responder.getMessageCount();
+        for (int i = 0; i < subresponseCount; i++) {
+          subresponseElements.add(batchResponse.getMessageIds(batchMessageIndex));
+          batchMessageIndex += 1;
+        }
+        PublishResponse response =
+            PublishResponse.newBuilder().addAllMessageIds(subresponseElements).build();
+        responder.setResponse(response);
+      }
+    }
+
+    @Override
+    public void splitException(
+        Throwable throwable, Collection<? extends BatchedRequestIssuer<PublishResponse>> batch) {
+      for (BatchedRequestIssuer<PublishResponse> responder : batch) {
+        responder.setException(throwable);
+      }
+    }
+
+    @Override
+    public long countElements(PublishRequest request) {
+      return request.getMessagesCount();
+    }
+
+    @Override
+    public long countBytes(PublishRequest request) {
+      return request.getSerializedSize();
+    }
+  }
+}

--- a/benchmark/src/jmh/java/com/google/api/gax/grpc/BatchingBenchmark.java
+++ b/benchmark/src/jmh/java/com/google/api/gax/grpc/BatchingBenchmark.java
@@ -271,7 +271,15 @@ public class BatchingBenchmark {
           }
         }
     );
-    impl1 = new Batcher<>(new FakeBatchingDescriptor(), baseCallable, batchingThresholds, executor, /*Duration.ofSeconds(5)*/ Duration.ofDays(1), new BatchExecutor<>(batchingDescriptor,partitionKey), batchingFlowController);
+    impl1 = Batcher.<PublishRequest, PublishResponse>newBuilder()
+      .setDescriptor(new FakeBatchingDescriptor())
+        .setInnerCallable(baseCallable)
+        .setThresholds(batchingThresholds)
+        .setExecutor(executor)
+        .setMaxDelay(Duration.ofSeconds(5))
+        .setReceiver(new BatchExecutor<>(batchingDescriptor,partitionKey))
+        .setFlowController(batchingFlowController)
+        .build();
   }
 
   @TearDown

--- a/benchmark/src/jmh/java/com/google/api/gax/grpc/BatchingBenchmark.java
+++ b/benchmark/src/jmh/java/com/google/api/gax/grpc/BatchingBenchmark.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.google.api.gax.grpc;
 
 import com.google.api.core.ApiFuture;

--- a/benchmark/src/jmh/java/com/google/api/gax/grpc/batching/Batcher.java
+++ b/benchmark/src/jmh/java/com/google/api/gax/grpc/batching/Batcher.java
@@ -42,8 +42,10 @@ import com.google.api.gax.rpc.BatchedFuture;
 import com.google.api.gax.rpc.BatchedRequestIssuer;
 import com.google.api.gax.rpc.BatchingDescriptor;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -51,22 +53,25 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import org.threeten.bp.Duration;
 
+/**
+ * Queues up elements until either a duration of time has passed or any threshold in a given set of
+ * thresholds is breached, and then delivers the elements in a batch to the consumer.
+ */
 public class Batcher<RequestT, ResponseT> {
-  final BatchingDescriptor<RequestT, ResponseT> descriptor;
-  final UnaryCallable<RequestT, ResponseT> innerCallable;
 
-  private final ArrayList<BatchingThreshold<RequestT>> thresholds;
-  private final ScheduledExecutorService executor;
-  private final Duration maxDelay;
-  private final ThresholdBatchReceiver<Batch<RequestT, ResponseT>> receiver;
-  private final BatchingFlowController<RequestT> flowController;
+  private class ReleaseResourcesFunction<T> implements ApiFunction<T, Void> {
+    private final RequestT request;
 
-  private final ReentrantLock lock = new ReentrantLock();
-  private RequestBuilder<RequestT> requestBuilder;
-  private Future<?> currentAlarmFuture;
+    private ReleaseResourcesFunction(RequestT request) {
+      this.request = request;
+    }
 
-  List<BatchedRequestIssuer<ResponseT>> requestIssuers = Lists.newArrayList();
-  long requestSize = 0;
+    @Override
+    public Void apply(T input) {
+      flowController.release(request);
+      return null;
+    }
+  }
 
   private final Runnable pushCurrentBatchRunnable =
       new Runnable() {
@@ -76,24 +81,104 @@ public class Batcher<RequestT, ResponseT> {
         }
       };
 
-  public Batcher(
-      BatchingDescriptor<RequestT, ResponseT> descriptor,
-      UnaryCallable<RequestT, ResponseT> innerCallable,
-      ArrayList<BatchingThreshold<RequestT>> thresholds,
-      ScheduledExecutorService executor,
-      Duration maxDelay,
-      ThresholdBatchReceiver<Batch<RequestT, ResponseT>> receiver,
-      BatchingFlowController<RequestT> flowController) {
-    this.descriptor = descriptor;
-    this.innerCallable = innerCallable;
-    this.thresholds = thresholds;
-    this.executor = executor;
-    this.maxDelay = maxDelay;
-    this.receiver = receiver;
-    this.flowController = flowController;
-    this.requestBuilder = descriptor.getRequestBuilder();
+  private final ArrayList<BatchingThreshold<RequestT>> thresholds;
+  private final ScheduledExecutorService executor;
+  private final Duration maxDelay;
+  private final ThresholdBatchReceiver<Batch<RequestT, ResponseT>> receiver;
+  private final BatchingFlowController<RequestT> flowController;
+
+  private final ReentrantLock lock = new ReentrantLock();
+
+  private RequestBuilder<RequestT> requestBuilder;
+  final BatchingDescriptor<RequestT, ResponseT> descriptor;
+  final UnaryCallable<RequestT, ResponseT> innerCallable;
+  List<BatchedRequestIssuer<ResponseT>> requestIssuers = Lists.newArrayList();
+  long requestSize = 0;
+
+  private Future<?> currentAlarmFuture;
+
+
+  private Batcher(Builder<RequestT, ResponseT> builder) {
+    this.thresholds = Lists.newArrayList(builder.thresholds);
+    this.executor = builder.executor;
+    this.maxDelay = builder.maxDelay;
+    this.receiver = builder.receiver;
+    this.flowController = builder.flowController;
+    this.requestBuilder = builder.descriptor.getRequestBuilder();
+    this.descriptor = builder.descriptor;
+    this.innerCallable = builder.innerCallable;
+
+    resetThresholds();
   }
 
+  /** Builder for a Batcher. */
+  public static class Builder<RequestT, ResponseT> {
+    private Collection<BatchingThreshold<RequestT>> thresholds;
+    private ScheduledExecutorService executor;
+    private Duration maxDelay;
+    private ThresholdBatchReceiver<Batch<RequestT, ResponseT>> receiver;
+    private BatchingFlowController<RequestT> flowController;
+
+    private BatchingDescriptor<RequestT, ResponseT> descriptor;
+    private UnaryCallable<RequestT, ResponseT> innerCallable;
+
+    private Builder() {}
+
+    /** Set the executor for the ThresholdBatcher. */
+    public Builder<RequestT, ResponseT> setExecutor(ScheduledExecutorService executor) {
+      this.executor = executor;
+      return this;
+    }
+
+    /** Set the max delay for a batch. This is counted from the first item added to a batch. */
+    public Builder<RequestT, ResponseT> setMaxDelay(Duration maxDelay) {
+      this.maxDelay = maxDelay;
+      return this;
+    }
+
+    /** Set the thresholds for the ThresholdBatcher. */
+    public Builder<RequestT, ResponseT> setThresholds(Collection<BatchingThreshold<RequestT>> thresholds) {
+      this.thresholds = Lists.newArrayList(thresholds);
+      return this;
+    }
+
+    /** Set the threshold batch receiver for the ThresholdBatcher. */
+    public Builder<RequestT, ResponseT> setReceiver(ThresholdBatchReceiver<Batch<RequestT, ResponseT>> receiver) {
+      this.receiver = receiver;
+      return this;
+    }
+
+    /** Set the flow controller for the ThresholdBatcher. */
+    public Builder<RequestT, ResponseT> setFlowController(BatchingFlowController<RequestT> flowController) {
+      this.flowController = flowController;
+      return this;
+    }
+
+    public Builder<RequestT, ResponseT> setDescriptor(BatchingDescriptor<RequestT, ResponseT> descriptor) {
+      this.descriptor = descriptor;
+      return this;
+    }
+
+    public Builder<RequestT, ResponseT> setInnerCallable(UnaryCallable<RequestT, ResponseT> innerCallable) {
+      this.innerCallable = innerCallable;
+      return this;
+    }
+
+    /** Build the ThresholdBatcher. */
+    public Batcher<RequestT, ResponseT> build() {
+      return new Batcher<>(this);
+    }
+  }
+
+    /** Get a new builder for a Batcher. */
+  public static <RequestT, ResponseT> Builder<RequestT, ResponseT> newBuilder() {
+    return new Builder<>();
+  }
+
+  /**
+   * Adds an element to the batcher. If the element causes the collection to go past any of the
+   * thresholds, the batch will be sent to the {@code ThresholdBatchReceiver}.
+   */
   public ApiFuture<ResponseT> add(RequestT r) throws FlowControlException {
     // We need to reserve resources from flowController outside the lock, so that they can be
     // released by pushCurrentBatch().
@@ -107,10 +192,17 @@ public class Batcher<RequestT, ResponseT> {
       requestIssuers.add(new BatchedRequestIssuer<>(future, descriptor.countElements(r)));
       requestSize += descriptor.countBytes(r);
 
-      if (!anyThresholdReached && currentAlarmFuture == null) {
-        currentAlarmFuture =
-            executor.schedule(pushCurrentBatchRunnable, maxDelay.toMillis(), TimeUnit.MILLISECONDS);
-      } else if (anyThresholdReached) {
+      if (currentAlarmFuture == null) {
+        // Schedule a job only when no thresholds have been exceeded, otherwise it will be
+        // immediately cancelled
+        if (!anyThresholdReached) {
+          currentAlarmFuture =
+              executor.schedule(
+                  pushCurrentBatchRunnable, maxDelay.toMillis(), TimeUnit.MILLISECONDS);
+        }
+      }
+
+      if (anyThresholdReached) {
         pushCurrentBatch();
       }
 
@@ -120,6 +212,26 @@ public class Batcher<RequestT, ResponseT> {
     }
   }
 
+  /** * Package-private for use in testing. */
+  @VisibleForTesting
+  boolean isEmpty() {
+    lock.lock();
+    try {
+      return requestSize == 0;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * Push the current batch to the batch receiver. Returns an ApiFuture that completes once the
+   * batch has been processed by the batch receiver and the flow controller resources have been
+   * released.
+   *
+   * <p>Note that this future can complete for the current batch before previous batches have
+   * completed, so it cannot be depended upon for flushing.
+   */
+  @VisibleForTesting
   public ApiFuture<Void> pushCurrentBatch() {
     final Batch<RequestT, ResponseT> batch = removeBatch();
     if (batch == null) {
@@ -131,20 +243,26 @@ public class Batcher<RequestT, ResponseT> {
   }
 
   private Batch<RequestT, ResponseT> removeBatch() {
-    RequestT request = requestBuilder.build();
-    if (currentAlarmFuture != null) {
-      currentAlarmFuture.cancel(false);
-      currentAlarmFuture = null;
+    lock.lock();
+    try {
+      RequestT request = requestBuilder.build();
+      if (currentAlarmFuture != null) {
+        currentAlarmFuture.cancel(false);
+        currentAlarmFuture = null;
+      }
+
+      requestBuilder = descriptor.getRequestBuilder();
+      resetThresholds();
+
+      Batch<RequestT, ResponseT> batch =
+          new Batch<>(request, requestIssuers, innerCallable, requestSize);
+      requestSize = 0;
+      requestIssuers = Lists.newArrayList();
+      resetThresholds();
+      return batch;
+    } finally {
+      lock.unlock();
     }
-
-    requestBuilder = descriptor.getRequestBuilder();
-    resetThresholds();
-
-    Batch<RequestT, ResponseT> batch =
-        new Batch<>(request, requestIssuers, innerCallable, requestSize);
-    requestSize = 0;
-    requestIssuers = Lists.newArrayList();
-    return batch;
   }
 
   private boolean isAnyThresholdReached(RequestT e) {
@@ -160,20 +278,6 @@ public class Batcher<RequestT, ResponseT> {
   private void resetThresholds() {
     for (int i = 0; i < thresholds.size(); i++) {
       thresholds.set(i, thresholds.get(i).copyWithZeroedValue());
-    }
-  }
-
-  private class ReleaseResourcesFunction<T> implements ApiFunction<T, Void> {
-    private final RequestT request;
-
-    private ReleaseResourcesFunction(RequestT request) {
-      this.request = request;
-    }
-
-    @Override
-    public Void apply(T input) {
-      flowController.release(request);
-      return null;
     }
   }
 }

--- a/benchmark/src/jmh/java/com/google/api/gax/grpc/batching/Batcher.java
+++ b/benchmark/src/jmh/java/com/google/api/gax/grpc/batching/Batcher.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2018, Google LLC All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.grpc.batching;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.batching.BatchingFlowController;
+import com.google.api.gax.batching.BatchingThreshold;
+import com.google.api.gax.batching.FlowController.FlowControlException;
+import com.google.api.gax.batching.RequestBuilder;
+import com.google.api.gax.batching.ThresholdBatchReceiver;
+import com.google.api.gax.rpc.Batch;
+import com.google.api.gax.rpc.BatchedFuture;
+import com.google.api.gax.rpc.BatchedRequestIssuer;
+import com.google.api.gax.rpc.BatchingDescriptor;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import org.threeten.bp.Duration;
+
+public class Batcher<RequestT, ResponseT> {
+  final BatchingDescriptor<RequestT, ResponseT> descriptor;
+  final UnaryCallable<RequestT, ResponseT> innerCallable;
+
+  private final ArrayList<BatchingThreshold<RequestT>> thresholds;
+  private final ScheduledExecutorService executor;
+  private final Duration maxDelay;
+  private final ThresholdBatchReceiver<Batch<RequestT, ResponseT>> receiver;
+  private final BatchingFlowController<RequestT> flowController;
+
+  private final ReentrantLock lock = new ReentrantLock();
+  private RequestBuilder<RequestT> requestBuilder;
+  private Future<?> currentAlarmFuture;
+
+  List<BatchedRequestIssuer<ResponseT>> requestIssuers = Lists.newArrayList();
+  long requestSize = 0;
+
+  private final Runnable pushCurrentBatchRunnable =
+      new Runnable() {
+        @Override
+        public void run() {
+          pushCurrentBatch();
+        }
+      };
+
+  public Batcher(
+      BatchingDescriptor<RequestT, ResponseT> descriptor,
+      UnaryCallable<RequestT, ResponseT> innerCallable,
+      ArrayList<BatchingThreshold<RequestT>> thresholds,
+      ScheduledExecutorService executor,
+      Duration maxDelay,
+      ThresholdBatchReceiver<Batch<RequestT, ResponseT>> receiver,
+      BatchingFlowController<RequestT> flowController) {
+    this.descriptor = descriptor;
+    this.innerCallable = innerCallable;
+    this.thresholds = thresholds;
+    this.executor = executor;
+    this.maxDelay = maxDelay;
+    this.receiver = receiver;
+    this.flowController = flowController;
+    this.requestBuilder = descriptor.getRequestBuilder();
+  }
+
+  public ApiFuture<ResponseT> add(RequestT r) throws FlowControlException {
+    // We need to reserve resources from flowController outside the lock, so that they can be
+    // released by pushCurrentBatch().
+    flowController.reserve(r);
+    lock.lock();
+    try {
+      boolean anyThresholdReached = isAnyThresholdReached(r);
+
+      requestBuilder.appendRequest(r);
+      BatchedFuture<ResponseT> future = new BatchedFuture<>();
+      requestIssuers.add(new BatchedRequestIssuer<>(future, descriptor.countElements(r)));
+      requestSize += descriptor.countBytes(r);
+
+      if (!anyThresholdReached && currentAlarmFuture == null) {
+        currentAlarmFuture =
+            executor.schedule(pushCurrentBatchRunnable, maxDelay.toMillis(), TimeUnit.MILLISECONDS);
+      } else if (anyThresholdReached) {
+        pushCurrentBatch();
+      }
+
+      return future;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  public ApiFuture<Void> pushCurrentBatch() {
+    final Batch<RequestT, ResponseT> batch = removeBatch();
+    if (batch == null) {
+      return ApiFutures.immediateFuture(null);
+    } else {
+      return ApiFutures.transform(
+          receiver.processBatch(batch), new ReleaseResourcesFunction<>(batch.getRequest()));
+    }
+  }
+
+  private Batch<RequestT, ResponseT> removeBatch() {
+    RequestT request = requestBuilder.build();
+    if (currentAlarmFuture != null) {
+      currentAlarmFuture.cancel(false);
+      currentAlarmFuture = null;
+    }
+
+    requestBuilder = descriptor.getRequestBuilder();
+    resetThresholds();
+
+    Batch<RequestT, ResponseT> batch =
+        new Batch<>(request, requestIssuers, innerCallable, requestSize);
+    requestSize = 0;
+    requestIssuers = Lists.newArrayList();
+    return batch;
+  }
+
+  private boolean isAnyThresholdReached(RequestT e) {
+    for (BatchingThreshold<RequestT> threshold : thresholds) {
+      threshold.accumulate(e);
+      if (threshold.isThresholdReached()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void resetThresholds() {
+    for (int i = 0; i < thresholds.size(); i++) {
+      thresholds.set(i, thresholds.get(i).copyWithZeroedValue());
+    }
+  }
+
+  private class ReleaseResourcesFunction<T> implements ApiFunction<T, Void> {
+    private final RequestT request;
+
+    private ReleaseResourcesFunction(RequestT request) {
+      this.request = request;
+    }
+
+    @Override
+    public Void apply(T input) {
+      flowController.release(request);
+      return null;
+    }
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/Batch.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Batch.java
@@ -56,6 +56,24 @@ public class Batch<RequestT, ResponseT> {
   private UnaryCallable<RequestT, ResponseT> callable;
   private long byteCount;
 
+  public Batch(final RequestT request, List<BatchedRequestIssuer<ResponseT>> requestIssuerList, UnaryCallable<RequestT, ResponseT> callable, long byteCount) {
+    requestBuilder = new RequestBuilder<RequestT>() {
+      @Override
+      public void appendRequest(RequestT request) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public RequestT build() {
+        return request;
+      }
+    };
+
+    this.requestIssuerList =requestIssuerList;
+    this.callable = callable;
+    this.byteCount = byteCount;
+  }
+
   public Batch(
       BatchingDescriptor<RequestT, ResponseT> descriptor,
       RequestT request,

--- a/gax/src/main/java/com/google/api/gax/rpc/BatchExecutor.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/BatchExecutor.java
@@ -48,7 +48,7 @@ import java.util.List;
  *
  * <p>Package-private for internal use.
  */
-class BatchExecutor<RequestT, ResponseT>
+public class BatchExecutor<RequestT, ResponseT>
     implements ThresholdBatchReceiver<Batch<RequestT, ResponseT>> {
 
   private final BatchingDescriptor<RequestT, ResponseT> batchingDescriptor;


### PR DESCRIPTION
I'm starting to work on bigtable batching, which will need flushing support. Which (I think) will entail exposing a lower level api.  I think that `ThresholdBatcher`s (or something in the same spirit) will have be exposed.  After reading @pongad's exploration in https://github.com/GoogleCloudPlatform/google-cloud-java/pull/2910, I wanted to write some benchmarks to identify the bottlenecks he found and to gain a better understanding of the existing batching infrastructure. 

Preliminary analysis seems to indicate that merging individual requests has a high cost associated with it.

I figured I'd post this in hopes it helping @pongad in his efforts with batching for logging

Edit:
I should point out that I'm mainly benchmarking single thread writers using netty over a loopback. I'm also only using element count threshold & flow control to keep the code simple