### PR TITLE
Implement extraHeaders for gax-grpc and gax-httpjson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ subprojects {
         // Testing
         junit: 'junit:junit:4.11',
         mockito: 'org.mockito:mockito-core:1.10.19',
-        truth: 'com.google.truth:truth:0.27',
+        truth: 'com.google.truth:truth:0.39',
         commons: 'org.apache.commons:commons-lang3:3.4',
         commonProtosGrpc: "com.google.api.grpc:grpc-google-common-protos:${commonProtosVersion}",
     ]

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -380,7 +380,7 @@ public final class GrpcCallContext implements ApiCallContext {
   @Override
   public int hashCode() {
     return Objects.hash(
-        channel, callOptions, streamWaitTimeout, streamIdleTimeout, channelAffinity);
+        channel, callOptions, streamWaitTimeout, streamIdleTimeout, channelAffinity, extraHeaders);
   }
 
   @Override

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -183,8 +183,12 @@ public final class GrpcCallContext implements ApiCallContext {
   }
 
   public GrpcCallContext withExtraHeaders(@Nullable Metadata extraHeaders) {
+    Metadata newExtraHeaders = new Metadata();
+    if (extraHeaders != null) {
+      newExtraHeaders.merge(extraHeaders);
+    }
     return new GrpcCallContext(
-        channel, callOptions, streamWaitTimeout, streamIdleTimeout, channelAffinity, extraHeaders);
+        channel, callOptions, streamWaitTimeout, streamIdleTimeout, channelAffinity, newExtraHeaders);
   }
 
   @Override
@@ -291,9 +295,15 @@ public final class GrpcCallContext implements ApiCallContext {
   /**
    * The extra header for this context.
    */
+  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nullable
   public Metadata getExtraHeaders() {
-    return extraHeaders;
+    if (this.extraHeaders == null) {
+      return null;
+    }
+    Metadata returnExtraHeaders = new Metadata();
+    returnExtraHeaders.merge(this.extraHeaders);
+    return returnExtraHeaders;
   }
 
   /** Returns a new instance with the channel set to the given channel. */
@@ -328,30 +338,5 @@ public final class GrpcCallContext implements ApiCallContext {
   @InternalApi("for testing")
   Deadline getDeadline() {
     return callOptions.getDeadline();
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    GrpcCallContext that = (GrpcCallContext) o;
-    return Objects.equals(channel, that.channel)
-        && Objects.equals(callOptions, that.callOptions)
-        && Objects.equals(streamWaitTimeout, that.streamWaitTimeout)
-        && Objects.equals(streamIdleTimeout, that.streamIdleTimeout)
-        && Objects.equals(channelAffinity, that.channelAffinity)
-        && Objects.equals(extraHeaders, that.extraHeaders);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        channel, callOptions, streamWaitTimeout, 
-        streamIdleTimeout, channelAffinity, extraHeaders);
   }
 }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -44,7 +44,6 @@ import io.grpc.Deadline;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.auth.MoreCallCredentials;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
@@ -177,18 +176,25 @@ public final class GrpcCallContext implements ApiCallContext {
         channel, callOptions, streamWaitTimeout, streamIdleTimeout, channelAffinity, extraHeaders);
   }
 
+  @BetaApi("The surface for channel affinity is not stable yet and may change in the future.")
   public GrpcCallContext withChannelAffinity(@Nullable Integer affinity) {
     return new GrpcCallContext(
         channel, callOptions, streamWaitTimeout, streamIdleTimeout, affinity, extraHeaders);
   }
 
+  @BetaApi("Ther surface for extra headers is not stable yet and may change in the future.")
   public GrpcCallContext withExtraHeaders(@Nullable Metadata extraHeaders) {
     Metadata newExtraHeaders = new Metadata();
     if (extraHeaders != null) {
       newExtraHeaders.merge(extraHeaders);
     }
     return new GrpcCallContext(
-        channel, callOptions, streamWaitTimeout, streamIdleTimeout, channelAffinity, newExtraHeaders);
+        channel,
+        callOptions,
+        streamWaitTimeout,
+        streamIdleTimeout,
+        channelAffinity,
+        newExtraHeaders);
   }
 
   @Override
@@ -245,8 +251,12 @@ public final class GrpcCallContext implements ApiCallContext {
             .withDeadline(newDeadline);
 
     return new GrpcCallContext(
-        newChannel, newCallOptions, newStreamWaitTimeout, 
-        newStreamIdleTimeout, newChannelAffinity, newExtraHeaders);
+        newChannel,
+        newCallOptions,
+        newStreamWaitTimeout,
+        newStreamIdleTimeout,
+        newChannelAffinity,
+        newExtraHeaders);
   }
 
   /** The {@link Channel} set on this context. */
@@ -281,21 +291,15 @@ public final class GrpcCallContext implements ApiCallContext {
     return streamIdleTimeout;
   }
 
-  /**
-   * The channel affinity for this context.
-   *
-   * @see ApiCallContext#withStreamIdleTimeout(Duration)
-   */
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+  /** The channel affinity for this context. */
+  @BetaApi("The surface for channel affinity is not stable yet and may change in the future.")
   @Nullable
   public Integer getChannelAffinity() {
     return channelAffinity;
   }
 
-  /**
-   * The extra header for this context.
-   */
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+  /** The extra header for this context. */
+  @BetaApi("The surface for extra headers is not stable yet and may change in the future.")
   @Nullable
   public Metadata getExtraHeaders() {
     if (this.extraHeaders == null) {

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -190,10 +190,11 @@ public final class GrpcCallContext implements ApiCallContext {
 
   @Override
   public GrpcCallContext withExtraHeaders(@Nullable Map<String, List<String>> extraHeaders) {
-    ImmutableListMultimap.Builder<String, String> newExtraHeadersBuilder = ImmutableListMultimap.builder();
+    ImmutableListMultimap.Builder<String, String> newExtraHeadersBuilder =
+        ImmutableListMultimap.builder();
     if (extraHeaders != null) {
       for (Map.Entry<String, List<String>> extraHeader : extraHeaders.entrySet()) {
-        newExtraHeadersBuilder.putAll(extraHeader.getKey(), extraHeader.getValue());  
+        newExtraHeadersBuilder.putAll(extraHeader.getKey(), extraHeader.getValue());
       }
     }
     if (this.extraHeaders != null) {
@@ -251,7 +252,7 @@ public final class GrpcCallContext implements ApiCallContext {
       newChannelAffinity = this.channelAffinity;
     }
 
-    ImmutableListMultimap.Builder<String, String> newExtraHeadersBuilder = 
+    ImmutableListMultimap.Builder<String, String> newExtraHeadersBuilder =
         ImmutableListMultimap.builder();
     if (grpcCallContext.extraHeaders != null) {
       newExtraHeadersBuilder.putAll(grpcCallContext.extraHeaders);
@@ -361,8 +362,8 @@ public final class GrpcCallContext implements ApiCallContext {
     Metadata metadata = new Metadata();
     if (this.extraHeaders != null) {
       for (Map.Entry<String, String> header : extraHeaders.entries()) {
-        metadata.put(Metadata.Key.of(header.getKey(), Metadata.ASCII_STRING_MARSHALLER),
-                     header.getValue());
+        metadata.put(
+            Metadata.Key.of(header.getKey(), Metadata.ASCII_STRING_MARSHALLER), header.getValue());
       }
     }
     return metadata;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -188,6 +188,7 @@ public final class GrpcCallContext implements ApiCallContext {
         channel, callOptions, streamWaitTimeout, streamIdleTimeout, affinity, extraHeaders);
   }
 
+  @BetaApi("The surface for extra headers is not stable yet and may change in the future.")
   @Override
   public GrpcCallContext withExtraHeaders(@Nullable Map<String, List<String>> extraHeaders) {
     ImmutableListMultimap.Builder<String, String> newExtraHeadersBuilder =

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcClientCalls.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcClientCalls.java
@@ -66,7 +66,7 @@ class GrpcClientCalls {
       channel = ((ChannelPool) channel).getChannel(grpcContext.getChannelAffinity());
     }
 
-    if (grpcContext.getExtraHeaders() != null && !grpcContext.getExtraHeaders().isEmpty()) {
+    if (!grpcContext.getExtraHeaders().isEmpty()) {
       ClientInterceptor interceptor =
           MetadataUtils.newAttachHeadersInterceptor(grpcContext.getMetadata());
       channel = ClientInterceptors.intercept(channel, interceptor);

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcClientCalls.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcClientCalls.java
@@ -34,7 +34,10 @@ import com.google.api.gax.rpc.ApiCallContext;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
 import io.grpc.MethodDescriptor;
+import io.grpc.stub.MetadataUtils;
 
 /**
  * {@code GrpcClientCalls} creates a new {@code ClientCall} from the given call context.
@@ -61,6 +64,11 @@ class GrpcClientCalls {
     Channel channel = grpcContext.getChannel();
     if (grpcContext.getChannelAffinity() != null && channel instanceof ChannelPool) {
       channel = ((ChannelPool) channel).getChannel(grpcContext.getChannelAffinity());
+    }
+
+    if (grpcContext.getExtraHeaders() != null) {
+      ClientInterceptor interceptor = MetadataUtils.newAttachHeadersInterceptor(grpcContext.getExtraHeaders());
+      channel = ClientInterceptors.intercept(channel, interceptor);
     }
 
     return channel.newCall(descriptor, callOptions);

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcClientCalls.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcClientCalls.java
@@ -67,7 +67,8 @@ class GrpcClientCalls {
     }
 
     if (grpcContext.getExtraHeaders() != null) {
-      ClientInterceptor interceptor = MetadataUtils.newAttachHeadersInterceptor(grpcContext.getExtraHeaders());
+      ClientInterceptor interceptor =
+          MetadataUtils.newAttachHeadersInterceptor(grpcContext.getExtraHeaders());
       channel = ClientInterceptors.intercept(channel, interceptor);
     }
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcClientCalls.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcClientCalls.java
@@ -66,9 +66,9 @@ class GrpcClientCalls {
       channel = ((ChannelPool) channel).getChannel(grpcContext.getChannelAffinity());
     }
 
-    if (grpcContext.getExtraHeaders() != null) {
+    if (grpcContext.getExtraHeaders() != null && !grpcContext.getExtraHeaders().isEmpty()) {
       ClientInterceptor interceptor =
-          MetadataUtils.newAttachHeadersInterceptor(grpcContext.getExtraHeaders());
+          MetadataUtils.newAttachHeadersInterceptor(grpcContext.getMetadata());
       channel = ClientInterceptors.intercept(channel, interceptor);
     }
 

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -222,7 +222,7 @@ public class GrpcCallContextTest {
         "metadata-header-2", Metadata.ASCII_STRING_MARSHALLER), "metadata-value-2");
     GrpcCallContext ctx1 = GrpcCallContext.createDefault();
     GrpcCallContext ctx2 = ctx1.withExtraHeaders(extraHeaders);
-    Truth.assertThat(ctx2.getExtraHeaders()).isEqualTo(extraHeaders);
+    Truth.assertThat(ctx2.getExtraHeaders().toString()).isEqualTo(extraHeaders.toString());
   }
 
   @Test
@@ -237,6 +237,7 @@ public class GrpcCallContextTest {
     ApiCallContext mergedApiCallContext = ctx1.merge(ctx2);
     Truth.assertThat(mergedApiCallContext).isInstanceOf(GrpcCallContext.class);
     GrpcCallContext mergedGrpcCallContext = (GrpcCallContext)mergedApiCallContext;
-    Truth.assertThat(mergedGrpcCallContext.getExtraHeaders()).isEqualTo(extraHeaders);
+    Truth.assertThat(mergedGrpcCallContext.getExtraHeaders().toString())
+        .isEqualTo(extraHeaders.toString());
   }
 }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -42,7 +42,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.truth.Truth;
 import io.grpc.CallOptions;
 import io.grpc.ManagedChannel;
-import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
 import java.util.HashMap;
 import java.util.List;
@@ -223,10 +222,11 @@ public class GrpcCallContextTest {
     ctx = ctx.withExtraHeaders(extraHeaders);
     Map<String, List<String>> gotExtraHeaders = ctx.getExtraHeaders();
     Truth.assertThat(gotExtraHeaders).isNotSameAs(extraHeaders);
-    Truth.assertThat(gotExtraHeaders).
-        containsEntry("header-key-1", ImmutableList.<String>of("header-value-11", "header-value-12"));
-    Truth.assertThat(gotExtraHeaders).
-        containsEntry("header-key-2", ImmutableList.<String>of("header-value-21"));
+    Truth.assertThat(gotExtraHeaders)
+        .containsEntry(
+            "header-key-1", ImmutableList.<String>of("header-value-11", "header-value-12"));
+    Truth.assertThat(gotExtraHeaders)
+        .containsEntry("header-key-2", ImmutableList.<String>of("header-value-21"));
   }
 
   @Test
@@ -237,15 +237,17 @@ public class GrpcCallContextTest {
     ApiCallContext mergedApiCallContext = ctx1.merge(ctx2);
     Truth.assertThat(mergedApiCallContext).isInstanceOf(GrpcCallContext.class);
     GrpcCallContext mergedGrpcCallContext = (GrpcCallContext) mergedApiCallContext;
-    Truth.assertThat(mergedGrpcCallContext.getExtraHeaders()).
-        containsEntry("header-key-1", ImmutableList.<String>of("header-value-11", "header-value-12"));
-    Truth.assertThat(mergedGrpcCallContext.getExtraHeaders()).
-        containsEntry("header-key-2", ImmutableList.<String>of("header-value-21"));
+    Truth.assertThat(mergedGrpcCallContext.getExtraHeaders())
+        .containsEntry(
+            "header-key-1", ImmutableList.<String>of("header-value-11", "header-value-12"));
+    Truth.assertThat(mergedGrpcCallContext.getExtraHeaders())
+        .containsEntry("header-key-2", ImmutableList.<String>of("header-value-21"));
   }
 
   private static Map<String, List<String>> createTestExtraHeaders() {
     Map<String, List<String>> extraHeaders = new HashMap<>();
-    extraHeaders.put("header-key-1", ImmutableList.<String>of("header-value-11", "header-value-12"));
+    extraHeaders.put(
+        "header-key-1", ImmutableList.<String>of("header-value-11", "header-value-12"));
     extraHeaders.put("header-key-2", ImmutableList.<String>of("header-value-21"));
     return extraHeaders;
   }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -231,15 +231,6 @@ public class GrpcCallContextTest {
   }
 
   @Test
-  public void testWithEmptyExtraHeaders() {
-    Map<String, List<String>> extraHeaders = createTestExtraHeaders();
-    GrpcCallContext ctx = GrpcCallContext.createDefault();
-    ctx = ctx.withExtraHeaders(extraHeaders);
-    ctx = ctx.withEmptyExtraHeaders();
-    Truth.assertThat(ctx.getExtraHeaders()).isEmpty();
-  }
-
-  @Test
   public void testMergeWithExtraHeaders() {
     Map<String, List<String>> extraHeaders1 =
         createTestExtraHeaders("key1", "value1", "key1", "value2");

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -216,10 +216,10 @@ public class GrpcCallContextTest {
   @Test
   public void testWithExtraHeaders() {
     Metadata extraHeaders = new Metadata();
-    extraHeaders.put(Metadata.Key.of(
-        "metadata-header-1", Metadata.ASCII_STRING_MARSHALLER), "metadata-value-1");
-    extraHeaders.put(Metadata.Key.of(
-        "metadata-header-2", Metadata.ASCII_STRING_MARSHALLER), "metadata-value-2");
+    extraHeaders.put(
+        Metadata.Key.of("metadata-header-1", Metadata.ASCII_STRING_MARSHALLER), "metadata-value-1");
+    extraHeaders.put(
+        Metadata.Key.of("metadata-header-2", Metadata.ASCII_STRING_MARSHALLER), "metadata-value-2");
     GrpcCallContext ctx1 = GrpcCallContext.createDefault();
     GrpcCallContext ctx2 = ctx1.withExtraHeaders(extraHeaders);
     Truth.assertThat(ctx2.getExtraHeaders().toString()).isEqualTo(extraHeaders.toString());
@@ -228,15 +228,15 @@ public class GrpcCallContextTest {
   @Test
   public void testMergeWithExtraHeaders() {
     Metadata extraHeaders = new Metadata();
-    extraHeaders.put(Metadata.Key.of(
-        "metadata-header-1", Metadata.ASCII_STRING_MARSHALLER), "metadata-value-1");
-    extraHeaders.put(Metadata.Key.of(
-        "metadata-header-2", Metadata.ASCII_STRING_MARSHALLER), "metadata-value-2");
+    extraHeaders.put(
+        Metadata.Key.of("metadata-header-1", Metadata.ASCII_STRING_MARSHALLER), "metadata-value-1");
+    extraHeaders.put(
+        Metadata.Key.of("metadata-header-2", Metadata.ASCII_STRING_MARSHALLER), "metadata-value-2");
     GrpcCallContext ctx1 = GrpcCallContext.createDefault();
     GrpcCallContext ctx2 = GrpcCallContext.createDefault().withExtraHeaders(extraHeaders);
     ApiCallContext mergedApiCallContext = ctx1.merge(ctx2);
     Truth.assertThat(mergedApiCallContext).isInstanceOf(GrpcCallContext.class);
-    GrpcCallContext mergedGrpcCallContext = (GrpcCallContext)mergedApiCallContext;
+    GrpcCallContext mergedGrpcCallContext = (GrpcCallContext) mergedApiCallContext;
     Truth.assertThat(mergedGrpcCallContext.getExtraHeaders().toString())
         .isEqualTo(extraHeaders.toString());
   }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -222,11 +222,7 @@ public class GrpcCallContextTest {
     ctx = ctx.withExtraHeaders(extraHeaders);
     Map<String, List<String>> gotExtraHeaders = ctx.getExtraHeaders();
     Truth.assertThat(gotExtraHeaders).isNotSameAs(extraHeaders);
-    Truth.assertThat(gotExtraHeaders)
-        .containsEntry(
-            "header-key-1", ImmutableList.<String>of("header-value-11", "header-value-12"));
-    Truth.assertThat(gotExtraHeaders)
-        .containsEntry("header-key-2", ImmutableList.<String>of("header-value-21"));
+    Truth.assertThat(gotExtraHeaders).containsExactlyEntriesIn(extraHeaders);
   }
 
   @Test
@@ -237,11 +233,9 @@ public class GrpcCallContextTest {
     ApiCallContext mergedApiCallContext = ctx1.merge(ctx2);
     Truth.assertThat(mergedApiCallContext).isInstanceOf(GrpcCallContext.class);
     GrpcCallContext mergedGrpcCallContext = (GrpcCallContext) mergedApiCallContext;
-    Truth.assertThat(mergedGrpcCallContext.getExtraHeaders())
-        .containsEntry(
-            "header-key-1", ImmutableList.<String>of("header-value-11", "header-value-12"));
-    Truth.assertThat(mergedGrpcCallContext.getExtraHeaders())
-        .containsEntry("header-key-2", ImmutableList.<String>of("header-value-21"));
+    Map<String, List<String>> gotExtraHeaders = mergedGrpcCallContext.getExtraHeaders();
+    Truth.assertThat(gotExtraHeaders).isNotSameAs(extraHeaders);
+    Truth.assertThat(gotExtraHeaders).containsExactlyEntriesIn(extraHeaders);
   }
 
   private static Map<String, List<String>> createTestExtraHeaders() {

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -31,6 +31,7 @@ package com.google.api.gax.grpc;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.DeadlineExceededException;
 import com.google.api.gax.rpc.testing.FakeCallContext;
 import com.google.api.gax.rpc.testing.FakeChannel;
@@ -40,6 +41,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.truth.Truth;
 import io.grpc.CallOptions;
 import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
 import java.util.Map;
 import org.junit.Rule;
@@ -209,5 +211,32 @@ public class GrpcCallContextTest {
         .isNotEqualTo(ctx1.getCallOptions().getOption(key));
     Truth.assertThat(merged.getCallOptions().getOption(key))
         .isEqualTo(ctx2.getCallOptions().getOption(key));
+  }
+
+  @Test
+  public void testWithExtraHeaders() {
+    Metadata extraHeaders = new Metadata();
+    extraHeaders.put(Metadata.Key.of(
+        "metadata-header-1", Metadata.ASCII_STRING_MARSHALLER), "metadata-value-1");
+    extraHeaders.put(Metadata.Key.of(
+        "metadata-header-2", Metadata.ASCII_STRING_MARSHALLER), "metadata-value-2");
+    GrpcCallContext ctx1 = GrpcCallContext.createDefault();
+    GrpcCallContext ctx2 = ctx1.withExtraHeaders(extraHeaders);
+    Truth.assertThat(ctx2.getExtraHeaders()).isEqualTo(extraHeaders);
+  }
+
+  @Test
+  public void testMergeWithExtraHeaders() {
+    Metadata extraHeaders = new Metadata();
+    extraHeaders.put(Metadata.Key.of(
+        "metadata-header-1", Metadata.ASCII_STRING_MARSHALLER), "metadata-value-1");
+    extraHeaders.put(Metadata.Key.of(
+        "metadata-header-2", Metadata.ASCII_STRING_MARSHALLER), "metadata-value-2");
+    GrpcCallContext ctx1 = GrpcCallContext.createDefault();
+    GrpcCallContext ctx2 = GrpcCallContext.createDefault().withExtraHeaders(extraHeaders);
+    ApiCallContext mergedApiCallContext = ctx1.merge(ctx2);
+    Truth.assertThat(mergedApiCallContext).isInstanceOf(GrpcCallContext.class);
+    GrpcCallContext mergedGrpcCallContext = (GrpcCallContext)mergedApiCallContext;
+    Truth.assertThat(mergedGrpcCallContext.getExtraHeaders()).isEqualTo(extraHeaders);
   }
 }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcClientCallsTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcClientCallsTest.java
@@ -84,35 +84,35 @@ public class GrpcClientCallsTest {
     Metadata emptyHeaders = new Metadata();
     final Metadata extraHeaders = new Metadata();
     extraHeaders.put(
-        Metadata.Key.of("metadata-header-1", Metadata.ASCII_STRING_MARSHALLER)
-        , "metadata-value-1");
+        Metadata.Key.of("metadata-header-1", Metadata.ASCII_STRING_MARSHALLER), "metadata-value-1");
 
     MethodDescriptor<Color, Money> descriptor = FakeServiceGrpc.METHOD_RECOGNIZE;
-    
+
     @SuppressWarnings("unchecked")
     ClientCall<Color, Money> mockClientCall = Mockito.mock(ClientCall.class);
-    
+
     @SuppressWarnings("unchecked")
     ClientCall.Listener<Money> mockListener = Mockito.mock(ClientCall.Listener.class);
 
     @SuppressWarnings("unchecked")
     Channel mockChannel = Mockito.mock(ManagedChannel.class);
 
-    Mockito.doAnswer(new Answer<Void>() {
-      public Void answer(InvocationOnMock invocation) {
-        Metadata clientCallHeaders = (Metadata) invocation.getArguments()[1];
-        assertThat(clientCallHeaders.toString()).isEqualTo(extraHeaders.toString());
-        return null;
-      }      
-    }).when(mockClientCall).start(
-        Mockito.<ClientCall.Listener<Money>>any(), 
-        Mockito.<Metadata>any());
+    Mockito.doAnswer(
+            new Answer<Void>() {
+              public Void answer(InvocationOnMock invocation) {
+                Metadata clientCallHeaders = (Metadata) invocation.getArguments()[1];
+                assertThat(clientCallHeaders.toString()).isEqualTo(extraHeaders.toString());
+                return null;
+              }
+            })
+        .when(mockClientCall)
+        .start(Mockito.<ClientCall.Listener<Money>>any(), Mockito.<Metadata>any());
 
     Mockito.when(mockChannel.newCall(Mockito.eq(descriptor), Mockito.<CallOptions>any()))
         .thenReturn(mockClientCall);
-    
-    GrpcCallContext context = GrpcCallContext.
-        createDefault().withChannel(mockChannel).withExtraHeaders(extraHeaders);
+
+    GrpcCallContext context =
+        GrpcCallContext.createDefault().withChannel(mockChannel).withExtraHeaders(extraHeaders);
     GrpcClientCalls.newCall(descriptor, context).start(mockListener, emptyHeaders);
   }
 }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcClientCallsTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcClientCallsTest.java
@@ -89,9 +89,8 @@ public class GrpcClientCallsTest {
     final Map<String, List<String>> extraHeaders = new HashMap<>();
     extraHeaders.put(
         "header-key-1", ImmutableList.<String>of("header-value-11", "header-value-12"));
-    extraHeaders.put(
-        "header-key-2", ImmutableList.<String>of("header-value-21"));
-    
+    extraHeaders.put("header-key-2", ImmutableList.<String>of("header-value-21"));
+
     MethodDescriptor<Color, Money> descriptor = FakeServiceGrpc.METHOD_RECOGNIZE;
 
     @SuppressWarnings("unchecked")
@@ -107,14 +106,13 @@ public class GrpcClientCallsTest {
             new Answer<Void>() {
               public Void answer(InvocationOnMock invocation) {
                 Metadata clientCallHeaders = (Metadata) invocation.getArguments()[1];
-                Metadata.Key<String> key1 = 
+                Metadata.Key<String> key1 =
                     Metadata.Key.of("header-key-1", Metadata.ASCII_STRING_MARSHALLER);
-                Metadata.Key<String> key2 = 
+                Metadata.Key<String> key2 =
                     Metadata.Key.of("header-key-2", Metadata.ASCII_STRING_MARSHALLER);
                 assertThat(clientCallHeaders.getAll(key1))
                     .containsExactly("header-value-11", "header-value-12");
-                assertThat(clientCallHeaders.getAll(key2))
-                    .containsExactly("header-value-21");
+                assertThat(clientCallHeaders.getAll(key2)).containsExactly("header-value-21");
                 return null;
               }
             })

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -76,7 +76,11 @@ public final class HttpJsonCallContext implements ApiCallContext {
     this.channel = channel;
     this.deadline = deadline;
     this.credentials = credentials;
-    this.extraHeaders = extraHeaders;
+    if (extraHeaders == null) {
+      this.extraHeaders = ImmutableListMultimap.<String, String>of();
+    } else {
+      this.extraHeaders = extraHeaders;
+    }
   }
 
   /**
@@ -133,9 +137,7 @@ public final class HttpJsonCallContext implements ApiCallContext {
     if (httpJsonCallContext.extraHeaders != null) {
       newExtraHeadersBuilder.putAll(httpJsonCallContext.extraHeaders);
     }
-    if (this.extraHeaders != null) {
-      newExtraHeadersBuilder.putAll(this.extraHeaders);
-    }
+    newExtraHeadersBuilder.putAll(this.extraHeaders);
     ImmutableListMultimap<String, String> newExtraHeaders = newExtraHeadersBuilder.build();
 
     return new HttpJsonCallContext(newChannel, newDeadline, newCredentials, newExtraHeaders);
@@ -203,9 +205,7 @@ public final class HttpJsonCallContext implements ApiCallContext {
         newExtraHeadersBuilder.putAll(extraHeader.getKey(), extraHeader.getValue());
       }
     }
-    if (this.extraHeaders != null) {
-      newExtraHeadersBuilder.putAll(this.extraHeaders);
-    }
+    newExtraHeadersBuilder.putAll(this.extraHeaders);
     ImmutableListMultimap<String, String> newExtraHeaders = newExtraHeadersBuilder.build();
     return new HttpJsonCallContext(this.channel, this.deadline, this.credentials, newExtraHeaders);
   }
@@ -214,10 +214,8 @@ public final class HttpJsonCallContext implements ApiCallContext {
   @Override
   public Map<String, List<String>> getExtraHeaders() {
     ImmutableMap.Builder<String, List<String>> builder = ImmutableMap.builder();
-    if (this.extraHeaders != null) {
-      for (Map.Entry<String, Collection<String>> entry : this.extraHeaders.asMap().entrySet()) {
-        builder.put(entry.getKey(), ImmutableList.<String>copyOf(entry.getValue()));
-      }
+    for (Map.Entry<String, Collection<String>> entry : this.extraHeaders.asMap().entrySet()) {
+      builder.put(entry.getKey(), ImmutableList.<String>copyOf(entry.getValue()));
     }
     return builder.build();
   }

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -193,6 +193,7 @@ public final class HttpJsonCallContext implements ApiCallContext {
     throw new UnsupportedOperationException("Http/json transport does not support streaming");
   }
 
+  @BetaApi("The surface for extra headers is not stable yet and may change in the future.")
   @Override
   public ApiCallContext withExtraHeaders(@Nullable Map<String, List<String>> extraHeaders) {
     ImmutableListMultimap.Builder<String, String> newExtraHeadersBuilder =
@@ -209,6 +210,7 @@ public final class HttpJsonCallContext implements ApiCallContext {
     return new HttpJsonCallContext(this.channel, this.deadline, this.credentials, newExtraHeaders);
   }
 
+  @BetaApi("The surface for extra headers is not stable yet and may change in the future.")
   @Override
   public Map<String, List<String>> getExtraHeaders() {
     ImmutableMap.Builder<String, List<String>> builder = ImmutableMap.builder();

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -136,4 +136,8 @@ public interface ApiCallContext {
   /** Return the extra headers set for this context. */
   @BetaApi("The surface for extra headers is not stable yet and may change in the future.")
   Map<String, List<String>> getExtraHeaders();
+
+  /** Return a new ApiCallContext with empty extra headers. */
+  @BetaApi
+  ApiCallContext withEmptyExtraHeaders();
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -32,6 +32,8 @@ package com.google.api.gax.rpc;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
 import com.google.auth.Credentials;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
@@ -126,4 +128,16 @@ public interface ApiCallContext {
    * in the present instance.
    */
   ApiCallContext merge(ApiCallContext inputCallContext);
+
+  /**
+   * Return a new ApiCallContext with the extraHeaders merged into the present instance.
+   */
+  @BetaApi("The surface for extra headers is not stable yet and may change in the future.")
+  ApiCallContext withExtraHeaders(Map<String, List<String>> extraHeaders);
+
+  /**
+   * Return the extra headers set for this context.
+   */
+  @BetaApi("The surface for extra headers is not stable yet and may change in the future.")
+  Map<String, List<String>> getExtraHeaders();
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -129,15 +129,11 @@ public interface ApiCallContext {
    */
   ApiCallContext merge(ApiCallContext inputCallContext);
 
-  /**
-   * Return a new ApiCallContext with the extraHeaders merged into the present instance.
-   */
+  /** Return a new ApiCallContext with the extraHeaders merged into the present instance. */
   @BetaApi("The surface for extra headers is not stable yet and may change in the future.")
   ApiCallContext withExtraHeaders(Map<String, List<String>> extraHeaders);
 
-  /**
-   * Return the extra headers set for this context.
-   */
+  /** Return the extra headers set for this context. */
   @BetaApi("The surface for extra headers is not stable yet and may change in the future.")
   Map<String, List<String>> getExtraHeaders();
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -136,8 +136,4 @@ public interface ApiCallContext {
   /** Return the extra headers set for this context. */
   @BetaApi("The surface for extra headers is not stable yet and may change in the future.")
   Map<String, List<String>> getExtraHeaders();
-
-  /** Return a new ApiCallContext with empty extra headers. */
-  @BetaApi
-  ApiCallContext withEmptyExtraHeaders();
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/internal/Headers.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/internal/Headers.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.api.gax.rpc.internal;
+
+import com.google.api.core.InternalApi;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+
+@InternalApi
+public class Headers {
+  public static ImmutableMap<String, List<String>> mergeHeaders(
+      Map<String, List<String>> firstHeader, Map<String, List<String>> secondHeader) {
+    ImmutableMap.Builder<String, List<String>> headerBuilder = ImmutableMap.builder();
+    for (Map.Entry<String, List<String>> entry : firstHeader.entrySet()) {
+      String key = entry.getKey();
+      List<String> firstValue = entry.getValue();
+      List<String> secondValue = secondHeader.get(key);
+      ImmutableList.Builder<String> mergedValueBuilder = ImmutableList.builder();
+      mergedValueBuilder.addAll(firstValue);
+      if (secondValue != null) {
+        mergedValueBuilder.addAll(secondValue);
+      }
+      headerBuilder.put(key, mergedValueBuilder.build());
+    }
+    for (Map.Entry<String, List<String>> entry : secondHeader.entrySet()) {
+      String key = entry.getKey();
+      if (!firstHeader.containsKey(key)) {
+        ImmutableList.Builder<String> mergedValueBuilder = ImmutableList.builder();
+        headerBuilder.put(key, mergedValueBuilder.addAll(entry.getValue()).build());
+      }
+    }
+    return headerBuilder.build();
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/internal/Headers.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/internal/Headers.java
@@ -39,26 +39,25 @@ import java.util.Map;
 @InternalApi
 public class Headers {
   public static ImmutableMap<String, List<String>> mergeHeaders(
-      Map<String, List<String>> firstHeader, Map<String, List<String>> secondHeader) {
-    ImmutableMap.Builder<String, List<String>> headerBuilder = ImmutableMap.builder();
-    for (Map.Entry<String, List<String>> entry : firstHeader.entrySet()) {
+      Map<String, List<String>> oldHeaders, Map<String, List<String>> newHeaders) {
+    ImmutableMap.Builder<String, List<String>> headersBuilder = ImmutableMap.builder();
+    for (Map.Entry<String, List<String>> entry : oldHeaders.entrySet()) {
       String key = entry.getKey();
-      List<String> firstValue = entry.getValue();
-      List<String> secondValue = secondHeader.get(key);
+      List<String> oldValue = entry.getValue();
+      List<String> newValue = newHeaders.get(key);
       ImmutableList.Builder<String> mergedValueBuilder = ImmutableList.builder();
-      mergedValueBuilder.addAll(firstValue);
-      if (secondValue != null) {
-        mergedValueBuilder.addAll(secondValue);
+      mergedValueBuilder.addAll(oldValue);
+      if (newValue != null) {
+        mergedValueBuilder.addAll(newValue);
       }
-      headerBuilder.put(key, mergedValueBuilder.build());
+      headersBuilder.put(key, mergedValueBuilder.build());
     }
-    for (Map.Entry<String, List<String>> entry : secondHeader.entrySet()) {
+    for (Map.Entry<String, List<String>> entry : newHeaders.entrySet()) {
       String key = entry.getKey();
-      if (!firstHeader.containsKey(key)) {
-        ImmutableList.Builder<String> mergedValueBuilder = ImmutableList.builder();
-        headerBuilder.put(key, mergedValueBuilder.addAll(entry.getValue()).build());
+      if (!oldHeaders.containsKey(key)) {
+        headersBuilder.put(key, ImmutableList.copyOf(entry.getValue()));
       }
     }
-    return headerBuilder.build();
+    return headersBuilder.build();
   }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/internal/HeadersTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/internal/HeadersTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.api.gax.rpc.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class HeadersTest {
+
+  @Test
+  public void testMergeHeaders() {
+    Map<String, List<String>> headers1 = createHeaders("key1", "value1", "key1", "value2");
+    Map<String, List<String>> headers2 = createHeaders("key1", "value2", "key2", "value2");
+    Map<String, List<String>> mergedHeaders = Headers.mergeHeaders(headers1, headers2);
+    Map<String, List<String>> expectedHeaders =
+        createHeaders("key1", "value1", "key1", "value2", "key1", "value2", "key2", "value2");
+    assertThat(mergedHeaders).containsExactlyEntriesIn(expectedHeaders);
+  }
+
+  @Test
+  public void testMergeHeadersEmpty() {
+    Map<String, List<String>> headers1 = createHeaders();
+    Map<String, List<String>> headers2 = createHeaders("key1", "value1", "key2", "value2");
+    Map<String, List<String>> mergedHeaders = Headers.mergeHeaders(headers1, headers2);
+    Map<String, List<String>> expectedHeaders = createHeaders("key1", "value1", "key2", "value2");
+    assertThat(mergedHeaders).containsExactlyEntriesIn(expectedHeaders);
+  }
+
+  private static Map<String, List<String>> createHeaders(String... keyValues) {
+    Map<String, List<String>> headers = new HashMap<>();
+    for (int i = 0; i < keyValues.length; i += 2) {
+      String key = keyValues[i];
+      String value = keyValues[i + 1];
+      if (!headers.containsKey(key)) {
+        headers.put(key, new ArrayList<String>());
+      }
+      headers.get(key).add(value);
+    }
+    return headers;
+  }
+}

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
@@ -66,7 +66,11 @@ public class FakeCallContext implements ApiCallContext {
     this.timeout = timeout;
     this.streamWaitTimeout = streamWaitTimeout;
     this.streamIdleTimeout = streamIdleTimeout;
-    this.extraHeaders = extraHeaders;
+    if (extraHeaders == null) {
+      this.extraHeaders = ImmutableListMultimap.<String, String>of();
+    } else {
+      this.extraHeaders = extraHeaders;
+    }
   }
 
   public static FakeCallContext createDefault() {
@@ -127,10 +131,8 @@ public class FakeCallContext implements ApiCallContext {
     }
 
     ImmutableListMultimap.Builder<String, String> extraHeadersBuilder =
-        ImmutableListMultimap.<String, String>builder();
-    if (this.extraHeaders != null) {
-      extraHeadersBuilder.putAll(this.extraHeaders);
-    }
+        ImmutableListMultimap.builder();
+    extraHeadersBuilder.putAll(this.extraHeaders);
     if (fakeCallContext.extraHeaders != null) {
       extraHeadersBuilder.putAll(fakeCallContext.extraHeaders);
     }
@@ -243,9 +245,7 @@ public class FakeCallContext implements ApiCallContext {
         newExtraHeadersBuilder.putAll(extraHeader.getKey(), extraHeader.getValue());
       }
     }
-    if (this.extraHeaders != null) {
-      newExtraHeadersBuilder.putAll(this.extraHeaders);
-    }
+    newExtraHeadersBuilder.putAll(this.extraHeaders);
     ImmutableListMultimap<String, String> newExtraHeaders = newExtraHeadersBuilder.build();
     return new FakeCallContext(
         this.credentials,
@@ -259,10 +259,8 @@ public class FakeCallContext implements ApiCallContext {
   @Override
   public Map<String, List<String>> getExtraHeaders() {
     ImmutableMap.Builder<String, List<String>> builder = ImmutableMap.builder();
-    if (this.extraHeaders != null) {
-      for (Map.Entry<String, Collection<String>> entry : this.extraHeaders.asMap().entrySet()) {
-        builder.put(entry.getKey(), ImmutableList.<String>copyOf(entry.getValue()));
-      }
+    for (Map.Entry<String, Collection<String>> entry : this.extraHeaders.asMap().entrySet()) {
+      builder.put(entry.getKey(), ImmutableList.<String>copyOf(entry.getValue()));
     }
     return builder.build();
   }

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
@@ -60,8 +60,7 @@ public class FakeCallContext implements ApiCallContext {
       Duration timeout,
       Duration streamWaitTimeout,
       Duration streamIdleTimeout,
-      ImmutableListMultimap<String, String> extraHeaders
-      ) {
+      ImmutableListMultimap<String, String> extraHeaders) {
     this.credentials = credentials;
     this.channel = channel;
     this.timeout = timeout;
@@ -127,7 +126,7 @@ public class FakeCallContext implements ApiCallContext {
       newStreamIdleTimeout = streamIdleTimeout;
     }
 
-    ImmutableListMultimap.Builder<String, String> extraHeadersBuilder = 
+    ImmutableListMultimap.Builder<String, String> extraHeadersBuilder =
         ImmutableListMultimap.<String, String>builder();
     if (this.extraHeaders != null) {
       extraHeadersBuilder.putAll(this.extraHeaders);
@@ -136,11 +135,11 @@ public class FakeCallContext implements ApiCallContext {
       extraHeadersBuilder.putAll(fakeCallContext.extraHeaders);
     }
     return new FakeCallContext(
-        newCallCredentials, 
-        newChannel, 
-        newTimeout, 
-        newStreamWaitTimeout, 
-        newStreamIdleTimeout, 
+        newCallCredentials,
+        newChannel,
+        newTimeout,
+        newStreamWaitTimeout,
+        newStreamIdleTimeout,
         extraHeadersBuilder.build());
   }
 
@@ -171,7 +170,12 @@ public class FakeCallContext implements ApiCallContext {
   @Override
   public FakeCallContext withCredentials(Credentials credentials) {
     return new FakeCallContext(
-        credentials, this.channel, this.timeout, this.streamWaitTimeout, this.streamIdleTimeout, this.extraHeaders);
+        credentials,
+        this.channel,
+        this.timeout,
+        this.streamWaitTimeout,
+        this.streamIdleTimeout,
+        this.extraHeaders);
   }
 
   @Override
@@ -187,35 +191,56 @@ public class FakeCallContext implements ApiCallContext {
 
   public FakeCallContext withChannel(FakeChannel channel) {
     return new FakeCallContext(
-        this.credentials, channel, this.timeout, this.streamWaitTimeout, this.streamIdleTimeout, this.extraHeaders);
+        this.credentials,
+        channel,
+        this.timeout,
+        this.streamWaitTimeout,
+        this.streamIdleTimeout,
+        this.extraHeaders);
   }
 
   @Override
   public FakeCallContext withTimeout(Duration timeout) {
     return new FakeCallContext(
-        this.credentials, this.channel, timeout, this.streamWaitTimeout, this.streamIdleTimeout, this.extraHeaders);
+        this.credentials,
+        this.channel,
+        timeout,
+        this.streamWaitTimeout,
+        this.streamIdleTimeout,
+        this.extraHeaders);
   }
 
   @Override
   public ApiCallContext withStreamWaitTimeout(@Nonnull Duration streamWaitTimeout) {
     Preconditions.checkNotNull(streamWaitTimeout);
     return new FakeCallContext(
-        this.credentials, this.channel, this.timeout, streamWaitTimeout, this.streamIdleTimeout, this.extraHeaders);
+        this.credentials,
+        this.channel,
+        this.timeout,
+        streamWaitTimeout,
+        this.streamIdleTimeout,
+        this.extraHeaders);
   }
 
   @Override
   public ApiCallContext withStreamIdleTimeout(@Nonnull Duration streamIdleTimeout) {
     Preconditions.checkNotNull(streamIdleTimeout);
     return new FakeCallContext(
-        this.credentials, this.channel, this.timeout, this.streamWaitTimeout, streamIdleTimeout, this.extraHeaders);
+        this.credentials,
+        this.channel,
+        this.timeout,
+        this.streamWaitTimeout,
+        streamIdleTimeout,
+        this.extraHeaders);
   }
 
   @Override
   public ApiCallContext withExtraHeaders(Map<String, List<String>> extraHeaders) {
-    ImmutableListMultimap.Builder<String, String> newExtraHeadersBuilder = ImmutableListMultimap.builder();
+    ImmutableListMultimap.Builder<String, String> newExtraHeadersBuilder =
+        ImmutableListMultimap.builder();
     if (extraHeaders != null) {
       for (Map.Entry<String, List<String>> extraHeader : extraHeaders.entrySet()) {
-        newExtraHeadersBuilder.putAll(extraHeader.getKey(), extraHeader.getValue());  
+        newExtraHeadersBuilder.putAll(extraHeader.getKey(), extraHeader.getValue());
       }
     }
     if (this.extraHeaders != null) {
@@ -223,7 +248,12 @@ public class FakeCallContext implements ApiCallContext {
     }
     ImmutableListMultimap<String, String> newExtraHeaders = newExtraHeadersBuilder.build();
     return new FakeCallContext(
-        this.credentials, channel, this.timeout, this.streamWaitTimeout, this.streamIdleTimeout, newExtraHeaders);
+        this.credentials,
+        channel,
+        this.timeout,
+        this.streamWaitTimeout,
+        this.streamIdleTimeout,
+        newExtraHeaders);
   }
 
   @Override


### PR DESCRIPTION
Add extraHeaders in GrpcClientCallsContext to allow adding metadata dynamically.