### PR TITLE
Added thread factory so we can set thread-name 

### DIFF
--- a/gax/src/main/java/com/google/api/gax/core/InstantiatingExecutorProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/InstantiatingExecutorProvider.java
@@ -60,20 +60,6 @@ public abstract class InstantiatingExecutorProvider implements ExecutorProvider 
   /** The number of threads used by the executor created by this ExecutorProvider. */
   public abstract int getExecutorThreadCount();
 
-  /** Return a thread-factory to create gax processing threads and name them appropriately */
-  public ThreadFactory getThreadFactory() {
-    return new ThreadFactory() {
-      private final AtomicInteger threadCount = new AtomicInteger();
-      @Override
-      public Thread newThread(Runnable runnable) {
-        Thread thread = new Thread(runnable);
-        thread.setName("Gax-" + threadCount.incrementAndGet());
-        thread.setDaemon(true);
-        return thread;
-      }
-    };
-  }
-
   public Builder toBuilder() {
     return new AutoValue_InstantiatingExecutorProvider.Builder(this);
   }
@@ -89,7 +75,19 @@ public abstract class InstantiatingExecutorProvider implements ExecutorProvider 
 
     public abstract int getExecutorThreadCount();
 
-    public abstract ThreadFactory getThreadFactory();
+    /** Return a thread-factory to create gax processing threads so we can name them appropriately */
+    public ThreadFactory getThreadFactory() {
+      return new ThreadFactory() {
+        private final AtomicInteger threadCount = new AtomicInteger();
+        @Override
+        public Thread newThread(Runnable runnable) {
+          Thread thread = new Thread(runnable);
+          thread.setName("Gax-" + threadCount.incrementAndGet());
+          thread.setDaemon(true);
+          return thread;
+        }
+      };
+    }
 
     public abstract InstantiatingExecutorProvider build();
   }

--- a/gax/src/main/java/com/google/api/gax/core/InstantiatingExecutorProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/InstantiatingExecutorProvider.java
@@ -85,6 +85,7 @@ public abstract class InstantiatingExecutorProvider implements ExecutorProvider 
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setExecutorThreadCount(int value);
+    public abstract Builder setThreadFactory(ThreadFactory threadFactory);
 
     public abstract int getExecutorThreadCount();
 


### PR DESCRIPTION
This is useful if we want to set the thread-name (for example) on the pub-sub worker threads.