### PR TITLE
Allow null HttpResponseParser

### DIFF
--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ApiMethodDescriptor.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ApiMethodDescriptor.java
@@ -40,7 +40,6 @@ public abstract class ApiMethodDescriptor<RequestT, ResponseT> {
 
   public abstract String getFullMethodName();
 
-  @Nullable
   public abstract HttpRequestFormatter<RequestT> getRequestFormatter();
 
   @Nullable

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallSettings.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallSettings.java
@@ -41,14 +41,12 @@ public class HttpJsonCallSettings<RequestT, ResponseT> {
     return methodDescriptor;
   }
 
-  public static <RequestT extends ApiMessage, ResponseT extends ApiMessage>
-      Builder<RequestT, ResponseT> newBuilder() {
+  public static <RequestT, ResponseT> Builder<RequestT, ResponseT> newBuilder() {
     return new Builder<>();
   }
 
-  public static <RequestT extends ApiMessage, ResponseT extends ApiMessage>
-      HttpJsonCallSettings<RequestT, ResponseT> create(
-          ApiMethodDescriptor<RequestT, ResponseT> methodDescriptor) {
+  public static <RequestT, ResponseT> HttpJsonCallSettings<RequestT, ResponseT> create(
+      ApiMethodDescriptor<RequestT, ResponseT> methodDescriptor) {
     return HttpJsonCallSettings.<RequestT, ResponseT>newBuilder()
         .setMethodDescriptor(methodDescriptor)
         .build();

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpRequestRunnable.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpRequestRunnable.java
@@ -135,8 +135,12 @@ class HttpRequestRunnable<RequestT, ResponseT> implements Runnable {
             HttpJsonStatusCode.of(httpResponse.getStatusCode(), httpResponse.getStatusMessage()),
             false);
       }
-      ResponseT response = methodDescriptor.getResponseParser().parse(httpResponse.getContent());
-      responseFuture.set(response);
+      if (methodDescriptor.getResponseParser() != null) {
+        ResponseT response = methodDescriptor.getResponseParser().parse(httpResponse.getContent());
+        responseFuture.set(response);
+      } else {
+        responseFuture.set(null);
+      }
     } catch (Exception e) {
       responseFuture.setException(e);
     }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/testing/MockHttpService.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/testing/MockHttpService.java
@@ -100,16 +100,22 @@ public final class MockHttpService extends MockHttpTransport {
             String relativePath = getRelativePath(fullTargetUrl);
 
             for (ApiMethodDescriptor methodDescriptor : serviceMethodDescriptors) {
+              if (!httpMethod.equals(methodDescriptor.getHttpMethod())) {
+                continue;
+              }
+
               PathTemplate pathTemplate = methodDescriptor.getRequestFormatter().getPathTemplate();
               // Server figures out which RPC method is called based on the endpoint path pattern.
-              if (pathTemplate.matches(relativePath)) {
-                // Emulate the server's creation of an HttpResponse from the response message instance.
-                String httpContent = methodDescriptor.getResponseParser().serialize(response);
-
-                httpResponse.setContent(httpContent.getBytes());
-                httpResponse.setStatusCode(200);
-                return httpResponse;
+              if (!pathTemplate.matches(relativePath)) {
+                continue;
               }
+
+              // Emulate the server's creation of an HttpResponse from the response message instance.
+              String httpContent = methodDescriptor.getResponseParser().serialize(response);
+
+              httpResponse.setContent(httpContent.getBytes());
+              httpResponse.setStatusCode(200);
+              return httpResponse;
             }
 
             // Return 404 when none of this server's endpoint templates match the given URL.


### PR DESCRIPTION
Some API methods have no response object, so the response parser for that method descriptor should be null.

Also check for right Http method when server is determing which method to run on a request.