### PR TITLE
Allow credentials to be nullable in HttpJsonCallOptions

### DIFF
--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallOptions.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallOptions.java
@@ -42,6 +42,7 @@ public abstract class HttpJsonCallOptions {
   @Nullable
   public abstract Instant getDeadline();
 
+  @Nullable
   public abstract Credentials getCredentials();
 
   public static Builder newBuilder() {


### PR DESCRIPTION
This allows generated unit tests, which don't have credentials set, to still be able to create the tested client object.