### PR TITLE
Batching - allow null entries

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/BatchedRequestIssuer.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/BatchedRequestIssuer.java
@@ -43,6 +43,7 @@ public final class BatchedRequestIssuer<ResponseT> {
   private final BatchedFuture<ResponseT> batchedFuture;
   private final long messageCount;
   private ResponseT responseToSend;
+  private boolean hasResponse;
   private Throwable throwableToSend;
 
   public BatchedRequestIssuer(BatchedFuture<ResponseT> batchedFuture, long messageCount) {
@@ -62,6 +63,7 @@ public final class BatchedRequestIssuer<ResponseT> {
    */
   public void setResponse(ResponseT response) {
     Preconditions.checkState(throwableToSend == null, "Cannot set both exception and response");
+    hasResponse = true;
     responseToSend = response;
   }
 
@@ -70,13 +72,13 @@ public final class BatchedRequestIssuer<ResponseT> {
    * called.
    */
   public void setException(Throwable throwable) {
-    Preconditions.checkState(responseToSend == null, "Cannot set both exception and response");
+    Preconditions.checkState(!hasResponse, "Cannot set both exception and response");
     throwableToSend = throwable;
   }
 
   /** Sends back the result that was stored by either setResponse or setException */
   public void sendResult() {
-    if (responseToSend != null) {
+    if (hasResponse) {
       batchedFuture.set(responseToSend);
     } else if (throwableToSend != null) {
       batchedFuture.setException(throwableToSend);

--- a/gax/src/test/java/com/google/api/gax/rpc/BatchedRequestIssuerTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/BatchedRequestIssuerTest.java
@@ -54,6 +54,19 @@ public class BatchedRequestIssuerTest {
   }
 
   @Test
+  public void testNullResult() throws Exception {
+    BatchedFuture<Integer> batchedFuture = BatchedFuture.<Integer>create();
+    BatchedRequestIssuer<Integer> issuer = new BatchedRequestIssuer<>(batchedFuture, 2);
+    issuer.setResponse(null);
+
+    Truth.assertThat(batchedFuture.isDone()).isFalse();
+    issuer.sendResult();
+
+    Truth.assertThat(batchedFuture.isDone()).isTrue();
+    Truth.assertThat(batchedFuture.get()).isNull();
+  }
+
+  @Test
   public void testException() throws Exception {
     Exception thrownException = new IllegalArgumentException("bad!");
 


### PR DESCRIPTION
This came out of working on https://github.com/GoogleCloudPlatform/google-cloud-java/pull/3026.

A Bigtable `MutateRowsResponse` contains a list of entries. Each entry simply contains a `Status` indicating if that entry succeeded or failed. Since the user only cares if the entry failed, the most useful type signature for a `BatchingCallable` representing the RPC would be `BatchingCallable<MutateRowsRequest, Void>`. 

Unfortunately,  `BatchedRequestIssuer` treats `null` response as absent. This PR adds an explicit `hasResponse` flag to check for missing responses, which allows for null responses for `Void` entries