### PR TITLE
Added thread factory so we can set thread-name on worker threads

### DIFF
--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/SettingsTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/SettingsTest.java
@@ -576,7 +576,8 @@ public class SettingsTest {
     assertIsReflectionEqual(builderA.fakeMethodSimple(), builderB.fakeMethodSimple());
     assertIsReflectionEqual(builderA.fakePagedMethod(), builderB.fakePagedMethod());
     assertIsReflectionEqual(builderA.fakeMethodBatching(), builderB.fakeMethodBatching());
-    assertIsReflectionEqual(builderA.getExecutorProvider(), builderB.getExecutorProvider());
+    assertIsReflectionEqual(
+        builderA.getExecutorProvider(), builderB.getExecutorProvider(), new String[] { "threadFactory" });
     assertIsReflectionEqual(builderA.getCredentialsProvider(), builderB.getCredentialsProvider());
     assertIsReflectionEqual(
         builderA.getTransportChannelProvider(), builderB.getTransportChannelProvider());


### PR DESCRIPTION
This is useful if we don't want the threads to show up as Thread-1 and would rather it be PubSub-Publisher-1 or something.
