### PR TITLE
Remove close exception

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcTransportChannel.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcTransportChannel.java
@@ -89,7 +89,7 @@ public abstract class GrpcTransportChannel implements TransportChannel {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     getManagedChannel().shutdown();
   }
 

--- a/gax-grpc/src/main/java/com/google/longrunning/OperationsClient.java
+++ b/gax-grpc/src/main/java/com/google/longrunning/OperationsClient.java
@@ -518,7 +518,7 @@ public class OperationsClient implements BackgroundResource {
   }
 
   @Override
-  public final void close() throws Exception {
+  public final void close() {
     stub.close();
   }
 

--- a/gax-grpc/src/main/java/com/google/longrunning/stub/GrpcOperationsStub.java
+++ b/gax-grpc/src/main/java/com/google/longrunning/stub/GrpcOperationsStub.java
@@ -205,7 +205,7 @@ public class GrpcOperationsStub extends OperationsStub {
   }
 
   @Override
-  public final void close() throws Exception {
+  public final void close() {
     shutdown();
   }
 

--- a/gax-grpc/src/main/java/com/google/longrunning/stub/OperationsStub.java
+++ b/gax-grpc/src/main/java/com/google/longrunning/stub/OperationsStub.java
@@ -73,4 +73,7 @@ public abstract class OperationsStub implements BackgroundResource {
   public UnaryCallable<DeleteOperationRequest, Empty> deleteOperationCallable() {
     throw new UnsupportedOperationException("Not implemented: deleteOperationCallable()");
   }
+
+  @Override
+  public abstract void close();
 }

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonTransportChannel.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonTransportChannel.java
@@ -90,7 +90,7 @@ public abstract class HttpJsonTransportChannel implements TransportChannel {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     getManagedChannel().shutdown();
   }
 

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ManagedHttpJsonChannel.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ManagedHttpJsonChannel.java
@@ -131,7 +131,7 @@ public class ManagedHttpJsonChannel implements HttpJsonChannel, BackgroundResour
   }
 
   @Override
-  public void close() throws Exception {}
+  public void close() {}
 
   public static Builder newBuilder() {
     return new Builder().setHeaderEnhancers(new LinkedList<HttpJsonHeaderEnhancer>());

--- a/gax/src/main/java/com/google/api/gax/core/BackgroundResource.java
+++ b/gax/src/main/java/com/google/api/gax/core/BackgroundResource.java
@@ -72,4 +72,6 @@ public interface BackgroundResource extends AutoCloseable {
    * or the current thread is interrupted, whichever happens first.
    */
   boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException;
+
+  // NEXT_MAJOR_VER: override close() to remove 'throws Exception'
 }

--- a/gax/src/main/java/com/google/api/gax/core/BackgroundResource.java
+++ b/gax/src/main/java/com/google/api/gax/core/BackgroundResource.java
@@ -72,7 +72,4 @@ public interface BackgroundResource extends AutoCloseable {
    * or the current thread is interrupted, whichever happens first.
    */
   boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException;
-
-  /** Closes this resource, relinquishing any underlying resources. */
-  void close();
 }

--- a/gax/src/main/java/com/google/api/gax/core/BackgroundResource.java
+++ b/gax/src/main/java/com/google/api/gax/core/BackgroundResource.java
@@ -72,4 +72,7 @@ public interface BackgroundResource extends AutoCloseable {
    * or the current thread is interrupted, whichever happens first.
    */
   boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException;
+
+  /** Closes this resource, relinquishing any underlying resources. */
+  void close();
 }

--- a/gax/src/main/java/com/google/api/gax/core/BackgroundResourceAggregation.java
+++ b/gax/src/main/java/com/google/api/gax/core/BackgroundResourceAggregation.java
@@ -87,6 +87,7 @@ public class BackgroundResourceAggregation implements BackgroundResource {
     return true;
   }
 
+  // NEXT_MAJOR_VER: remove 'throws Exception'
   @Override
   public final void close() throws Exception {
     shutdown();

--- a/gax/src/main/java/com/google/api/gax/core/BackgroundResourceAggregation.java
+++ b/gax/src/main/java/com/google/api/gax/core/BackgroundResourceAggregation.java
@@ -88,7 +88,7 @@ public class BackgroundResourceAggregation implements BackgroundResource {
   }
 
   @Override
-  public final void close() throws Exception {
+  public final void close() {
     shutdown();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/core/BackgroundResourceAggregation.java
+++ b/gax/src/main/java/com/google/api/gax/core/BackgroundResourceAggregation.java
@@ -88,7 +88,7 @@ public class BackgroundResourceAggregation implements BackgroundResource {
   }
 
   @Override
-  public final void close() {
+  public final void close() throws Exception {
     shutdown();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/core/BaseBackgroundResource.java
+++ b/gax/src/main/java/com/google/api/gax/core/BaseBackgroundResource.java
@@ -59,6 +59,7 @@ public class BaseBackgroundResource implements BackgroundResource {
     return false;
   }
 
+  // NEXT_MAJOR_VER: remove 'throws Exception'
   @Override
   public void close() throws Exception {
     shutdown();

--- a/gax/src/main/java/com/google/api/gax/core/BaseBackgroundResource.java
+++ b/gax/src/main/java/com/google/api/gax/core/BaseBackgroundResource.java
@@ -60,7 +60,7 @@ public class BaseBackgroundResource implements BackgroundResource {
   }
 
   @Override
-  public void close() {
+  public void close() throws Exception {
     shutdown();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/core/BaseBackgroundResource.java
+++ b/gax/src/main/java/com/google/api/gax/core/BaseBackgroundResource.java
@@ -60,7 +60,7 @@ public class BaseBackgroundResource implements BackgroundResource {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     shutdown();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/core/ExecutorAsBackgroundResource.java
+++ b/gax/src/main/java/com/google/api/gax/core/ExecutorAsBackgroundResource.java
@@ -70,6 +70,7 @@ public class ExecutorAsBackgroundResource implements BackgroundResource {
     return executor.awaitTermination(duration, unit);
   }
 
+  // NEXT_MAJOR_VER: remove 'throws Exception'
   @Override
   public void close() throws Exception {
     shutdown();

--- a/gax/src/main/java/com/google/api/gax/core/ExecutorAsBackgroundResource.java
+++ b/gax/src/main/java/com/google/api/gax/core/ExecutorAsBackgroundResource.java
@@ -71,7 +71,7 @@ public class ExecutorAsBackgroundResource implements BackgroundResource {
   }
 
   @Override
-  public void close() {
+  public void close() throws Exception {
     shutdown();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/core/ExecutorAsBackgroundResource.java
+++ b/gax/src/main/java/com/google/api/gax/core/ExecutorAsBackgroundResource.java
@@ -71,7 +71,7 @@ public class ExecutorAsBackgroundResource implements BackgroundResource {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     shutdown();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientSettings.java
@@ -279,8 +279,7 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
     /** Applies the given settings updater function to the given method settings builders. */
     protected static void applyToAllUnaryMethods(
         Iterable<UnaryCallSettings.Builder<?, ?>> methodSettingsBuilders,
-        ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater)
-        throws Exception {
+        ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) {
       StubSettings.Builder.applyToAllUnaryMethods(methodSettingsBuilders, settingsUpdater);
     }
 

--- a/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -342,8 +342,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     /** Applies the given settings updater function to the given method settings builders. */
     protected static void applyToAllUnaryMethods(
         Iterable<UnaryCallSettings.Builder<?, ?>> methodSettingsBuilders,
-        ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater)
-        throws Exception {
+        ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) {
       for (UnaryCallSettings.Builder<?, ?> settingsBuilder : methodSettingsBuilders) {
         settingsUpdater.apply(settingsBuilder);
       }

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeTransportChannel.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeTransportChannel.java
@@ -89,7 +89,7 @@ public class FakeTransportChannel implements TransportChannel {
   }
 
   @Override
-  public void close() throws Exception {}
+  public void close() {}
 
   public FakeChannel getChannel() {
     return channel;


### PR DESCRIPTION
Removes the `throws Exception` clause from `close()` methods.

There is a problem though - this is technically a breaking change for any interface or class that could be extended (and isn't marked internal or beta), including `BackgroundResource`, `BackgroundResourceAggregation`, `BaseBackgroundResource` and `ExecutorAsBackgroundResource`. Should this be treated as a breaking change? It will break anyone implementing or extending any of those classes.