### PR TITLE
Use initial RPC timeout in the first attempt

### DIFF
--- a/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
@@ -69,7 +69,7 @@ public class ExponentialRetryAlgorithm implements TimedRetryAlgorithm {
     return TimedAttemptSettings.newBuilder()
         .setGlobalSettings(globalSettings)
         .setRetryDelay(Duration.ZERO)
-        .setRpcTimeout(globalSettings.getTotalTimeout())
+        .setRpcTimeout(globalSettings.getInitialRpcTimeout())
         .setRandomizedRetryDelay(Duration.ZERO)
         .setAttemptCount(0)
         .setFirstAttemptStartTimeNanos(clock.nanoTime())


### PR DESCRIPTION
ExponentialRetryAlgorithm uses the total RPC timeout in the first
attempt. It should start with the initial RPC timeout instead: some
servers may enforce a max request deadline and treat a (usually longer)
total timeout as an invalid argument and thus fail the request.