### PR TITLE
Allow LRO futures to be transformed by ApiFutures.

### DIFF
--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationFutureImpl.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationFutureImpl.java
@@ -35,6 +35,7 @@ import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
 import com.google.api.gax.retrying.RetryingFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -46,8 +47,11 @@ import java.util.concurrent.TimeoutException;
  * {@link com.google.api.gax.retrying.TimedRetryAlgorithm}.
  *
  * <p>This class is thread-safe.
+ *
+ * <p>This is public only for technical reasons, for advanced usage.
  */
 @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+@InternalApi
 public final class OperationFutureImpl<ResponseT, MetadataT>
     implements OperationFuture<ResponseT, MetadataT> {
   private final Object lock = new Object();

--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationFutureImpl.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationFutureImpl.java
@@ -31,7 +31,6 @@ package com.google.api.gax.longrunning;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.api.core.AbstractApiFuture;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
@@ -49,7 +48,7 @@ import java.util.concurrent.TimeoutException;
  * <p>This class is thread-safe.
  */
 @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
-public final class OperationFutureImpl<ResponseT, MetadataT> extends AbstractApiFuture<ResponseT>
+public final class OperationFutureImpl<ResponseT, MetadataT>
     implements OperationFuture<ResponseT, MetadataT> {
   private final Object lock = new Object();
 


### PR DESCRIPTION
Fixes #552

This is an API breaking change. However LRO surface is still marked as
BetaApi and it's unlikely that someone is depending on AbstractApiFuture
being a subclass of OperationFuture.

ApiFutures.transform() has an optimization that lets it access the
underlying Guava future impl in AbstractApiFuture. This lets it avoid
calling through the ApiFuture wrapper. Unfortunately this doesn't play nicely with
the current implementation of OperationFutureImpl. OperationFutureImpl
inherits from AbstractApiFuture, but replaces all of its functionality,
except for getInternalListenableFuture(). This causes transforms chained
via ApiFutures.transform() to listen to an orphaned internal future.

This PR removes the superfluous base class from OperationFutureImpl.