### PR TITLE
Revert "Update the ResumptionStrategy interface to allow it to modify the incoming response stream. 

### DIFF
--- a/gax/src/main/java/com/google/api/gax/retrying/SimpleStreamResumptionStrategy.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/SimpleStreamResumptionStrategy.java
@@ -47,9 +47,8 @@ public final class SimpleStreamResumptionStrategy<RequestT, ResponseT>
   }
 
   @Override
-  public ResponseT processResponse(ResponseT response) {
+  public void onProgress(ResponseT response) {
     seenFirstResponse = true;
-    return response;
   }
 
   @Override

--- a/gax/src/main/java/com/google/api/gax/retrying/StreamResumptionStrategy.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/StreamResumptionStrategy.java
@@ -30,8 +30,6 @@
 package com.google.api.gax.retrying;
 
 import com.google.api.core.BetaApi;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * This is part of the server streaming retry api. Its implementers are responsible for tracking the
@@ -43,34 +41,21 @@ import javax.annotation.Nullable;
 public interface StreamResumptionStrategy<RequestT, ResponseT> {
 
   /** Creates a new instance of this StreamResumptionStrategy without accumulated state */
-  @Nonnull
   StreamResumptionStrategy<RequestT, ResponseT> createNew();
 
   /**
    * Called by the {@code ServerStreamingAttemptCallable} when a response has been successfully
-   * received. This method accomplishes two goals:
-   *
-   * <ol>
-   *   <li>It allows the strategy implementation to update its internal state so that it can compose
-   *       the resume request
-   *   <li>It allows the strategy to alter the incoming responses to adjust for after resume. For
-   *       example, if the responses are numbered sequentially from the start of the stream, upon
-   *       resume, the strategy could rewrite the messages to continue the sequence from where it
-   *       left off. Please note that all messages (even for the first attempt) will be passed
-   *       through this method.
-   * </ol>
+   * received.
    */
-  @Nonnull
-  ResponseT processResponse(ResponseT response);
+  void onProgress(ResponseT response);
 
   /**
    * Called when a stream needs to be restarted, the implementation should generate a request that
    * will yield a new stream whose first response would come right after the last response received
-   * by processResponse.
+   * by onProgress.
    *
    * @return A request that can be used to resume the stream.
    */
-  @Nullable
   RequestT getResumeRequest(RequestT originalRequest);
 
   /** If a resume request can be created. */

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
@@ -344,7 +344,7 @@ final class ServerStreamingAttemptCallable<RequestT, ResponseT> implements Calla
     }
     // Update local state to allow for future resume.
     seenSuccessSinceLastError = true;
-    message = resumptionStrategy.processResponse(message);
+    resumptionStrategy.onProgress(message);
     // Notify the outer observer.
     outerObserver.onResponse(message);
   }

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingAttemptCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingAttemptCallableTest.java
@@ -291,40 +291,6 @@ public class ServerStreamingAttemptCallableTest {
         .isTrue();
   }
 
-  @Test
-  public void testResponseSubstitution() {
-    resumptionStrategy =
-        new MyStreamResumptionStrategy() {
-          @Override
-          public String processResponse(String response) {
-            return super.processResponse(response) + "+suffix";
-          }
-        };
-
-    observer = new AccumulatingObserver(false);
-    ServerStreamingAttemptCallable<String, String> callable = createCallable();
-    callable.start();
-
-    MockServerStreamingCall<String, String> call = innerCallable.popLastCall();
-
-    // Send initial response & then error
-    call.getController().getObserver().onResponse("first");
-    call.getController().getObserver().onError(new FakeApiException(null, Code.UNAVAILABLE, true));
-
-    // Make the retry call
-    callable.call();
-    call = innerCallable.popLastCall();
-
-    // Send another couple of responses (the first one will be ignored)
-    call.getController().getObserver().onResponse("second");
-    call.getController().getObserver().onResponse("third");
-    call.getController().getObserver().onComplete();
-
-    // Verify the request and send a response
-    Truth.assertThat(observer.responses)
-        .containsExactly("first+suffix", "second+suffix", "third+suffix");
-  }
-
   static class MyStreamResumptionStrategy implements StreamResumptionStrategy<String, String> {
     private int responseCount;
 
@@ -334,9 +300,8 @@ public class ServerStreamingAttemptCallableTest {
     }
 
     @Override
-    public String processResponse(String response) {
+    public void onProgress(String response) {
       responseCount++;
-      return response;
     }
 
     @Override


### PR DESCRIPTION
I apologize for the noise,  I thought I could use this functionality for batching in https://github.com/GoogleCloudPlatform/google-cloud-java/pull/3026, but turns out I was wrong and had to implement a custom attempt callable regardless.

I still think this functionality (along with response suppression) can be useful for spanner, but I figured I'd revert it until it is actually needed.