### PR TITLE
Expose error message from an operation

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcOperationSnapshot.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcOperationSnapshot.java
@@ -72,6 +72,11 @@ class GrpcOperationSnapshot implements OperationSnapshot {
     return GrpcStatusCode.of(Status.fromCodeValue(operation.getError().getCode()).getCode());
   }
 
+  @Override
+  public String getErrorMessage() {
+    return operation.getError().getMessage();
+  }
+
   public static GrpcOperationSnapshot create(Operation operation) {
     return new GrpcOperationSnapshot(operation);
   }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ProtoOperationTransformers.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ProtoOperationTransformers.java
@@ -55,7 +55,15 @@ public class ProtoOperationTransformers {
     public ResponseT apply(OperationSnapshot operationSnapshot) {
       if (!operationSnapshot.getErrorCode().getCode().equals(Code.OK)) {
         throw ApiExceptionFactory.createException(
-            operationSnapshot.getErrorMessage(), null, operationSnapshot.getErrorCode(), false);
+            "Operation with name \""
+                + operationSnapshot.getName()
+                + "\" failed with status = "
+                + operationSnapshot.getErrorCode()
+                + " and message = "
+                + operationSnapshot.getErrorMessage(),
+            null,
+            operationSnapshot.getErrorCode(),
+            false);
       }
       try {
         return transformer.apply((Any) operationSnapshot.getResponse());

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ProtoOperationTransformers.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ProtoOperationTransformers.java
@@ -55,24 +55,13 @@ public class ProtoOperationTransformers {
     public ResponseT apply(OperationSnapshot operationSnapshot) {
       if (!operationSnapshot.getErrorCode().getCode().equals(Code.OK)) {
         throw ApiExceptionFactory.createException(
-            "Operation with name \""
-                + operationSnapshot.getName()
-                + "\" failed with status = "
-                + operationSnapshot.getErrorCode(),
-            null,
-            operationSnapshot.getErrorCode(),
-            false);
+            operationSnapshot.getErrorMessage(), null, operationSnapshot.getErrorCode(), false);
       }
       try {
         return transformer.apply((Any) operationSnapshot.getResponse());
       } catch (RuntimeException e) {
         throw ApiExceptionFactory.createException(
-            "Operation with name \""
-                + operationSnapshot.getName()
-                + "\" succeeded, but encountered a problem unpacking it.",
-            e,
-            operationSnapshot.getErrorCode(),
-            false);
+            operationSnapshot.getErrorMessage(), e, operationSnapshot.getErrorCode(), false);
       }
     }
 
@@ -97,12 +86,7 @@ public class ProtoOperationTransformers {
             operationSnapshot.getMetadata() != null ? (Any) operationSnapshot.getMetadata() : null);
       } catch (RuntimeException e) {
         throw ApiExceptionFactory.createException(
-            "Polling operation with name \""
-                + operationSnapshot.getName()
-                + "\" succeeded, but encountered a problem unpacking it.",
-            e,
-            operationSnapshot.getErrorCode(),
-            false);
+            operationSnapshot.getErrorMessage(), e, operationSnapshot.getErrorCode(), false);
       }
     }
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ProtoOperationTransformers.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ProtoOperationTransformers.java
@@ -61,7 +61,12 @@ public class ProtoOperationTransformers {
         return transformer.apply((Any) operationSnapshot.getResponse());
       } catch (RuntimeException e) {
         throw ApiExceptionFactory.createException(
-            operationSnapshot.getErrorMessage(), e, operationSnapshot.getErrorCode(), false);
+            "Operation with name \""
+                + operationSnapshot.getName()
+                + "\" succeeded, but encountered a problem unpacking it.",
+            e,
+            operationSnapshot.getErrorCode(),
+            false);
       }
     }
 
@@ -86,7 +91,12 @@ public class ProtoOperationTransformers {
             operationSnapshot.getMetadata() != null ? (Any) operationSnapshot.getMetadata() : null);
       } catch (RuntimeException e) {
         throw ApiExceptionFactory.createException(
-            operationSnapshot.getErrorMessage(), e, operationSnapshot.getErrorCode(), false);
+            "Polling operation with name \""
+                + operationSnapshot.getName()
+                + "\" succeeded, but encountered a problem unpacking it.",
+            e,
+            operationSnapshot.getErrorCode(),
+            false);
       }
     }
 

--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationSnapshot.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationSnapshot.java
@@ -62,9 +62,9 @@ public interface OperationSnapshot {
    */
   StatusCode getErrorCode();
 
-  /** 
-   * If the operation is done and it failed, returns the error message; if the operation is
-   * not done or if it succeeded, returns null.
+  /**
+   * If the operation is done and it failed, returns the error message; if the operation is not done
+   * or if it succeeded, returns null.
    */
   String getErrorMessage();
 }

--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationSnapshot.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationSnapshot.java
@@ -61,4 +61,10 @@ public interface OperationSnapshot {
    * not done or if it succeeded, returns null.
    */
   StatusCode getErrorCode();
+
+  /** 
+   * If the operation is done and it failed, returns the error message; if the operation is
+   * not done or if it succeeded, returns null.
+   */
+  String getErrorMessage();
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/OperationCallableImpl.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/OperationCallableImpl.java
@@ -86,7 +86,6 @@ class OperationCallableImpl<RequestT, ResponseT, MetadataT>
     RecheckingCallable<RequestT, OperationSnapshot> callable =
         new RecheckingCallable<>(
             new OperationCheckingCallable<RequestT>(longRunningClient, initialFuture), executor);
-
     RetryingFuture<OperationSnapshot> pollingFuture = callable.futureCall(null, null);
     return new OperationFutureImpl<>(
         pollingFuture, initialFuture, responseTransformer, metadataTransformer);

--- a/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
@@ -137,8 +137,6 @@ public class OperationCallableImplTest {
   private static class ResponseTransformer implements ApiFunction<OperationSnapshot, Color> {
     @Override
     public Color apply(OperationSnapshot operationSnapshot) {
-      System.out.println("got here");
-      System.out.println("operationsnapshot.errormessage: " + operationSnapshot.getErrorMessage());
       if (!operationSnapshot.getErrorCode().getCode().equals(StatusCode.Code.OK)) {
         throw ApiExceptionFactory.createException(
             operationSnapshot.getErrorMessage(), null, operationSnapshot.getErrorCode(), false);

--- a/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
@@ -137,15 +137,11 @@ public class OperationCallableImplTest {
   private static class ResponseTransformer implements ApiFunction<OperationSnapshot, Color> {
     @Override
     public Color apply(OperationSnapshot operationSnapshot) {
+      System.out.println("got here");
+      System.out.println("operationsnapshot.errormessage: " + operationSnapshot.getErrorMessage());
       if (!operationSnapshot.getErrorCode().getCode().equals(StatusCode.Code.OK)) {
         throw ApiExceptionFactory.createException(
-            "Operation with name \""
-                + operationSnapshot.getName()
-                + "\" failed with status = "
-                + operationSnapshot.getErrorCode(),
-            null,
-            operationSnapshot.getErrorCode(),
-            false);
+            operationSnapshot.getErrorMessage(), null, operationSnapshot.getErrorCode(), false);
       }
       if (operationSnapshot.getResponse() == null) {
         return null;
@@ -285,7 +281,8 @@ public class OperationCallableImplTest {
     String opName = "testFutureCallInitialDoneWithError";
     StatusCode errorCode = FakeStatusCode.of(StatusCode.Code.ALREADY_EXISTS);
     Currency meta = Currency.getInstance("UAH");
-    OperationSnapshot resultOperation = getOperation(opName, null, errorCode, meta, true);
+    OperationSnapshot resultOperation =
+        getOperation(opName, null, errorCode, meta, true, "Already exists error");
     UnaryCallable<Integer, OperationSnapshot> initialCallable =
         mockGetOpSnapshotCallable(StatusCode.Code.OK, resultOperation);
     LongRunningClient longRunningClient = new UnsupportedOperationApi();
@@ -297,7 +294,8 @@ public class OperationCallableImplTest {
     OperationFuture<Color, Currency> future =
         callable.futureCall(2, FakeCallContext.createDefault());
 
-    assertFutureFailMetaSuccess(future, meta, FakeStatusCode.of(StatusCode.Code.ALREADY_EXISTS));
+    assertFutureFailMetaSuccess(
+        future, meta, FakeStatusCode.of(StatusCode.Code.ALREADY_EXISTS), "Already exists error");
     assertThat(executor.getIterationsCount()).isEqualTo(0);
   }
 
@@ -318,7 +316,11 @@ public class OperationCallableImplTest {
     OperationFuture<Color, Currency> future =
         callable.futureCall(2, FakeCallContext.createDefault());
 
-    assertFutureFailMetaSuccess(future, meta, FakeStatusCode.of(StatusCode.Code.OK));
+    assertFutureFailMetaSuccess(
+        future,
+        meta,
+        FakeStatusCode.of(StatusCode.Code.OK),
+        "type mismatch: expected java.awt.Color, found java.util.Currency");
     assertThat(executor.getIterationsCount()).isEqualTo(0);
   }
 
@@ -516,12 +518,14 @@ public class OperationCallableImplTest {
     String opName = "testFutureCallPollDoneWithError";
     Currency meta = Currency.getInstance("UAH");
     Color resp = getColor(1.0f);
-    OperationSnapshot initialOperation = getOperation(opName, resp, null, meta, false);
+    OperationSnapshot initialOperation =
+        getOperation(opName, resp, null, meta, false, "Already exists error");
     UnaryCallable<Integer, OperationSnapshot> initialCallable =
         mockGetOpSnapshotCallable(StatusCode.Code.OK, initialOperation);
 
     StatusCode errorCode = FakeStatusCode.of(StatusCode.Code.ALREADY_EXISTS);
-    OperationSnapshot resultOperation = getOperation(opName, null, errorCode, meta, true);
+    OperationSnapshot resultOperation =
+        getOperation(opName, null, errorCode, meta, true, "Already exists error");
     LongRunningClient longRunningClient = mockGetOperation(StatusCode.Code.OK, resultOperation);
 
     OperationCallable<Integer, Color, Currency> callable =
@@ -530,7 +534,8 @@ public class OperationCallableImplTest {
     OperationFuture<Color, Currency> future =
         callable.futureCall(2, FakeCallContext.createDefault());
 
-    assertFutureFailMetaSuccess(future, meta, FakeStatusCode.of(StatusCode.Code.ALREADY_EXISTS));
+    assertFutureFailMetaSuccess(
+        future, meta, FakeStatusCode.of(StatusCode.Code.ALREADY_EXISTS), "Already exists error");
     assertThat(executor.getIterationsCount()).isEqualTo(0);
   }
 
@@ -660,7 +665,7 @@ public class OperationCallableImplTest {
     OperationFuture<Color, Currency> future =
         callable.futureCall(2, FakeCallContext.createDefault());
 
-    assertFutureFailMetaSuccess(future, meta, FakeStatusCode.of(StatusCode.Code.CANCELLED));
+    assertFutureFailMetaSuccess(future, meta, FakeStatusCode.of(StatusCode.Code.CANCELLED), null);
     assertThat(executor.getIterationsCount()).isEqualTo(0);
   }
 
@@ -684,7 +689,7 @@ public class OperationCallableImplTest {
     OperationFuture<Color, Currency> future =
         callable.futureCall(2, FakeCallContext.createDefault());
 
-    assertFutureFailMetaSuccess(future, meta, FakeStatusCode.of(StatusCode.Code.CANCELLED));
+    assertFutureFailMetaSuccess(future, meta, FakeStatusCode.of(StatusCode.Code.CANCELLED), null);
     assertThat(executor.getIterationsCount()).isEqualTo(1);
   }
 
@@ -862,7 +867,10 @@ public class OperationCallableImplTest {
   }
 
   private void assertFutureFailMetaSuccess(
-      OperationFuture<Color, Currency> future, Currency meta, FakeStatusCode statusCode)
+      OperationFuture<Color, Currency> future,
+      Currency meta,
+      FakeStatusCode statusCode,
+      String errorMessage)
       throws TimeoutException, InterruptedException, ExecutionException {
     Exception exception = null;
     try {
@@ -875,6 +883,7 @@ public class OperationCallableImplTest {
     assertExceptionMatchesCode(statusCode, exception.getCause());
     ApiException cause = (ApiException) exception.getCause();
     assertThat(cause.getStatusCode()).isEqualTo(statusCode);
+    assertThat(cause.getMessage()).isEqualTo(errorMessage);
     assertThat(future.isDone()).isTrue();
     assertThat(future.isCancelled()).isFalse();
 
@@ -972,7 +981,12 @@ public class OperationCallableImplTest {
   }
 
   private OperationSnapshot getOperation(
-      String name, Object response, StatusCode errorCode, Object metadata, boolean done) {
+      String name,
+      Object response,
+      StatusCode errorCode,
+      Object metadata,
+      boolean done,
+      String errorMessage) {
     FakeOperationSnapshot.Builder builder =
         FakeOperationSnapshot.newBuilder().setName(name).setDone(done);
     if (response != null) {
@@ -986,7 +1000,15 @@ public class OperationCallableImplTest {
     if (metadata != null) {
       builder.setMetadata(metadata);
     }
+    if (errorMessage != null) {
+      builder.setErrorMessage(errorMessage);
+    }
     return builder.build();
+  }
+
+  private OperationSnapshot getOperation(
+      String name, Object response, StatusCode errorCode, Object metadata, boolean done) {
+    return getOperation(name, response, errorCode, metadata, done, null);
   }
 
   private <RequestT> UnaryCallable<RequestT, OperationSnapshot> mockGetOpSnapshotCallable(

--- a/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
@@ -299,7 +299,7 @@ public class OperationCallableImplTest {
 
     OperationFuture<Color, Currency> future =
         callable.futureCall(2, FakeCallContext.createDefault());
-    
+
     String errorMessage =
         "Operation with name \""
             + opName
@@ -546,7 +546,7 @@ public class OperationCallableImplTest {
             initialCallable, callSettings, initialContext, longRunningClient);
     OperationFuture<Color, Currency> future =
         callable.futureCall(2, FakeCallContext.createDefault());
-    
+
     String errorMessage =
         "Operation with name \""
             + opName
@@ -692,7 +692,8 @@ public class OperationCallableImplTest {
             + errorCode
             + " and message = "
             + "null";
-    assertFutureFailMetaSuccess(future, meta, FakeStatusCode.of(StatusCode.Code.CANCELLED), errorMessage);
+    assertFutureFailMetaSuccess(
+        future, meta, FakeStatusCode.of(StatusCode.Code.CANCELLED), errorMessage);
     assertThat(executor.getIterationsCount()).isEqualTo(0);
   }
 
@@ -723,7 +724,8 @@ public class OperationCallableImplTest {
             + errorCode
             + " and message = "
             + "null";
-    assertFutureFailMetaSuccess(future, meta, FakeStatusCode.of(StatusCode.Code.CANCELLED), errorMessage);
+    assertFutureFailMetaSuccess(
+        future, meta, FakeStatusCode.of(StatusCode.Code.CANCELLED), errorMessage);
     assertThat(executor.getIterationsCount()).isEqualTo(1);
   }
 

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeOperationSnapshot.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeOperationSnapshot.java
@@ -56,6 +56,10 @@ public abstract class FakeOperationSnapshot implements OperationSnapshot {
   @Override
   public abstract StatusCode getErrorCode();
 
+  @Override
+  @Nullable
+  public abstract String getErrorMessage();
+
   public static Builder newBuilder() {
     return new AutoValue_FakeOperationSnapshot.Builder();
   }
@@ -71,6 +75,8 @@ public abstract class FakeOperationSnapshot implements OperationSnapshot {
     public abstract Builder setResponse(Object value);
 
     public abstract Builder setErrorCode(StatusCode value);
+
+    public abstract Builder setErrorMessage(String value);
 
     public abstract FakeOperationSnapshot build();
   }


### PR DESCRIPTION
when an operation fails with an error message, store the error message in OperationSnapshot and put the error message in the message of the ApiException to throw.