### PR TITLE
RFC: rough sketch of retry tracing (DON'T MERGE)

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -32,6 +32,8 @@ package com.google.api.gax.grpc;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.core.InternalExtensionOnly;
+import com.google.api.gax.opencensus.NoopTracer;
+import com.google.api.gax.opencensus.Tracer;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.DeadlineExceededException;
 import com.google.api.gax.rpc.TransportChannel;
@@ -41,6 +43,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
+import io.grpc.CallOptions.Key;
 import io.grpc.Channel;
 import io.grpc.Deadline;
 import io.grpc.Metadata;
@@ -64,6 +67,8 @@ import org.threeten.bp.Duration;
 @BetaApi("Reference ApiCallContext instead - this class is likely to experience breaking changes")
 @InternalExtensionOnly
 public final class GrpcCallContext implements ApiCallContext {
+  private static final CallOptions.Key<Tracer> TRACER_KEY = Key.createWithDefault("tracer", NoopTracer.create());
+
   private final Channel channel;
   private final CallOptions callOptions;
   @Nullable private final Duration streamWaitTimeout;
@@ -294,6 +299,16 @@ public final class GrpcCallContext implements ApiCallContext {
   @Nullable
   public Duration getStreamIdleTimeout() {
     return streamIdleTimeout;
+  }
+
+  @Override
+  public ApiCallContext withTracer(Tracer tracer) {
+    return withCallOptions(callOptions.withOption(TRACER_KEY, tracer));
+  }
+
+  @Override
+  public Tracer getTracer() {
+    return callOptions.getOption(TRACER_KEY);
   }
 
   /** The channel affinity for this context. */

--- a/gax/src/main/java/com/google/api/gax/opencensus/NoopTracer.java
+++ b/gax/src/main/java/com/google/api/gax/opencensus/NoopTracer.java
@@ -1,0 +1,74 @@
+package com.google.api.gax.opencensus;
+
+import org.threeten.bp.Duration;
+
+public class NoopTracer implements Tracer {
+  public static Tracer create() {
+    return new NoopTracer();
+  }
+
+  @Override
+  public void operationStarted() {
+
+  }
+
+  @Override
+  public void operationFailed(Throwable throwable) {
+
+  }
+
+  @Override
+  public void operationSucceeded() {
+
+  }
+
+  @Override
+  public void connectionSelected(int id) {
+
+  }
+
+  @Override
+  public void credentialsRefreshed() {
+
+  }
+
+  @Override
+  public void startAttempt() {
+
+  }
+
+  @Override
+  public void attemptSucceeded() {
+
+  }
+
+  @Override
+  public void retryableFailure(Throwable error, Duration delay) {
+
+  }
+
+  @Override
+  public void retriesExhausted() {
+
+  }
+
+  @Override
+  public void permanentFailure(Throwable error) {
+
+  }
+
+  @Override
+  public void receivedResponse() {
+
+  }
+
+  @Override
+  public void sentRequest() {
+
+  }
+
+  @Override
+  public void sentBatchRequest(int elementCount, int requestSize) {
+
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/opencensus/OpenCensusTracer.java
+++ b/gax/src/main/java/com/google/api/gax/opencensus/OpenCensusTracer.java
@@ -1,0 +1,89 @@
+package com.google.api.gax.opencensus;
+
+import java.io.Closeable;
+import org.threeten.bp.Duration;
+
+public class OpenCensusTracer implements Tracer {
+
+  public static OpenCensusTracer create(String spanName) {
+
+    return null;
+  }
+
+  public TracerContext enter() {
+    return new TracerContext();
+  }
+
+  @Override
+  public void operationStarted() {
+
+  }
+
+  @Override
+  public void operationFailed(Throwable throwable) {
+
+  }
+
+  @Override
+  public void operationSucceeded() {
+
+  }
+
+  @Override
+  public void connectionSelected(int id) {
+
+  }
+
+  @Override
+  public void credentialsRefreshed() {
+
+  }
+
+  @Override
+  public void startAttempt() {
+
+  }
+
+  @Override
+  public void attemptSucceeded() {
+
+  }
+
+  @Override
+  public void retryableFailure(Throwable error, Duration delay) {
+
+  }
+
+  @Override
+  public void retriesExhausted() {
+
+  }
+
+  @Override
+  public void permanentFailure(Throwable error) {
+
+  }
+
+  @Override
+  public void receivedResponse() {
+
+  }
+
+  @Override
+  public void sentRequest() {
+
+  }
+
+  @Override
+  public void sentBatchRequest(int elementCount, int requestSize) {
+
+  }
+
+  static class TracerContext implements AutoCloseable {
+
+    @Override
+    public void close() {
+
+    }
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/opencensus/TracedUnaryCallable.java
+++ b/gax/src/main/java/com/google/api/gax/opencensus/TracedUnaryCallable.java
@@ -1,0 +1,49 @@
+package com.google.api.gax.opencensus;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.util.concurrent.MoreExecutors;
+
+public class TracedUnaryCallable<RequestT, ResponseT> extends UnaryCallable<RequestT, ResponseT> {
+  private final UnaryCallable<RequestT, ResponseT> innerCallable;
+  private final String spanName;
+
+  public TracedUnaryCallable(
+      UnaryCallable<RequestT, ResponseT> innerCallable, String spanName) {
+    this.innerCallable = innerCallable;
+    this.spanName = spanName;
+  }
+
+  @Override
+  public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext context) {
+    final OpenCensusTracer tracer = OpenCensusTracer.create(spanName);
+
+    ApiFuture<ResponseT> innerFuture;
+
+    try (OpenCensusTracer.TracerContext ignored = tracer.enter()) {
+      tracer.operationStarted();
+      context = context.withTracer(tracer);
+
+      innerFuture = innerCallable.futureCall(request, context);
+    }
+
+    ApiFutures.addCallback(innerFuture, new ApiFutureCallback<ResponseT>() {
+      @Override
+      public void onFailure(Throwable throwable) {
+        tracer.operationFailed(throwable);
+      }
+
+      @Override
+      public void onSuccess(ResponseT responseT) {
+        tracer.operationSucceeded();
+      }
+    }, MoreExecutors.directExecutor());
+
+    return innerFuture;
+  }
+
+
+}

--- a/gax/src/main/java/com/google/api/gax/opencensus/TracedUnaryCallable.java
+++ b/gax/src/main/java/com/google/api/gax/opencensus/TracedUnaryCallable.java
@@ -23,8 +23,9 @@ public class TracedUnaryCallable<RequestT, ResponseT> extends UnaryCallable<Requ
 
     ApiFuture<ResponseT> innerFuture;
 
+    tracer.operationStarted();
+
     try (OpenCensusTracer.TracerContext ignored = tracer.enter()) {
-      tracer.operationStarted();
       context = context.withTracer(tracer);
 
       innerFuture = innerCallable.futureCall(request, context);

--- a/gax/src/main/java/com/google/api/gax/opencensus/Tracer.java
+++ b/gax/src/main/java/com/google/api/gax/opencensus/Tracer.java
@@ -1,0 +1,26 @@
+package com.google.api.gax.opencensus;
+
+import com.google.api.core.InternalExtensionOnly;
+import com.google.api.gax.retrying.RetryingFuture;
+import org.threeten.bp.Duration;
+
+@InternalExtensionOnly
+public interface Tracer {
+  void operationStarted();
+  void operationFailed(Throwable throwable);
+  void operationSucceeded();
+
+  void connectionSelected(int id);
+  void credentialsRefreshed();
+
+  void startAttempt();
+  void attemptSucceeded();
+
+  void retryableFailure(Throwable error, Duration delay);
+  void retriesExhausted();
+  void permanentFailure(Throwable error);
+
+  void receivedResponse();
+  void sentRequest();
+  void sentBatchRequest(int elementCount, int requestSize);
+}

--- a/gax/src/main/java/com/google/api/gax/retrying/CallbackChainRetryingFuture.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/CallbackChainRetryingFuture.java
@@ -32,6 +32,7 @@ package com.google.api.gax.retrying;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.gax.opencensus.Tracer;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -58,8 +59,9 @@ class CallbackChainRetryingFuture<ResponseT> extends BasicRetryingFuture<Respons
   CallbackChainRetryingFuture(
       Callable<ResponseT> callable,
       RetryAlgorithm<ResponseT> retryAlgorithm,
-      RetryingExecutor<ResponseT> retryingExecutor) {
-    super(callable, retryAlgorithm);
+      RetryingExecutor<ResponseT> retryingExecutor,
+      Tracer tracer) {
+    super(callable, retryAlgorithm, tracer);
     this.retryingExecutor = checkNotNull(retryingExecutor);
   }
 

--- a/gax/src/main/java/com/google/api/gax/retrying/DirectRetryingExecutor.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/DirectRetryingExecutor.java
@@ -70,7 +70,7 @@ public class DirectRetryingExecutor<ResponseT> implements RetryingExecutor<Respo
    */
   @Override
   public RetryingFuture<ResponseT> createFuture(Callable<ResponseT> callable) {
-    return new BasicRetryingFuture<>(callable, retryAlgorithm);
+    return new BasicRetryingFuture<>(callable, retryAlgorithm, tracer);
   }
 
   /**

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -31,7 +31,9 @@ package com.google.api.gax.rpc;
 
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
+import com.google.api.gax.opencensus.Tracer;
 import com.google.auth.Credentials;
+import com.sun.deploy.trace.Trace;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -119,6 +121,10 @@ public interface ApiCallContext {
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nullable
   Duration getStreamIdleTimeout();
+
+  ApiCallContext withTracer(Tracer tracer);
+
+  Tracer getTracer();
 
   /** If inputContext is not null, returns it; if it is null, returns the present instance. */
   ApiCallContext nullToSelf(ApiCallContext inputContext);

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -59,15 +59,12 @@ public class Callables {
       return innerCallable;
     }
 
-    RetryAlgorithm<ResponseT> retryAlgorithm =
-        new RetryAlgorithm<>(
-            new ApiResultRetryAlgorithm<ResponseT>(),
-            new ExponentialRetryAlgorithm(
-                callSettings.getRetrySettings(), clientContext.getClock()));
-    RetryingExecutor<ResponseT> retryingExecutor =
-        new ScheduledRetryingExecutor<>(retryAlgorithm, clientContext.getExecutor());
     return new RetryingCallable<>(
-        clientContext.getDefaultCallContext(), innerCallable, retryingExecutor);
+        innerCallable,
+        callSettings.getRetrySettings(),
+        clientContext.getClock(),
+        clientContext.getExecutor()
+    );
   }
 
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")


### PR DESCRIPTION
This is a rough sketch of how I plan on integrating opencensus.

There are 2 main changes being demonstrated in this PR:
1. Introduction of a `Tracer` that gets passed around in the `ApiCallContext`. The `Tracer` contains methods that correspond to various spans and annotations that will be generated. There are 2 implementations of `Tracer`: a noop one that will be used for external direct instantiations of the `RetryingExecutor`s in google-cloud-java and the real `OpencensusTracer`, which will generate real spans and annotations. Each instance of a `Tracer` corresponds to a single logical operation (an operation can contain multiple rpcs for retries).
2. Changes to `RetryingExecutor` and `RetryAlgorithm` to create them per operation rather then per client. This approach was suggested by @garrettjonesgoogle and is different then the approach I discussed with @vam-google. It avoids the need to break the public surface.

@garrettjonesgoogle & @vam-google take a look at this when you have a moment and let me know if I should continue down this road.