### PR TITLE
Make sure to preserve the caller's stacktrace when calling sync variants of UnaryCallables.

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/AsyncTaskException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/AsyncTaskException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google LLC
+ * Copyright 2017 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,36 +29,14 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.ApiFuture;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.UncheckedExecutionException;
-
-/** A utility class for working with {@link ApiException}. */
-public class ApiExceptions {
-  private ApiExceptions() {}
-
-  /**
-   * Invokes {@link ApiFuture#get()} on the given future, and if the call throws an exception (which
-   * will be {@link UncheckedExecutionException}), the exception is processed in the following way:
-   *
-   * <ol>
-   *   <li>If the exception cause is a RuntimeException, the RuntimeException is rethrown. To ease
-   *       debugging, the a {@link AsyncTaskException} is added as a suppressed exception to
-   *       maintain the callsite.
-   *   <li>Otherwise, the UncheckedExecutionException is rethrown.
-   * </ol>
-   */
-  public static <ResponseT> ResponseT callAndTranslateApiException(ApiFuture<ResponseT> future) {
-    try {
-      return Futures.getUnchecked(future);
-    } catch (UncheckedExecutionException exception) {
-      if (exception.getCause() instanceof RuntimeException) {
-        RuntimeException cause = (RuntimeException) exception.getCause();
-        cause.addSuppressed(new AsyncTaskException());
-        throw cause;
-      }
-
-      throw exception;
-    }
+/**
+ * This exception is used to preserve the caller's stacktrace when invoking an async task in a sync
+ * context. It will be added as a suppressed exception when propagating the async exception. This
+ * allows callers to catch ApiException thrown in an async operation, while still maintaining the
+ * call site.
+ */
+public class AsyncTaskException extends RuntimeException {
+  AsyncTaskException() {
+    super("Asynchronous task failed");
   }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamIterator.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamIterator.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.rpc;
 
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -98,11 +99,20 @@ final class ServerStreamIterator<V> implements Iterator<V> {
         throw new RuntimeException(e);
       }
     }
+    // Preserve async error while keeping the callers stacktrace as a suppressed exception
+    if (last instanceof RuntimeException) {
+      RuntimeException runtimeException = (RuntimeException) last;
+      runtimeException.addSuppressed(new RuntimeException("Asynchronous task failed"));
+      throw runtimeException;
+    }
+
+    // This should never really happen because currently gax doesn't throw checked exceptions
+    // Wrap checked exceptions. This will preserve both the callers stacktrace and the async error.
     if (last instanceof Throwable) {
       Throwable throwable = (Throwable) last;
-
-      throw new RuntimeException(throwable);
+      throw new UncheckedExecutionException(throwable);
     }
+
     return last != QueuingResponseObserver.EOF_MARKER;
   }
 

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamIterator.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamIterator.java
@@ -99,15 +99,15 @@ final class ServerStreamIterator<V> implements Iterator<V> {
         throw new RuntimeException(e);
       }
     }
-    // Preserve async error while keeping the callers stacktrace as a suppressed exception
+    // Preserve async error while keeping the caller's stacktrace as a suppressed exception
     if (last instanceof RuntimeException) {
       RuntimeException runtimeException = (RuntimeException) last;
       runtimeException.addSuppressed(new RuntimeException("Asynchronous task failed"));
       throw runtimeException;
     }
 
-    // This should never really happen because currently gax doesn't throw checked exceptions
-    // Wrap checked exceptions. This will preserve both the callers stacktrace and the async error.
+    // This should never really happen because currently gax doesn't throw checked exceptions.
+    // Wrap checked exceptions. This will preserve both the caller's stacktrace and the async error.
     if (last instanceof Throwable) {
       Throwable throwable = (Throwable) last;
       throw new UncheckedExecutionException(throwable);

--- a/gax/src/test/java/com/google/api/gax/rpc/ApiExceptionsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ApiExceptionsTest.java
@@ -29,11 +29,17 @@
  */
 package com.google.api.gax.rpc;
 
+import static com.google.common.truth.Truth.*;
+
 import com.google.api.core.ApiFutures;
+import com.google.api.core.ListenableFutureToApiFuture;
 import com.google.api.gax.rpc.testing.FakeStatusCode;
-import com.google.common.truth.Truth;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.io.IOException;
+import java.util.concurrent.Executors;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -47,7 +53,7 @@ public class ApiExceptionsTest {
   @Test
   public void noException() {
     Integer result = ApiExceptions.callAndTranslateApiException(ApiFutures.immediateFuture(2));
-    Truth.assertThat(result).isEqualTo(2);
+    assertThat(result).isEqualTo(2);
   }
 
   @Test
@@ -69,5 +75,53 @@ public class ApiExceptionsTest {
     thrown.expect(IllegalArgumentException.class);
     ApiExceptions.callAndTranslateApiException(
         ApiFutures.immediateFailedFuture(new IllegalArgumentException()));
+  }
+
+  /**
+   * Make sure that the caller's stacktrace is preserved when the future is unwrapped. The
+   * stacktrace will be preserved as a suppressed RuntimeException.
+   */
+  @Test
+  public void containsCurrentStacktrace() {
+    final String currentMethod = "containsCurrentStacktrace";
+
+    // Throw an error in an executor, which will cause it to lose the current stack frame
+    ListeningExecutorService executor =
+        MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor());
+
+    ListenableFuture<?> futureError =
+        executor.submit(
+            new Runnable() {
+              @Override
+              public void run() {
+                throw new IllegalArgumentException();
+              }
+            });
+    ListenableFutureToApiFuture<?> futureErrorWrapper =
+        new ListenableFutureToApiFuture<>(futureError);
+    executor.shutdown();
+
+    // Unwrap the future
+    Exception actualError = null;
+    try {
+      ApiExceptions.callAndTranslateApiException(futureErrorWrapper);
+    } catch (Exception e) {
+      actualError = e;
+    }
+
+    // Sanity check that the current stack trace is not in the exception
+    assertThat(actualError).isNotNull();
+    assertThat(isMethodInStacktrace(currentMethod, actualError)).isFalse();
+    assertThat(isMethodInStacktrace(currentMethod, actualError.getSuppressed()[0])).isTrue();
+  }
+
+  private static boolean isMethodInStacktrace(String method, Throwable t) {
+    for (StackTraceElement e : t.getStackTrace()) {
+      if (method.equals(e.getMethodName())) {
+        return true;
+      }
+    }
+
+    return false;
   }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/ApiExceptionsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ApiExceptionsTest.java
@@ -29,7 +29,7 @@
  */
 package com.google.api.gax.rpc;
 
-import static com.google.common.truth.Truth.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.core.ApiFutures;
 import com.google.api.core.ListenableFutureToApiFuture;

--- a/gax/src/test/java/com/google/api/gax/rpc/ApiExceptionsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ApiExceptionsTest.java
@@ -112,6 +112,8 @@ public class ApiExceptionsTest {
     // Sanity check that the current stack trace is not in the exception
     assertThat(actualError).isNotNull();
     assertThat(isMethodInStacktrace(currentMethod, actualError)).isFalse();
+
+    // Verify that it is preserved as a suppressed exception.
     assertThat(isMethodInStacktrace(currentMethod, actualError.getSuppressed()[0])).isTrue();
   }
 

--- a/gax/src/test/java/com/google/api/gax/rpc/ApiExceptionsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ApiExceptionsTest.java
@@ -114,6 +114,7 @@ public class ApiExceptionsTest {
     assertThat(isMethodInStacktrace(currentMethod, actualError)).isFalse();
 
     // Verify that it is preserved as a suppressed exception.
+    assertThat(actualError.getSuppressed()[0]).isInstanceOf(AsyncTaskException.class);
     assertThat(isMethodInStacktrace(currentMethod, actualError.getSuppressed()[0])).isTrue();
   }
 

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamTest.java
@@ -37,12 +37,10 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +54,7 @@ public class ServerStreamTest {
   private ExecutorService executor;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     stream = new ServerStream<>();
     controller = new MockStreamController<>(stream.observer());
 
@@ -65,7 +63,7 @@ public class ServerStreamTest {
   }
 
   @After
-  public void tearDown() throws Exception {
+  public void tearDown() {
     executor.shutdownNow();
   }
 
@@ -82,7 +80,7 @@ public class ServerStreamTest {
         executor.submit(
             new Callable<Void>() {
               @Override
-              public Void call() throws InterruptedException {
+              public Void call() {
                 for (int i = 0; i < 5; i++) {
                   int requestCount = controller.popLastPull();
 
@@ -101,7 +99,7 @@ public class ServerStreamTest {
         executor.submit(
             new Callable<List<Integer>>() {
               @Override
-              public List<Integer> call() throws Exception {
+              public List<Integer> call() {
                 return Lists.newArrayList(stream);
               }
             });
@@ -117,7 +115,7 @@ public class ServerStreamTest {
         executor.submit(
             new Callable<Void>() {
               @Override
-              public Void call() throws InterruptedException, ExecutionException, TimeoutException {
+              public Void call() {
                 int i = 0;
                 while (controller.popLastPull() > 0) {
                   stream.observer().onResponse(i++);
@@ -155,12 +153,12 @@ public class ServerStreamTest {
       actualError = t;
     }
 
-    Truth.assertThat(actualError.getCause()).hasMessageThat().contains(e.getMessage());
-    Truth.assertThat(actualError.getCause()).isEqualTo(e);
+    Truth.assertThat(actualError).hasMessageThat().contains(e.getMessage());
+    Truth.assertThat(actualError).isEqualTo(e);
   }
 
   @Test
-  public void testNoErrorsBetweenHasNextAndNext() throws InterruptedException {
+  public void testNoErrorsBetweenHasNextAndNext() {
     Iterator<Integer> it = stream.iterator();
 
     controller.popLastPull();
@@ -177,12 +175,12 @@ public class ServerStreamTest {
       it.next();
       throw new RuntimeException("ServerStream never threw an error!");
     } catch (RuntimeException e) {
-      Truth.assertThat(e.getCause()).isSameAs(fakeError);
+      Truth.assertThat(e).isSameAs(fakeError);
     }
   }
 
   @Test
-  public void testReady() throws InterruptedException {
+  public void testReady() {
     Iterator<Integer> it = stream.iterator();
     Truth.assertThat(stream.isReceiveReady()).isFalse();
 
@@ -221,18 +219,19 @@ public class ServerStreamTest {
     Throwable actualError = null;
 
     try {
-      it.hasNext();
+      @SuppressWarnings("unused")
+      boolean ignored = it.hasNext();
     } catch (Throwable t) {
       actualError = t;
     }
 
-    Truth.assertThat(actualError.getCause()).isEqualTo(expectError);
+    Truth.assertThat(actualError).isEqualTo(expectError);
 
     try {
       it.next();
     } catch (Throwable t) {
       actualError = t;
     }
-    Truth.assertThat(actualError.getCause()).isEqualTo(expectError);
+    Truth.assertThat(actualError).isEqualTo(expectError);
   }
 }


### PR DESCRIPTION
Fixes #484

The stacktrace will be preserved as a suppressed exception. This is a bit of hack, but provides a good balance between keeping current behavior of being able to catch exceptions in try-catch block and allowing the caller to debug where in their application the error occurred.