### PR TITLE
Add opt-in support for JWT tokens

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ project.version = file("gax/version.txt").text.trim()
 ext {
   grpcVersion = '1.10.1'
   commonProtosVersion = '1.0.0'
-  authVersion = '0.9.0'
+  authVersion = '0.9.1'
   // Project names not used for release
   nonReleaseProjects = ['benchmark']
   libraryVendor = 'Google'

--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,8 @@ subprojects {
         // Testing
         junit: 'junit:junit:4.11',
         mockito: 'org.mockito:mockito-core:1.10.19',
+        powermockJunit: 'org.powermock:powermock-module-junit4:1.6.2',
+        powermockMockito: 'org.powermock:powermock-api-mockito:1.6.2',
         truth: 'com.google.truth:truth:0.39',
         commons: 'org.apache.commons:commons-lang3:3.4',
         commonProtosGrpc: "com.google.api.grpc:grpc-google-common-protos:${commonProtosVersion}",

--- a/gax/build.gradle
+++ b/gax/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 
   testCompile libraries.junit,
     libraries.mockito,
+    libraries.powermockJunit,
+    libraries.powermockMockito,
     libraries.truth,
     libraries.autovalue
 

--- a/gax/src/test/java/com/google/api/gax/core/GoogleCredentialsProviderTest.java
+++ b/gax/src/test/java/com/google/api/gax/core/GoogleCredentialsProviderTest.java
@@ -29,8 +29,7 @@
  */
 package com.google.api.gax.core;
 
-import static com.google.common.truth.Truth.*;
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;

--- a/gax/src/test/java/com/google/api/gax/core/GoogleCredentialsProviderTest.java
+++ b/gax/src/test/java/com/google/api/gax/core/GoogleCredentialsProviderTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.core;
+
+import static com.google.common.truth.Truth.*;
+import static org.junit.Assert.*;
+
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.auth.oauth2.ServiceAccountJwtAccessCredentials;
+import com.google.common.collect.ImmutableList;
+import java.security.PrivateKey;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(GoogleCredentials.class)
+public class GoogleCredentialsProviderTest {
+  @Test
+  public void serviceAccountReplacedWithJwtTokens() throws Exception {
+    ServiceAccountCredentials serviceAccountCredentials =
+        ServiceAccountCredentials.newBuilder()
+            .setClientId("fake-client-id")
+            .setClientEmail("fake@example.com")
+            .setPrivateKeyId("fake-private-key")
+            .setPrivateKey(Mockito.mock(PrivateKey.class))
+            .build();
+
+    PowerMockito.mockStatic(GoogleCredentials.class);
+    Mockito.when(GoogleCredentials.getApplicationDefault()).thenReturn(serviceAccountCredentials);
+
+    GoogleCredentialsProvider provider =
+        GoogleCredentialsProvider.newBuilder()
+            .setScopesToApply(ImmutableList.of("scope1", "scope2"))
+            .setJwtEnabledScopes(ImmutableList.of("scope1"))
+            .build();
+
+    Credentials credentials = provider.getCredentials();
+    assertThat(credentials).isInstanceOf(ServiceAccountJwtAccessCredentials.class);
+    ServiceAccountJwtAccessCredentials jwtCreds = (ServiceAccountJwtAccessCredentials) credentials;
+    assertThat(jwtCreds.getClientId()).isEqualTo(serviceAccountCredentials.getClientId());
+    assertThat(jwtCreds.getClientEmail()).isEqualTo(serviceAccountCredentials.getClientEmail());
+    assertThat(jwtCreds.getPrivateKeyId()).isEqualTo(serviceAccountCredentials.getPrivateKeyId());
+    assertThat(jwtCreds.getPrivateKey()).isEqualTo(serviceAccountCredentials.getPrivateKey());
+  }
+
+  @Test
+  public void noJwtWithoutScopeMatch() throws Exception {
+    ServiceAccountCredentials serviceAccountCredentials =
+        ServiceAccountCredentials.newBuilder()
+            .setClientId("fake-client-id")
+            .setClientEmail("fake@example.com")
+            .setPrivateKeyId("fake-private-key")
+            .setPrivateKey(Mockito.mock(PrivateKey.class))
+            .build();
+
+    PowerMockito.mockStatic(GoogleCredentials.class);
+    Mockito.when(GoogleCredentials.getApplicationDefault()).thenReturn(serviceAccountCredentials);
+
+    GoogleCredentialsProvider provider =
+        GoogleCredentialsProvider.newBuilder()
+            .setScopesToApply(ImmutableList.of("scope1", "scope2"))
+            .setJwtEnabledScopes(ImmutableList.of("other"))
+            .build();
+
+    Credentials credentials = provider.getCredentials();
+    assertThat(credentials).isInstanceOf(ServiceAccountCredentials.class);
+
+    ServiceAccountCredentials serviceAccountCredentials2 = (ServiceAccountCredentials) credentials;
+    assertThat(serviceAccountCredentials2.getClientId())
+        .isEqualTo(serviceAccountCredentials.getClientId());
+    assertThat(serviceAccountCredentials2.getClientEmail())
+        .isEqualTo(serviceAccountCredentials.getClientEmail());
+    assertThat(serviceAccountCredentials2.getPrivateKeyId())
+        .isEqualTo(serviceAccountCredentials.getPrivateKeyId());
+    assertThat(serviceAccountCredentials2.getPrivateKey())
+        .isEqualTo(serviceAccountCredentials.getPrivateKey());
+    assertThat(serviceAccountCredentials2.getScopes()).containsExactly("scope1", "scope2");
+  }
+}


### PR DESCRIPTION
Currently JWT tokens are fairly hard to enable because GoogleCredentialsProvider will always set scopes on ServiceAccountCredentials. The only workaround is manually set
FixCredentials.of(ServiceAccountJwtAccessCredentials). This PR enables automatic JWT tokens support for services that opt into it.

The main limitation of JWT tokens is that they don't support scopes. So they can't be used when a user wants to explicitly limit a service account's permissions __within__ a service. (ie. using https://www.googleapis.com/auth/bigtable.data.readonly instead of https://www.googleapis.com/auth/bigtable.data). This should be a minority of users...most will just use the DEFAULT_SERVICE_SCOPES in their settings.

To opt-in for JWT, a client will need to register scopes that are equivalent to having full access to the target service (ie. https://www.googleapis.com/auth/bigtable.data and https://www.googleapis.com/auth/cloud-platform).

The intended usage for this is that `EnhancedBigtableStubSettings.Builder` will:
- create a new instance of GoogleCredentialsProvider
- set BigtableStubSettings#getDefaultServiceScopes() on the new provider
- set `https://www.googleapis.com/auth/bigtable.data`, `https://www.googleapis.com/auth/cloud-bigtable.data` and `https://www.googleapis.com/auth/cloud-platform` as `JwtEnabledScopes`
- set the new provider as the CredentialsProvider in base settings

To enable testing, I had to add powermock to mock GoogleCredentials.getApplicationDefault() inside GoogleCredentialsProvider

If this works out well, I would recommend to deprecate and remove the ability for users to configure custom scopes and try to use JWT tokens as much as possible.