### PR TITLE
batching: fix permit leak

### DIFF
--- a/gax/src/main/java/com/google/api/gax/batching/AccumulatingBatchReceiver.java
+++ b/gax/src/main/java/com/google/api/gax/batching/AccumulatingBatchReceiver.java
@@ -34,11 +34,17 @@ import com.google.api.core.ApiFutures;
 import com.google.api.core.BetaApi;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
-/** A simple ThresholdBatchReceiver that just accumulates batches. Not thread-safe. */
+/** A simple ThresholdBatchReceiver that just accumulates batches. */
 @BetaApi("The surface for batching is not stable yet and may change in the future.")
 public final class AccumulatingBatchReceiver<T> implements ThresholdBatchReceiver<T> {
-  private final List<T> batches = new ArrayList<>();
+  private final ConcurrentLinkedQueue<T> batches = new ConcurrentLinkedQueue<>();
+  private final ApiFuture<?> retFuture;
+
+  public AccumulatingBatchReceiver(ApiFuture<?> retFuture) {
+    this.retFuture = retFuture;
+  }
 
   @Override
   public void validateBatch(T message) {
@@ -48,11 +54,11 @@ public final class AccumulatingBatchReceiver<T> implements ThresholdBatchReceive
   @Override
   public ApiFuture<?> processBatch(T batch) {
     batches.add(batch);
-    return ApiFutures.<Void>immediateFuture(null);
+    return retFuture;
   }
 
-  /** Returns the accumulated batches. */
+  /** Returns the accumulated batches. If called concurrently with {@code processBatch}, the new batch may or may not be returned. */
   public List<T> getBatches() {
-    return batches;
+    return new ArrayList<>(batches);
   }
 }

--- a/gax/src/main/java/com/google/api/gax/batching/AccumulatingBatchReceiver.java
+++ b/gax/src/main/java/com/google/api/gax/batching/AccumulatingBatchReceiver.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.batching;
 
 import com.google.api.core.ApiFuture;
-import com.google.api.core.ApiFutures;
 import com.google.api.core.BetaApi;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,7 +56,10 @@ public final class AccumulatingBatchReceiver<T> implements ThresholdBatchReceive
     return retFuture;
   }
 
-  /** Returns the accumulated batches. If called concurrently with {@code processBatch}, the new batch may or may not be returned. */
+  /**
+   * Returns the accumulated batches. If called concurrently with {@code processBatch}, the new
+   * batch may or may not be returned.
+   */
   public List<T> getBatches() {
     return new ArrayList<>(batches);
   }

--- a/gax/src/main/java/com/google/api/gax/batching/ThresholdBatcher.java
+++ b/gax/src/main/java/com/google/api/gax/batching/ThresholdBatcher.java
@@ -33,10 +33,10 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
-import com.google.api.core.ApiFutures;
-import com.google.api.core.SettableApiFuture;
 import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
 import com.google.api.core.BetaApi;
+import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.batching.FlowController.FlowControlException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -229,19 +229,22 @@ public final class ThresholdBatcher<E> {
     // separately to release. This probably works as most users expect,
     // but makes this class hard to test: retFuture.get() returning
     // won't guarantee that flow control has been released.
-    ApiFutures.addCallback(receiver.processBatch(batch), new ApiFutureCallback<Object>() {
-      @Override
-      public void onSuccess(Object obj) {
-        flowController.release(batch);
-        retFuture.set(null);
-      }
+    ApiFutures.addCallback(
+        receiver.processBatch(batch),
+        new ApiFutureCallback<Object>() {
+          @Override
+          public void onSuccess(Object obj) {
+            flowController.release(batch);
+            retFuture.set(null);
+          }
 
-      @Override
-      public void onFailure(Throwable t) {
-        flowController.release(batch);
-        retFuture.setException(t);
-      }
-    }, directExecutor());
+          @Override
+          public void onFailure(Throwable t) {
+            flowController.release(batch);
+            retFuture.setException(t);
+          }
+        },
+        directExecutor());
 
     return retFuture;
   }

--- a/gax/src/main/java/com/google/api/gax/batching/ThresholdBatcher.java
+++ b/gax/src/main/java/com/google/api/gax/batching/ThresholdBatcher.java
@@ -34,6 +34,8 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
+import com.google.api.core.SettableApiFuture;
+import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.BetaApi;
 import com.google.api.gax.batching.FlowController.FlowControlException;
 import com.google.common.annotations.VisibleForTesting;
@@ -216,10 +218,32 @@ public final class ThresholdBatcher<E> {
     final E batch = removeBatch();
     if (batch == null) {
       return ApiFutures.immediateFuture(null);
-    } else {
-      return ApiFutures.transform(
-          receiver.processBatch(batch), new ReleaseResourcesFunction<>(batch), directExecutor());
     }
+
+    final SettableApiFuture<Void> retFuture = SettableApiFuture.create();
+
+    // It is tempting to use transform to both release and get ApiFuture<Void>.
+    // This is incorrect because we also need to release on failure.
+    //
+    // It is also tempting to transform to get ApiFuture<Void> and addListener
+    // separately to release. This probably works as most users expect,
+    // but makes this class hard to test: retFuture.get() returning
+    // won't guarantee that flow control has been released.
+    ApiFutures.addCallback(receiver.processBatch(batch), new ApiFutureCallback<Object>() {
+      @Override
+      public void onSuccess(Object obj) {
+        flowController.release(batch);
+        retFuture.set(null);
+      }
+
+      @Override
+      public void onFailure(Throwable t) {
+        flowController.release(batch);
+        retFuture.setException(t);
+      }
+    }, directExecutor());
+
+    return retFuture;
   }
 
   private E removeBatch() {

--- a/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
@@ -319,10 +319,9 @@ public class ThresholdBatcherTest {
 
   @Test
   public void testBatchingFailedRPC() throws Exception {
+    Exception ex = new IllegalStateException("does nothing, unsuccessfully");
     AccumulatingBatchReceiver<SimpleBatch> receiver =
-        new AccumulatingBatchReceiver<>(
-            ApiFutures.<Void>immediateFailedFuture(
-                new IllegalStateException("does nothing, unsuccessfully")));
+        new AccumulatingBatchReceiver<>(ApiFutures.<Void>immediateFailedFuture(ex));
     ThresholdBatcher<SimpleBatch> batcher =
         createSimpleBatcherBuidler(receiver)
             .setThresholds(BatchingThresholds.<SimpleBatch>create(4))
@@ -342,6 +341,7 @@ public class ThresholdBatcherTest {
       Assert.fail("expected exception");
     } catch (Exception e) {
       assertThat(e).isInstanceOf(ExecutionException.class);
+      assertThat(e).hasCauseThat().isSameAs(ex);
     }
     assertThat(receiver.getBatches()).hasSize(1);
 

--- a/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
@@ -151,11 +151,11 @@ public class ThresholdBatcherTest {
     ThresholdBatcher<SimpleBatch> batcher = createSimpleBatcherBuidler(receiver).build();
     batcher.add(SimpleBatch.fromInteger(14));
     assertThat(batcher.isEmpty()).isFalse();
-    assertThat(receiver.getBatches().size()).isEqualTo(0);
+    assertThat(receiver.getBatches()).hasSize(0);
 
     batcher.pushCurrentBatch().get();
     assertThat(batcher.isEmpty()).isTrue();
-    assertThat(receiver.getBatches().size()).isEqualTo(1);
+    assertThat(receiver.getBatches()).hasSize(1);
     assertThat(receiver.getBatches().get(0).getIntegers()).isEqualTo(Arrays.asList(14));
   }
 
@@ -172,13 +172,13 @@ public class ThresholdBatcherTest {
     batcher.add(SimpleBatch.fromInteger(5));
     // Give time for the executor to push the batch
     Thread.sleep(100);
-    assertThat(receiver.getBatches().size()).isEqualTo(1);
+    assertThat(receiver.getBatches()).hasSize(1);
 
     batcher.add(SimpleBatch.fromInteger(7));
     batcher.add(SimpleBatch.fromInteger(9));
     // Give time for the executor to push the batch
     Thread.sleep(100);
-    assertThat(receiver.getBatches().size()).isEqualTo(2);
+    assertThat(receiver.getBatches()).hasSize(2);
 
     batcher.add(SimpleBatch.fromInteger(11));
 
@@ -204,7 +204,7 @@ public class ThresholdBatcherTest {
     batcher.add(SimpleBatch.fromInteger(5));
     // Give time for the delay to trigger and push the batch
     Thread.sleep(500);
-    assertThat(receiver.getBatches().size()).isEqualTo(1);
+    assertThat(receiver.getBatches()).hasSize(1);
 
     batcher.add(SimpleBatch.fromInteger(11));
 
@@ -251,11 +251,11 @@ public class ThresholdBatcherTest {
     batcher.add(SimpleBatch.fromInteger(5));
     batcher.add(
         SimpleBatch.fromInteger(7)); // We expect to block here until the first batch is handled
-    assertThat(receiver.getBatches().size()).isEqualTo(1);
+    assertThat(receiver.getBatches()).hasSize(1);
     batcher.add(SimpleBatch.fromInteger(9));
     batcher.add(
         SimpleBatch.fromInteger(11)); // We expect to block here until the second batch is handled
-    assertThat(receiver.getBatches().size()).isEqualTo(2);
+    assertThat(receiver.getBatches()).hasSize(2);
 
     batcher.pushCurrentBatch().get();
 
@@ -299,7 +299,7 @@ public class ThresholdBatcherTest {
     } catch (FlowControlException e) {
     }
     batcher.pushCurrentBatch().get();
-    assertThat(receiver.getBatches().size()).isEqualTo(1);
+    assertThat(receiver.getBatches()).hasSize(1);
     batcher.add(SimpleBatch.fromInteger(11));
     batcher.add(SimpleBatch.fromInteger(13));
     batcher.pushCurrentBatch().get();

--- a/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
@@ -31,18 +31,18 @@ package com.google.api.gax.batching;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.api.core.ApiFutures;
 import com.google.api.gax.batching.FlowController.FlowControlException;
 import com.google.api.gax.batching.FlowController.LimitExceededBehavior;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import com.google.api.core.ApiFutures;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.Assert;
 import org.junit.rules.ExpectedException;
 import org.threeten.bp.Duration;
 
@@ -146,7 +146,8 @@ public class ThresholdBatcherTest {
 
   @Test
   public void testAdd() throws Exception {
-    AccumulatingBatchReceiver<SimpleBatch> receiver = new AccumulatingBatchReceiver<>(ApiFutures.<Void>immediateFuture(null));
+    AccumulatingBatchReceiver<SimpleBatch> receiver =
+        new AccumulatingBatchReceiver<>(ApiFutures.<Void>immediateFuture(null));
     ThresholdBatcher<SimpleBatch> batcher = createSimpleBatcherBuidler(receiver).build();
     batcher.add(SimpleBatch.fromInteger(14));
     assertThat(batcher.isEmpty()).isFalse();
@@ -160,7 +161,8 @@ public class ThresholdBatcherTest {
 
   @Test
   public void testBatching() throws Exception {
-    AccumulatingBatchReceiver<SimpleBatch> receiver = new AccumulatingBatchReceiver<>(ApiFutures.<Void>immediateFuture(null));
+    AccumulatingBatchReceiver<SimpleBatch> receiver =
+        new AccumulatingBatchReceiver<>(ApiFutures.<Void>immediateFuture(null));
     ThresholdBatcher<SimpleBatch> batcher =
         createSimpleBatcherBuidler(receiver)
             .setThresholds(BatchingThresholds.<SimpleBatch>create(2))
@@ -193,7 +195,8 @@ public class ThresholdBatcherTest {
 
   @Test
   public void testBatchingWithDelay() throws Exception {
-    AccumulatingBatchReceiver<SimpleBatch> receiver = new AccumulatingBatchReceiver<>(ApiFutures.<Void>immediateFuture(null));
+    AccumulatingBatchReceiver<SimpleBatch> receiver =
+        new AccumulatingBatchReceiver<>(ApiFutures.<Void>immediateFuture(null));
     ThresholdBatcher<SimpleBatch> batcher =
         createSimpleBatcherBuidler(receiver).setMaxDelay(Duration.ofMillis(100)).build();
 
@@ -222,14 +225,16 @@ public class ThresholdBatcherTest {
         .setThresholds(BatchingThresholds.<SimpleBatch>create(100))
         .setExecutor(EXECUTOR)
         .setMaxDelay(Duration.ofMillis(10000))
-        .setReceiver(new AccumulatingBatchReceiver<SimpleBatch>(ApiFutures.<Void>immediateFuture(null)))
+        .setReceiver(
+            new AccumulatingBatchReceiver<SimpleBatch>(ApiFutures.<Void>immediateFuture(null)))
         .setBatchMerger(new SimpleBatchMerger())
         .build();
   }
 
   @Test
   public void testBatchingWithFlowControl() throws Exception {
-    AccumulatingBatchReceiver<SimpleBatch> receiver = new AccumulatingBatchReceiver<>(ApiFutures.<Void>immediateFuture(null));
+    AccumulatingBatchReceiver<SimpleBatch> receiver =
+        new AccumulatingBatchReceiver<>(ApiFutures.<Void>immediateFuture(null));
     ThresholdBatcher<SimpleBatch> batcher =
         createSimpleBatcherBuidler(receiver)
             .setThresholds(BatchingThresholds.<SimpleBatch>create(2))
@@ -270,7 +275,8 @@ public class ThresholdBatcherTest {
 
   @Test
   public void testBatchingFlowControlExceptionRecovery() throws Exception {
-    AccumulatingBatchReceiver<SimpleBatch> receiver = new AccumulatingBatchReceiver<>(ApiFutures.<Void>immediateFuture(null));
+    AccumulatingBatchReceiver<SimpleBatch> receiver =
+        new AccumulatingBatchReceiver<>(ApiFutures.<Void>immediateFuture(null));
     ThresholdBatcher<SimpleBatch> batcher =
         createSimpleBatcherBuidler(receiver)
             .setThresholds(BatchingThresholds.<SimpleBatch>create(4))
@@ -313,7 +319,10 @@ public class ThresholdBatcherTest {
 
   @Test
   public void testBatchingFailedRPC() throws Exception {
-    AccumulatingBatchReceiver<SimpleBatch> receiver = new AccumulatingBatchReceiver<>(ApiFutures.<Void>immediateFailedFuture(new IllegalStateException("does nothing, unsuccessfully")));
+    AccumulatingBatchReceiver<SimpleBatch> receiver =
+        new AccumulatingBatchReceiver<>(
+            ApiFutures.<Void>immediateFailedFuture(
+                new IllegalStateException("does nothing, unsuccessfully")));
     ThresholdBatcher<SimpleBatch> batcher =
         createSimpleBatcherBuidler(receiver)
             .setThresholds(BatchingThresholds.<SimpleBatch>create(4))


### PR DESCRIPTION
Previously flow control was released only if the RPC returns
successfully. This caused us to leak permits if RPCs fail.

This commit makes us unconditionally release permits.