### PR TITLE
Make ApiContext timeout relative to the start of each RPC

### DIFF
--- a/benchmark/src/jmh/java/com/google/api/gax/grpc/ServerStreamingCallableBenchmark.java
+++ b/benchmark/src/jmh/java/com/google/api/gax/grpc/ServerStreamingCallableBenchmark.java
@@ -171,7 +171,6 @@ public class ServerStreamingCallableBenchmark {
                     .setMaxRpcTimeout(Duration.ofHours(1))
                     .build())
             .setIdleTimeout(Duration.ofSeconds(1))
-            .setTimeoutCheckInterval(Duration.ofSeconds(1))
             .build();
 
     baseCallable =

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -147,7 +147,7 @@ public final class GrpcCallContext implements ApiCallContext {
     // Prevent expanding timeouts
     if (rpcTimeout != null
         && this.rpcTimeout != null
-        && this.rpcTimeout.compareTo(rpcTimeout) > 0) {
+        && this.rpcTimeout.compareTo(rpcTimeout) <= 0) {
       return this;
     }
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -144,7 +144,7 @@ public final class GrpcCallContext implements ApiCallContext {
           !rpcTimeout.isZero() && !rpcTimeout.isNegative(), "Invalid timeout: <= 0 s");
     }
 
-    // Prevent expanding deadlines
+    // Prevent expanding timeouts
     if (rpcTimeout != null
         && this.rpcTimeout != null
         && this.rpcTimeout.compareTo(rpcTimeout) > 0) {

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -62,7 +62,7 @@ import org.threeten.bp.Duration;
 public final class GrpcCallContext implements ApiCallContext {
   private final Channel channel;
   private final CallOptions callOptions;
-  private final Duration rpcTimeout;
+  @Nullable private final Duration timeout;
   @Nullable private final Duration streamWaitTimeout;
   @Nullable private final Duration streamIdleTimeout;
   @Nullable private final Integer channelAffinity;
@@ -83,14 +83,14 @@ public final class GrpcCallContext implements ApiCallContext {
   private GrpcCallContext(
       Channel channel,
       CallOptions callOptions,
-      @Nullable Duration rpcTimeout,
+      @Nullable Duration timeout,
       @Nullable Duration streamWaitTimeout,
       @Nullable Duration streamIdleTimeout,
       @Nullable Integer channelAffinity,
       ImmutableMap<String, List<String>> extraHeaders) {
     this.channel = channel;
     this.callOptions = Preconditions.checkNotNull(callOptions);
-    this.rpcTimeout = rpcTimeout;
+    this.timeout = timeout;
     this.streamWaitTimeout = streamWaitTimeout;
     this.streamIdleTimeout = streamIdleTimeout;
     this.channelAffinity = channelAffinity;
@@ -138,23 +138,21 @@ public final class GrpcCallContext implements ApiCallContext {
   }
 
   @Override
-  public GrpcCallContext withTimeout(@Nullable Duration rpcTimeout) {
+  public GrpcCallContext withTimeout(@Nullable Duration timeout) {
     // Default RetrySettings use 0 for RPC timeout. Treat that as disabled timeouts.
-    if (rpcTimeout != null && (rpcTimeout.isZero() || rpcTimeout.isNegative())) {
-      rpcTimeout = null;
+    if (timeout != null && (timeout.isZero() || timeout.isNegative())) {
+      timeout = null;
     }
 
     // Prevent expanding timeouts
-    if (rpcTimeout != null
-        && this.rpcTimeout != null
-        && this.rpcTimeout.compareTo(rpcTimeout) <= 0) {
+    if (timeout != null && this.timeout != null && this.timeout.compareTo(timeout) <= 0) {
       return this;
     }
 
     return new GrpcCallContext(
         this.channel,
         this.callOptions,
-        rpcTimeout,
+        timeout,
         this.streamWaitTimeout,
         this.streamIdleTimeout,
         this.channelAffinity,
@@ -164,7 +162,7 @@ public final class GrpcCallContext implements ApiCallContext {
   @Nullable
   @Override
   public Duration getTimeout() {
-    return rpcTimeout;
+    return timeout;
   }
 
   @Override
@@ -177,7 +175,7 @@ public final class GrpcCallContext implements ApiCallContext {
     return new GrpcCallContext(
         channel,
         callOptions,
-        rpcTimeout,
+        timeout,
         streamWaitTimeout,
         streamIdleTimeout,
         channelAffinity,
@@ -194,7 +192,7 @@ public final class GrpcCallContext implements ApiCallContext {
     return new GrpcCallContext(
         channel,
         callOptions,
-        rpcTimeout,
+        timeout,
         streamWaitTimeout,
         streamIdleTimeout,
         channelAffinity,
@@ -206,7 +204,7 @@ public final class GrpcCallContext implements ApiCallContext {
     return new GrpcCallContext(
         channel,
         callOptions,
-        rpcTimeout,
+        timeout,
         streamWaitTimeout,
         streamIdleTimeout,
         affinity,
@@ -222,7 +220,7 @@ public final class GrpcCallContext implements ApiCallContext {
     return new GrpcCallContext(
         channel,
         callOptions,
-        rpcTimeout,
+        timeout,
         streamWaitTimeout,
         streamIdleTimeout,
         channelAffinity,
@@ -256,9 +254,9 @@ public final class GrpcCallContext implements ApiCallContext {
       newCallCredentials = this.callOptions.getCredentials();
     }
 
-    Duration newRpcTimeout = grpcCallContext.rpcTimeout;
-    if (newRpcTimeout == null) {
-      newRpcTimeout = this.rpcTimeout;
+    Duration newTimeout = grpcCallContext.timeout;
+    if (newTimeout == null) {
+      newTimeout = this.timeout;
     }
 
     Duration newStreamWaitTimeout = grpcCallContext.streamWaitTimeout;
@@ -288,7 +286,7 @@ public final class GrpcCallContext implements ApiCallContext {
     return new GrpcCallContext(
         newChannel,
         newCallOptions,
-        newRpcTimeout,
+        newTimeout,
         newStreamWaitTimeout,
         newStreamIdleTimeout,
         newChannelAffinity,
@@ -346,7 +344,7 @@ public final class GrpcCallContext implements ApiCallContext {
     return new GrpcCallContext(
         newChannel,
         this.callOptions,
-        rpcTimeout,
+        timeout,
         this.streamWaitTimeout,
         this.streamIdleTimeout,
         this.channelAffinity,
@@ -358,7 +356,7 @@ public final class GrpcCallContext implements ApiCallContext {
     return new GrpcCallContext(
         this.channel,
         newCallOptions,
-        rpcTimeout,
+        timeout,
         this.streamWaitTimeout,
         this.streamIdleTimeout,
         this.channelAffinity,
@@ -377,7 +375,7 @@ public final class GrpcCallContext implements ApiCallContext {
     return Objects.hash(
         channel,
         callOptions,
-        rpcTimeout,
+        timeout,
         streamWaitTimeout,
         streamIdleTimeout,
         channelAffinity,
@@ -396,7 +394,7 @@ public final class GrpcCallContext implements ApiCallContext {
     GrpcCallContext that = (GrpcCallContext) o;
     return Objects.equals(channel, that.channel)
         && Objects.equals(callOptions, that.callOptions)
-        && Objects.equals(rpcTimeout, that.rpcTimeout)
+        && Objects.equals(timeout, that.timeout)
         && Objects.equals(streamWaitTimeout, that.streamWaitTimeout)
         && Objects.equals(streamIdleTimeout, that.streamIdleTimeout)
         && Objects.equals(channelAffinity, that.channelAffinity)

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -139,9 +139,9 @@ public final class GrpcCallContext implements ApiCallContext {
 
   @Override
   public GrpcCallContext withTimeout(@Nullable Duration rpcTimeout) {
-    if (rpcTimeout != null) {
-      Preconditions.checkArgument(
-          !rpcTimeout.isZero() && !rpcTimeout.isNegative(), "Invalid timeout: <= 0 s");
+    // Default RetrySettings use 0 for RPC timeout. Treat that as disabled timeouts.
+    if (rpcTimeout != null && (rpcTimeout.isZero() || rpcTimeout.isNegative())) {
+      rpcTimeout = null;
     }
 
     // Prevent expanding timeouts

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcClientCalls.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcClientCalls.java
@@ -63,7 +63,7 @@ class GrpcClientCalls {
     CallOptions callOptions = grpcContext.getCallOptions();
     Preconditions.checkNotNull(callOptions);
 
-    // Set the RPC timeout
+    // Try to convert the timeout into a deadline and use it if it occurs before the actual deadline
     if (grpcContext.getTimeout() != null) {
       Deadline newDeadline =
           Deadline.after(grpcContext.getTimeout().toMillis(), TimeUnit.MILLISECONDS);

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcClientCalls.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcClientCalls.java
@@ -36,8 +36,10 @@ import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
+import io.grpc.Deadline;
 import io.grpc.MethodDescriptor;
 import io.grpc.stub.MetadataUtils;
+import java.util.concurrent.TimeUnit;
 
 /**
  * {@code GrpcClientCalls} creates a new {@code ClientCall} from the given call context.
@@ -60,6 +62,17 @@ class GrpcClientCalls {
 
     CallOptions callOptions = grpcContext.getCallOptions();
     Preconditions.checkNotNull(callOptions);
+
+    // Set the RPC timeout
+    if (grpcContext.getTimeout() != null) {
+      Deadline newDeadline =
+          Deadline.after(grpcContext.getTimeout().toMillis(), TimeUnit.MILLISECONDS);
+      Deadline oldDeadline = callOptions.getDeadline();
+
+      if (oldDeadline == null || newDeadline.isBefore(oldDeadline)) {
+        callOptions = callOptions.withDeadline(newDeadline);
+      }
+    }
 
     Channel channel = grpcContext.getChannel();
     if (grpcContext.getChannelAffinity() != null && channel instanceof ChannelPool) {

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -153,6 +153,27 @@ public class GrpcCallContextTest {
   }
 
   @Test
+  public void testMergeWithNullTimeout() {
+    Duration timeout = Duration.ofSeconds(10);
+    GrpcCallContext baseContext = GrpcCallContext.createDefault().withTimeout(timeout);
+
+    GrpcCallContext defaultOverlay = GrpcCallContext.createDefault();
+    Truth.assertThat(baseContext.merge(defaultOverlay).getTimeout()).isEqualTo(timeout);
+
+    GrpcCallContext explicitNullOverlay = GrpcCallContext.createDefault().withTimeout(null);
+    Truth.assertThat(baseContext.merge(explicitNullOverlay).getTimeout()).isEqualTo(timeout);
+  }
+
+  @Test
+  public void testMergeWithTimeout() {
+    Duration timeout = Duration.ofSeconds(19);
+    GrpcCallContext ctx1 = GrpcCallContext.createDefault();
+    GrpcCallContext ctx2 = GrpcCallContext.createDefault().withTimeout(timeout);
+
+    Truth.assertThat(ctx1.merge(ctx2).getTimeout()).isEqualTo(timeout);
+  }
+
+  @Test
   public void testWithStreamingWaitTimeout() {
     Duration timeout = Duration.ofSeconds(15);
     GrpcCallContext context = GrpcCallContext.createDefault().withStreamWaitTimeout(timeout);

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -32,7 +32,6 @@ package com.google.api.gax.grpc;
 import static org.junit.Assert.assertEquals;
 
 import com.google.api.gax.rpc.ApiCallContext;
-import com.google.api.gax.rpc.DeadlineExceededException;
 import com.google.api.gax.rpc.testing.FakeCallContext;
 import com.google.api.gax.rpc.testing.FakeChannel;
 import com.google.api.gax.rpc.testing.FakeTransportChannel;
@@ -109,18 +108,18 @@ public class GrpcCallContextTest {
 
   @Test
   public void testWithTimeout() {
-    Truth.assertThat(GrpcCallContext.createDefault().withTimeout(null).getDeadline()).isNull();
+    Truth.assertThat(GrpcCallContext.createDefault().withTimeout(null).getTimeout()).isNull();
   }
 
   @Test
   public void testWithNegativeTimeout() {
-    thrown.expect(DeadlineExceededException.class);
+    thrown.expect(IllegalArgumentException.class);
     GrpcCallContext.createDefault().withTimeout(Duration.ofSeconds(-1L));
   }
 
   @Test
   public void testWithZeroTimeout() {
-    thrown.expect(DeadlineExceededException.class);
+    thrown.expect(IllegalArgumentException.class);
     GrpcCallContext.createDefault().withTimeout(Duration.ofSeconds(0L));
   }
 

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -113,14 +113,16 @@ public class GrpcCallContextTest {
 
   @Test
   public void testWithNegativeTimeout() {
-    thrown.expect(IllegalArgumentException.class);
-    GrpcCallContext.createDefault().withTimeout(Duration.ofSeconds(-1L));
+    Truth.assertThat(
+            GrpcCallContext.createDefault().withTimeout(Duration.ofSeconds(-1L)).getTimeout())
+        .isNull();
   }
 
   @Test
   public void testWithZeroTimeout() {
-    thrown.expect(IllegalArgumentException.class);
-    GrpcCallContext.createDefault().withTimeout(Duration.ofSeconds(0L));
+    Truth.assertThat(
+            GrpcCallContext.createDefault().withTimeout(Duration.ofSeconds(0L)).getTimeout())
+        .isNull();
   }
 
   @Test

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -126,6 +126,33 @@ public class GrpcCallContextTest {
   }
 
   @Test
+  public void testWithShorterTimeout() {
+    GrpcCallContext ctxWithLongTimeout =
+        GrpcCallContext.createDefault().withTimeout(Duration.ofSeconds(10));
+
+    // Sanity check
+    Truth.assertThat(ctxWithLongTimeout.getTimeout()).isEqualTo(Duration.ofSeconds(10));
+
+    // Shorten the timeout and make sure it changed
+    GrpcCallContext ctxWithShorterTimeout = ctxWithLongTimeout.withTimeout(Duration.ofSeconds(5));
+    Truth.assertThat(ctxWithShorterTimeout.getTimeout()).isEqualTo(Duration.ofSeconds(5));
+  }
+
+  @Test
+  public void testWithLongerTimeout() {
+    GrpcCallContext ctxWithShortTimeout =
+        GrpcCallContext.createDefault().withTimeout(Duration.ofSeconds(5));
+
+    // Sanity check
+    Truth.assertThat(ctxWithShortTimeout.getTimeout()).isEqualTo(Duration.ofSeconds(5));
+
+    // Try to extend the timeout and verify that it was ignored
+    GrpcCallContext ctxWithUnchangedTimeout =
+        ctxWithShortTimeout.withTimeout(Duration.ofSeconds(10));
+    Truth.assertThat(ctxWithUnchangedTimeout.getTimeout()).isEqualTo(Duration.ofSeconds(5));
+  }
+
+  @Test
   public void testWithStreamingWaitTimeout() {
     Duration timeout = Duration.ofSeconds(15);
     GrpcCallContext context = GrpcCallContext.createDefault().withStreamWaitTimeout(timeout);

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcClientCallsTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcClientCallsTest.java
@@ -33,11 +33,13 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.gax.grpc.testing.FakeServiceGrpc;
 import com.google.common.collect.ImmutableList;
+import com.google.common.truth.Truth;
 import com.google.type.Color;
 import com.google.type.Money;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
+import io.grpc.Deadline;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -45,10 +47,13 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.threeten.bp.Duration;
 
 public class GrpcClientCallsTest {
   @Test
@@ -125,5 +130,109 @@ public class GrpcClientCallsTest {
     GrpcCallContext context =
         GrpcCallContext.createDefault().withChannel(mockChannel).withExtraHeaders(extraHeaders);
     GrpcClientCalls.newCall(descriptor, context).start(mockListener, emptyHeaders);
+  }
+
+  @Test
+  public void testTimeoutToDeadlineConversion() {
+    MethodDescriptor<Color, Money> descriptor = FakeServiceGrpc.METHOD_RECOGNIZE;
+
+    @SuppressWarnings("unchecked")
+    ClientCall<Color, Money> mockClientCall = Mockito.mock(ClientCall.class);
+
+    @SuppressWarnings("unchecked")
+    ClientCall.Listener<Money> mockListener = Mockito.mock(ClientCall.Listener.class);
+
+    @SuppressWarnings("unchecked")
+    Channel mockChannel = Mockito.mock(ManagedChannel.class);
+
+    ArgumentCaptor<CallOptions> capturedCallOptions = ArgumentCaptor.forClass(CallOptions.class);
+
+    Mockito.when(mockChannel.newCall(Mockito.eq(descriptor), capturedCallOptions.capture()))
+        .thenReturn(mockClientCall);
+
+    Duration timeout = Duration.ofSeconds(10);
+    Deadline minExpectedDeadline = Deadline.after(timeout.getSeconds(), TimeUnit.SECONDS);
+
+    GrpcCallContext context =
+        GrpcCallContext.createDefault().withChannel(mockChannel).withTimeout(timeout);
+
+    GrpcClientCalls.newCall(descriptor, context).start(mockListener, new Metadata());
+
+    Deadline maxExpectedDeadline = Deadline.after(timeout.getSeconds(), TimeUnit.SECONDS);
+
+    Truth.assertThat(capturedCallOptions.getValue().getDeadline()).isAtLeast(minExpectedDeadline);
+    Truth.assertThat(capturedCallOptions.getValue().getDeadline()).isAtMost(maxExpectedDeadline);
+  }
+
+  @Test
+  public void testTimeoutAfterDeadline() {
+    MethodDescriptor<Color, Money> descriptor = FakeServiceGrpc.METHOD_RECOGNIZE;
+
+    @SuppressWarnings("unchecked")
+    ClientCall<Color, Money> mockClientCall = Mockito.mock(ClientCall.class);
+
+    @SuppressWarnings("unchecked")
+    ClientCall.Listener<Money> mockListener = Mockito.mock(ClientCall.Listener.class);
+
+    @SuppressWarnings("unchecked")
+    Channel mockChannel = Mockito.mock(ManagedChannel.class);
+
+    ArgumentCaptor<CallOptions> capturedCallOptions = ArgumentCaptor.forClass(CallOptions.class);
+
+    Mockito.when(mockChannel.newCall(Mockito.eq(descriptor), capturedCallOptions.capture()))
+        .thenReturn(mockClientCall);
+
+    // Configure a timeout that occurs after the grpc deadline
+    Deadline priorDeadline = Deadline.after(5, TimeUnit.SECONDS);
+    Duration timeout = Duration.ofSeconds(10);
+
+    GrpcCallContext context =
+        GrpcCallContext.createDefault()
+            .withChannel(mockChannel)
+            .withCallOptions(CallOptions.DEFAULT.withDeadline(priorDeadline))
+            .withTimeout(timeout);
+
+    GrpcClientCalls.newCall(descriptor, context).start(mockListener, new Metadata());
+
+    // Verify that the timeout is ignored
+    Truth.assertThat(capturedCallOptions.getValue().getDeadline()).isEqualTo(priorDeadline);
+  }
+
+  @Test
+  public void testTimeoutBeforeDeadline() {
+    MethodDescriptor<Color, Money> descriptor = FakeServiceGrpc.METHOD_RECOGNIZE;
+
+    @SuppressWarnings("unchecked")
+    ClientCall<Color, Money> mockClientCall = Mockito.mock(ClientCall.class);
+
+    @SuppressWarnings("unchecked")
+    ClientCall.Listener<Money> mockListener = Mockito.mock(ClientCall.Listener.class);
+
+    @SuppressWarnings("unchecked")
+    Channel mockChannel = Mockito.mock(ManagedChannel.class);
+
+    ArgumentCaptor<CallOptions> capturedCallOptions = ArgumentCaptor.forClass(CallOptions.class);
+
+    Mockito.when(mockChannel.newCall(Mockito.eq(descriptor), capturedCallOptions.capture()))
+        .thenReturn(mockClientCall);
+
+    // Configure a timeout that occurs before the grpc deadline
+    Duration timeout = Duration.ofSeconds(5);
+    Deadline subsequentDeadline = Deadline.after(10, TimeUnit.SECONDS);
+    Deadline minExpectedDeadline = Deadline.after(timeout.getSeconds(), TimeUnit.SECONDS);
+
+    GrpcCallContext context =
+        GrpcCallContext.createDefault()
+            .withChannel(mockChannel)
+            .withCallOptions(CallOptions.DEFAULT.withDeadline(subsequentDeadline))
+            .withTimeout(timeout);
+
+    GrpcClientCalls.newCall(descriptor, context).start(mockListener, new Metadata());
+
+    // Verify that the timeout is ignored
+    Deadline maxExpectedDeadline = Deadline.after(timeout.getSeconds(), TimeUnit.SECONDS);
+
+    Truth.assertThat(capturedCallOptions.getValue().getDeadline()).isAtLeast(minExpectedDeadline);
+    Truth.assertThat(capturedCallOptions.getValue().getDeadline()).isAtMost(maxExpectedDeadline);
   }
 }

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -57,7 +57,7 @@ import org.threeten.bp.Instant;
 @InternalExtensionOnly
 public final class HttpJsonCallContext implements ApiCallContext {
   private final HttpJsonChannel channel;
-  private final Duration rpcTimeout;
+  private final Duration timeout;
   private final Instant deadline;
   private final Credentials credentials;
   private final ImmutableMap<String, List<String>> extraHeaders;
@@ -69,12 +69,12 @@ public final class HttpJsonCallContext implements ApiCallContext {
 
   private HttpJsonCallContext(
       HttpJsonChannel channel,
-      Duration rpcTimeout,
+      Duration timeout,
       Instant deadline,
       Credentials credentials,
       ImmutableMap<String, List<String>> extraHeaders) {
     this.channel = channel;
-    this.rpcTimeout = rpcTimeout;
+    this.timeout = timeout;
     this.deadline = deadline;
     this.credentials = credentials;
     this.extraHeaders = extraHeaders;
@@ -119,9 +119,9 @@ public final class HttpJsonCallContext implements ApiCallContext {
       newChannel = this.channel;
     }
 
-    Duration newRpcTimeout = httpJsonCallContext.rpcTimeout;
-    if (newRpcTimeout == null) {
-      newRpcTimeout = this.rpcTimeout;
+    Duration newTimeout = httpJsonCallContext.timeout;
+    if (newTimeout == null) {
+      newTimeout = this.timeout;
     }
 
     Instant newDeadline = httpJsonCallContext.deadline;
@@ -138,13 +138,13 @@ public final class HttpJsonCallContext implements ApiCallContext {
         Headers.mergeHeaders(extraHeaders, httpJsonCallContext.extraHeaders);
 
     return new HttpJsonCallContext(
-        newChannel, newRpcTimeout, newDeadline, newCredentials, newExtraHeaders);
+        newChannel, newTimeout, newDeadline, newCredentials, newExtraHeaders);
   }
 
   @Override
   public HttpJsonCallContext withCredentials(Credentials newCredentials) {
     return new HttpJsonCallContext(
-        this.channel, this.rpcTimeout, this.deadline, newCredentials, this.extraHeaders);
+        this.channel, this.timeout, this.deadline, newCredentials, this.extraHeaders);
   }
 
   @Override
@@ -159,27 +159,27 @@ public final class HttpJsonCallContext implements ApiCallContext {
   }
 
   @Override
-  public HttpJsonCallContext withTimeout(Duration rpcTimeout) {
+  public HttpJsonCallContext withTimeout(Duration timeout) {
     // Default RetrySettings use 0 for RPC timeout. Treat that as disabled timeouts.
-    if (rpcTimeout != null && (rpcTimeout.isZero() || rpcTimeout.isNegative())) {
-      rpcTimeout = null;
+    if (timeout != null && (timeout.isZero() || timeout.isNegative())) {
+      timeout = null;
     }
 
     // Prevent expanding deadlines
-    if (rpcTimeout != null
-        && this.rpcTimeout != null
-        && this.rpcTimeout.compareTo(rpcTimeout) <= 0) {
+    if (timeout != null
+        && this.timeout != null
+        && this.timeout.compareTo(timeout) <= 0) {
       return this;
     }
 
     return new HttpJsonCallContext(
-        this.channel, rpcTimeout, this.deadline, this.credentials, this.extraHeaders);
+        this.channel, timeout, this.deadline, this.credentials, this.extraHeaders);
   }
 
   @Nullable
   @Override
   public Duration getTimeout() {
-    return rpcTimeout;
+    return timeout;
   }
 
   @Override
@@ -210,7 +210,7 @@ public final class HttpJsonCallContext implements ApiCallContext {
     Preconditions.checkNotNull(extraHeaders);
     ImmutableMap<String, List<String>> newExtraHeaders =
         Headers.mergeHeaders(this.extraHeaders, extraHeaders);
-    return new HttpJsonCallContext(channel, rpcTimeout, deadline, credentials, newExtraHeaders);
+    return new HttpJsonCallContext(channel, timeout, deadline, credentials, newExtraHeaders);
   }
 
   @BetaApi("The surface for extra headers is not stable yet and may change in the future.")
@@ -232,11 +232,11 @@ public final class HttpJsonCallContext implements ApiCallContext {
   }
 
   public HttpJsonCallContext withChannel(HttpJsonChannel newChannel) {
-    return new HttpJsonCallContext(newChannel, rpcTimeout, deadline, credentials, extraHeaders);
+    return new HttpJsonCallContext(newChannel, timeout, deadline, credentials, extraHeaders);
   }
 
   public HttpJsonCallContext withDeadline(Instant newDeadline) {
-    return new HttpJsonCallContext(channel, rpcTimeout, newDeadline, credentials, extraHeaders);
+    return new HttpJsonCallContext(channel, timeout, newDeadline, credentials, extraHeaders);
   }
 
   @Override

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -166,9 +166,7 @@ public final class HttpJsonCallContext implements ApiCallContext {
     }
 
     // Prevent expanding deadlines
-    if (timeout != null
-        && this.timeout != null
-        && this.timeout.compareTo(timeout) <= 0) {
+    if (timeout != null && this.timeout != null && this.timeout.compareTo(timeout) <= 0) {
       return this;
     }
 

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -160,6 +160,11 @@ public final class HttpJsonCallContext implements ApiCallContext {
 
   @Override
   public HttpJsonCallContext withTimeout(Duration rpcTimeout) {
+    // Default RetrySettings use 0 for RPC timeout. Treat that as disabled timeouts.
+    if (rpcTimeout != null && (rpcTimeout.isZero() || rpcTimeout.isNegative())) {
+      rpcTimeout = null;
+    }
+
     // Prevent expanding deadlines
     if (rpcTimeout != null
         && this.rpcTimeout != null

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -120,7 +120,7 @@ public final class HttpJsonCallContext implements ApiCallContext {
     }
 
     Duration newRpcTimeout = httpJsonCallContext.rpcTimeout;
-    if (newRpcTimeout != null) {
+    if (newRpcTimeout == null) {
       newRpcTimeout = this.rpcTimeout;
     }
 

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -168,7 +168,7 @@ public final class HttpJsonCallContext implements ApiCallContext {
     // Prevent expanding deadlines
     if (rpcTimeout != null
         && this.rpcTimeout != null
-        && this.rpcTimeout.compareTo(rpcTimeout) > 0) {
+        && this.rpcTimeout.compareTo(rpcTimeout) <= 0) {
       return this;
     }
 
@@ -179,7 +179,7 @@ public final class HttpJsonCallContext implements ApiCallContext {
   @Nullable
   @Override
   public Duration getTimeout() {
-    return null;
+    return rpcTimeout;
   }
 
   @Override

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonDirectCallable.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonDirectCallable.java
@@ -55,7 +55,7 @@ class HttpJsonDirectCallable<RequestT, ResponseT> extends UnaryCallable<RequestT
     HttpJsonCallContext context = HttpJsonCallContext.createDefault().nullToSelf(inputContext);
 
     @Nullable Instant deadline = context.getDeadline();
-
+    // Try to convert the timeout into a deadline and use it if it occurs before the actual deadline
     if (context.getTimeout() != null) {
       @Nonnull Instant newDeadline = Instant.now().plus(context.getTimeout());
 

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonDirectCallable.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonDirectCallable.java
@@ -33,6 +33,9 @@ import com.google.api.core.ApiFuture;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.common.base.Preconditions;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.threeten.bp.Instant;
 
 /**
  * {@code HttpJsonDirectCallable} creates HTTP calls.
@@ -50,9 +53,20 @@ class HttpJsonDirectCallable<RequestT, ResponseT> extends UnaryCallable<RequestT
   public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext inputContext) {
     Preconditions.checkNotNull(request);
     HttpJsonCallContext context = HttpJsonCallContext.createDefault().nullToSelf(inputContext);
+
+    @Nullable Instant deadline = context.getDeadline();
+
+    if (context.getTimeout() != null) {
+      @Nonnull Instant newDeadline = Instant.now().plus(context.getTimeout());
+
+      if (deadline == null || newDeadline.isBefore(deadline)) {
+        deadline = newDeadline;
+      }
+    }
+
     HttpJsonCallOptions callOptions =
         HttpJsonCallOptions.newBuilder()
-            .setDeadline(context.getDeadline())
+            .setDeadline(deadline)
             .setCredentials(context.getCredentials())
             .build();
     return context.getChannel().issueFutureUnaryCall(callOptions, request, descriptor);

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallContextTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallContextTest.java
@@ -131,4 +131,25 @@ public class HttpJsonCallContextTest {
         ctxWithShortTimeout.withTimeout(Duration.ofSeconds(10));
     Truth.assertThat(ctxWithUnchangedTimeout.getTimeout()).isEqualTo(Duration.ofSeconds(5));
   }
+
+  @Test
+  public void testMergeWithNullTimeout() {
+    Duration timeout = Duration.ofSeconds(10);
+    HttpJsonCallContext baseContext = HttpJsonCallContext.createDefault().withTimeout(timeout);
+
+    HttpJsonCallContext defaultOverlay = HttpJsonCallContext.createDefault();
+    Truth.assertThat(baseContext.merge(defaultOverlay).getTimeout()).isEqualTo(timeout);
+
+    HttpJsonCallContext explicitNullOverlay = HttpJsonCallContext.createDefault().withTimeout(null);
+    Truth.assertThat(baseContext.merge(explicitNullOverlay).getTimeout()).isEqualTo(timeout);
+  }
+
+  @Test
+  public void testMergeWithTimeout() {
+    Duration timeout = Duration.ofSeconds(19);
+    HttpJsonCallContext ctx1 = HttpJsonCallContext.createDefault();
+    HttpJsonCallContext ctx2 = HttpJsonCallContext.createDefault().withTimeout(timeout);
+
+    Truth.assertThat(ctx1.merge(ctx2).getTimeout()).isEqualTo(timeout);
+  }
 }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallContextTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallContextTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.httpjson;
+
+import com.google.api.gax.rpc.testing.FakeCallContext;
+import com.google.api.gax.rpc.testing.FakeChannel;
+import com.google.api.gax.rpc.testing.FakeTransportChannel;
+import com.google.auth.Credentials;
+import com.google.common.truth.Truth;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+import org.threeten.bp.Duration;
+
+@RunWith(JUnit4.class)
+public class HttpJsonCallContextTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testNullToSelfWrongType() {
+    thrown.expect(IllegalArgumentException.class);
+    HttpJsonCallContext.createDefault().nullToSelf(FakeCallContext.createDefault());
+  }
+
+  @Test
+  public void testWithCredentials() {
+    Credentials credentials = Mockito.mock(Credentials.class);
+    HttpJsonCallContext emptyContext = HttpJsonCallContext.createDefault();
+    Truth.assertThat(emptyContext.getCredentials()).isNull();
+    HttpJsonCallContext context = emptyContext.withCredentials(credentials);
+    Truth.assertThat(context.getCredentials()).isNotNull();
+  }
+
+  @Test
+  public void testWithTransportChannel() {
+    ManagedHttpJsonChannel channel = Mockito.mock(ManagedHttpJsonChannel.class);
+
+    HttpJsonCallContext context =
+        HttpJsonCallContext.createDefault()
+            .withTransportChannel(
+                HttpJsonTransportChannel.newBuilder().setManagedChannel(channel).build());
+    Truth.assertThat(context.getChannel()).isSameAs(channel);
+  }
+
+  @Test
+  public void testWithTransportChannelWrongType() {
+    thrown.expect(IllegalArgumentException.class);
+    FakeChannel channel = new FakeChannel();
+    HttpJsonCallContext.createDefault().withTransportChannel(FakeTransportChannel.create(channel));
+  }
+
+  @Test
+  public void testMergeWrongType() {
+    thrown.expect(IllegalArgumentException.class);
+    HttpJsonCallContext.createDefault().merge(FakeCallContext.createDefault());
+  }
+
+  @Test
+  public void testWithTimeout() {
+    Truth.assertThat(HttpJsonCallContext.createDefault().withTimeout(null).getTimeout()).isNull();
+  }
+
+  @Test
+  public void testWithNegativeTimeout() {
+    Truth.assertThat(
+            HttpJsonCallContext.createDefault().withTimeout(Duration.ofSeconds(-1L)).getTimeout())
+        .isNull();
+  }
+
+  @Test
+  public void testWithZeroTimeout() {
+    Truth.assertThat(
+            HttpJsonCallContext.createDefault().withTimeout(Duration.ofSeconds(0L)).getTimeout())
+        .isNull();
+  }
+
+  @Test
+  public void testWithShorterTimeout() {
+    HttpJsonCallContext ctxWithLongTimeout =
+        HttpJsonCallContext.createDefault().withTimeout(Duration.ofSeconds(10));
+
+    // Sanity check
+    Truth.assertThat(ctxWithLongTimeout.getTimeout()).isEqualTo(Duration.ofSeconds(10));
+
+    // Shorten the timeout and make sure it changed
+    HttpJsonCallContext ctxWithShorterTimeout =
+        ctxWithLongTimeout.withTimeout(Duration.ofSeconds(5));
+    Truth.assertThat(ctxWithShorterTimeout.getTimeout()).isEqualTo(Duration.ofSeconds(5));
+  }
+
+  @Test
+  public void testWithLongerTimeout() {
+    HttpJsonCallContext ctxWithShortTimeout =
+        HttpJsonCallContext.createDefault().withTimeout(Duration.ofSeconds(5));
+
+    // Sanity check
+    Truth.assertThat(ctxWithShortTimeout.getTimeout()).isEqualTo(Duration.ofSeconds(5));
+
+    // Try to extend the timeout and verify that it was ignored
+    HttpJsonCallContext ctxWithUnchangedTimeout =
+        ctxWithShortTimeout.withTimeout(Duration.ofSeconds(10));
+    Truth.assertThat(ctxWithUnchangedTimeout.getTimeout()).isEqualTo(Duration.ofSeconds(5));
+  }
+}

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonDirectCallableTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonDirectCallableTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2017 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.httpjson;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.core.SettableApiFuture;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.common.collect.ImmutableMap;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.threeten.bp.Duration;
+import org.threeten.bp.Instant;
+
+public class HttpJsonDirectCallableTest {
+  private final ApiMethodDescriptor<String, String> API_DESCRIPTOR =
+      ApiMethodDescriptor.<String, String>newBuilder()
+          .setFullMethodName("fakeMethod")
+          .setHttpMethod("GET")
+          .setRequestFormatter(new FakeRequestFormatter())
+          .setResponseParser(new FakeResponseParser())
+          .build();
+
+  @Test
+  public void testTimeout() {
+    HttpJsonChannel mockChannel = Mockito.mock(HttpJsonChannel.class);
+
+    String expectedRequest = "fake";
+
+    HttpJsonDirectCallable<String, String> callable = new HttpJsonDirectCallable<>(API_DESCRIPTOR);
+
+    // Mock the channel that captures the call options
+    ArgumentCaptor<HttpJsonCallOptions> capturedCallOptions =
+        ArgumentCaptor.forClass(HttpJsonCallOptions.class);
+
+    Mockito.when(
+            mockChannel.issueFutureUnaryCall(
+                capturedCallOptions.capture(),
+                Mockito.anyString(),
+                Mockito.any(ApiMethodDescriptor.class)))
+        .thenReturn(SettableApiFuture.create());
+
+    // Compose the call context
+    Duration timeout = Duration.ofSeconds(10);
+    Instant minExpectedDeadline = Instant.now().plus(timeout);
+
+    HttpJsonCallContext callContext =
+        HttpJsonCallContext.createDefault().withChannel(mockChannel).withTimeout(timeout);
+
+    callable.futureCall(expectedRequest, callContext);
+
+    Instant maxExpectedDeadline = Instant.now().plus(timeout);
+
+    // Verify that the timeout was converted into a deadline
+    assertThat(capturedCallOptions.getValue().getDeadline()).isAtLeast(minExpectedDeadline);
+    assertThat(capturedCallOptions.getValue().getDeadline()).isAtMost(maxExpectedDeadline);
+  }
+
+  @Test
+  public void testTimeoutAfterDeadline() {
+    HttpJsonChannel mockChannel = Mockito.mock(HttpJsonChannel.class);
+
+    String expectedRequest = "fake";
+
+    HttpJsonDirectCallable<String, String> callable = new HttpJsonDirectCallable<>(API_DESCRIPTOR);
+
+    // Mock the channel that captures the call options
+    ArgumentCaptor<HttpJsonCallOptions> capturedCallOptions =
+        ArgumentCaptor.forClass(HttpJsonCallOptions.class);
+
+    Mockito.when(
+            mockChannel.issueFutureUnaryCall(
+                capturedCallOptions.capture(),
+                Mockito.anyString(),
+                Mockito.any(ApiMethodDescriptor.class)))
+        .thenReturn(SettableApiFuture.create());
+
+    // Compose the call context
+    Instant priorDeadline = Instant.now().plusSeconds(5);
+    Duration timeout = Duration.ofSeconds(10);
+
+    HttpJsonCallContext callContext =
+        HttpJsonCallContext.createDefault()
+            .withChannel(mockChannel)
+            .withDeadline(priorDeadline)
+            .withTimeout(timeout);
+
+    callable.futureCall(expectedRequest, callContext);
+
+    // Verify that the timeout was ignored
+    assertThat(capturedCallOptions.getValue().getDeadline()).isEqualTo(priorDeadline);
+  }
+
+  @Test
+  public void testTimeoutBeforeDeadline() {
+    HttpJsonChannel mockChannel = Mockito.mock(HttpJsonChannel.class);
+
+    String expectedRequest = "fake";
+
+    HttpJsonDirectCallable<String, String> callable = new HttpJsonDirectCallable<>(API_DESCRIPTOR);
+
+    // Mock the channel that captures the call options
+    ArgumentCaptor<HttpJsonCallOptions> capturedCallOptions =
+        ArgumentCaptor.forClass(HttpJsonCallOptions.class);
+
+    Mockito.when(
+            mockChannel.issueFutureUnaryCall(
+                capturedCallOptions.capture(),
+                Mockito.anyString(),
+                Mockito.any(ApiMethodDescriptor.class)))
+        .thenReturn(SettableApiFuture.create());
+
+    // Compose the call context
+    Duration timeout = Duration.ofSeconds(10);
+    Instant subsequentDeadline = Instant.now().plusSeconds(15);
+
+    Instant minExpectedDeadline = Instant.now().plus(timeout);
+
+    HttpJsonCallContext callContext =
+        HttpJsonCallContext.createDefault()
+            .withChannel(mockChannel)
+            .withDeadline(subsequentDeadline)
+            .withTimeout(timeout);
+
+    callable.futureCall(expectedRequest, callContext);
+
+    Instant maxExpectedDeadline = Instant.now().plus(timeout);
+
+    // Verify that the timeout was converted into a deadline
+    assertThat(capturedCallOptions.getValue().getDeadline()).isAtLeast(minExpectedDeadline);
+    assertThat(capturedCallOptions.getValue().getDeadline()).isAtMost(maxExpectedDeadline);
+  }
+
+  private static final class FakeRequestFormatter implements HttpRequestFormatter<String> {
+    @Override
+    public Map<String, List<String>> getQueryParamNames(String apiMessage) {
+      return ImmutableMap.of();
+    }
+
+    @Override
+    public String getRequestBody(String apiMessage) {
+      return "fake";
+    }
+
+    @Override
+    public String getPath(String apiMessage) {
+      return "/fake/path";
+    }
+
+    @Override
+    public PathTemplate getPathTemplate() {
+      return PathTemplate.create("/fake/path");
+    }
+  }
+
+  private static final class FakeResponseParser implements HttpResponseParser<String> {
+    @Override
+    public String parse(InputStream httpContent) {
+      return "fake";
+    }
+
+    @Override
+    public String serialize(String response) {
+      return response;
+    }
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/retrying/RetrySettings.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetrySettings.java
@@ -60,8 +60,8 @@ import org.threeten.bp.Duration;
  * is computed which will terminate the call when the total time is up.
  *
  * <p>Server streaming RPCs interpret RPC timeouts a bit differently. For server streaming RPCs, the
- * RPC timeout gets converted into a wait timeout {@see
- * ApiCallContext#withStreamWaitTimeout(Duration)}.
+ * RPC timeout gets converted into a wait timeout {@link
+ * com.google.api.gax.rpc.ApiCallContext#withStreamWaitTimeout(Duration)}.
  */
 @AutoValue
 public abstract class RetrySettings implements Serializable {

--- a/gax/src/main/java/com/google/api/gax/retrying/RetrySettings.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetrySettings.java
@@ -58,6 +58,10 @@ import org.threeten.bp.Duration;
  * another call. The new timeout is computed by multiplying the current timeout by the timeout
  * multiplier, but if that results in a deadline after the total timeout, then a new timeout value
  * is computed which will terminate the call when the total time is up.
+ *
+ * <p>Server streaming RPCs interpret RPC timeouts a bit differently. For server streaming RPCs, the
+ * RPC timeout gets converted into a wait timeout {@see
+ * ApiCallContext#withStreamWaitTimeout(Duration)}.
  */
 @AutoValue
 public abstract class RetrySettings implements Serializable {

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -61,7 +61,7 @@ public interface ApiCallContext {
    * that are measure from the beginning of each RPC attempt. Please note that this will limit the
    * duration of a server streaming RPC as well.
    */
-  ApiCallContext withTimeout(@Nullable Duration rpcTimeout);
+  ApiCallContext withTimeout(@Nullable Duration timeout);
 
   /** Returns the configured per-RPC timeout. */
   @Nullable

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -40,6 +40,9 @@ import org.threeten.bp.Duration;
 /**
  * Context for an API call.
  *
+ * <p>An API call can be composed of many RPCs (in case of retries). This class contains settings
+ * for both: API calls and RPCs.
+ *
  * <p>Implementations need to be immutable because default instances are stored in callable objects.
  *
  * <p>This is transport specific and each transport has an implementation with its own options.

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -56,10 +56,15 @@ public interface ApiCallContext {
   /**
    * Returns a new ApiCallContext with the given timeout set.
    *
-   * <p>This timeout only applies to a single RPC call; if timeouts are configured, the overall time
-   * taken will be much higher.
+   * <p>This sets the maximum amount of time a single unary RPC attempt can take. If retries are
+   * enabled, then this can take much longer. Please note that this will limit the duration of a
+   * stream as well.
    */
-  ApiCallContext withTimeout(Duration rpcTimeout);
+  ApiCallContext withTimeout(@Nullable Duration rpcTimeout);
+
+  /** Returns the configured per-RPC timeout. */
+  @Nullable
+  Duration getTimeout();
 
   /**
    * Returns a new ApiCallContext with the given stream timeout set.

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -71,7 +71,7 @@ public interface ApiCallContext {
    * Returns a new ApiCallContext with the given stream timeout set.
    *
    * <p>This timeout only applies to a {@link ServerStreamingCallable}s. It limits the maximum
-   * amount of timeout that can pass between demand being signaled via {@link
+   * amount of time that can pass between demand being signaled via {@link
    * StreamController#request(int)} and actual message delivery to {@link
    * ResponseObserver#onResponse(Object)}. Or, in the case of automatic flow control, since the last
    * message was delivered to {@link ResponseObserver#onResponse(Object)}. This is useful to detect

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -57,8 +57,9 @@ public interface ApiCallContext {
    * Returns a new ApiCallContext with the given timeout set.
    *
    * <p>This sets the maximum amount of time a single unary RPC attempt can take. If retries are
-   * enabled, then this can take much longer. Please note that this will limit the duration of a
-   * stream as well.
+   * enabled, then this can take much longer. Unlike a deadline, timeouts are relative durations
+   * that are measure from the beginning of each RPC attempt. Please note that this will limit the
+   * duration of a server streaming RPC as well.
    */
   ApiCallContext withTimeout(@Nullable Duration rpcTimeout);
 

--- a/gax/src/test/java/com/google/api/gax/rpc/AttemptCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/AttemptCallableTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.retrying.RetryingFuture;
+import com.google.api.gax.retrying.TimedAttemptSettings;
+import com.google.api.gax.rpc.testing.FakeCallContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import org.threeten.bp.Duration;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AttemptCallableTest {
+  @Mock UnaryCallable<String, String> mockInnerCallable;
+  ArgumentCaptor<ApiCallContext> capturedCallContext;
+  @Mock RetryingFuture<String> mockExternalFuture;
+  TimedAttemptSettings currentAttemptSettings;
+
+  @Before
+  public void setUp() {
+    capturedCallContext = ArgumentCaptor.forClass(ApiCallContext.class);
+    Mockito.when(mockInnerCallable.futureCall(Mockito.anyString(), capturedCallContext.capture()))
+        .thenReturn(SettableApiFuture.<String>create());
+
+    currentAttemptSettings =
+        TimedAttemptSettings.newBuilder()
+            .setGlobalSettings(RetrySettings.newBuilder().build())
+            .setAttemptCount(0)
+            .setFirstAttemptStartTimeNanos(0)
+            .setRetryDelay(Duration.ofSeconds(1))
+            .setRandomizedRetryDelay(Duration.ofSeconds(1))
+            .setRpcTimeout(Duration.ZERO)
+            .build();
+
+    Mockito.when(mockExternalFuture.getAttemptSettings())
+        .thenAnswer(
+            new Answer<TimedAttemptSettings>() {
+              @Override
+              public TimedAttemptSettings answer(InvocationOnMock invocation) throws Throwable {
+                return currentAttemptSettings;
+              }
+            });
+  }
+
+  @Test
+  public void testRpcTimeout() {
+    AttemptCallable<String, String> callable =
+        new AttemptCallable<>(mockInnerCallable, "fake-request", FakeCallContext.createDefault());
+    callable.setExternalFuture(mockExternalFuture);
+
+    // Make sure that the rpc timeout is set
+    Duration timeout = Duration.ofSeconds(10);
+    currentAttemptSettings = currentAttemptSettings.toBuilder().setRpcTimeout(timeout).build();
+
+    callable.call();
+
+    assertThat(capturedCallContext.getValue().getTimeout()).isEqualTo(timeout);
+
+    // Make sure that subsequent attempts can extend the time out
+    Duration longerTimeout = Duration.ofSeconds(20);
+    currentAttemptSettings =
+        currentAttemptSettings.toBuilder().setRpcTimeout(longerTimeout).build();
+    callable.call();
+    assertThat(capturedCallContext.getValue().getTimeout()).isEqualTo(longerTimeout);
+  }
+}

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
@@ -144,6 +144,7 @@ public class FakeCallContext implements ApiCallContext {
     return channel;
   }
 
+  @Override
   public Duration getTimeout() {
     return timeout;
   }
@@ -194,6 +195,11 @@ public class FakeCallContext implements ApiCallContext {
 
   @Override
   public FakeCallContext withTimeout(Duration timeout) {
+    // Prevent expanding deadlines
+    if (timeout != null && this.timeout != null && this.timeout.compareTo(timeout) > 0) {
+      return this;
+    }
+
     return new FakeCallContext(
         this.credentials,
         this.channel,

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
@@ -201,7 +201,7 @@ public class FakeCallContext implements ApiCallContext {
     }
 
     // Prevent expanding timeouts
-    if (timeout != null && this.timeout != null && this.timeout.compareTo(timeout) > 0) {
+    if (timeout != null && this.timeout != null && this.timeout.compareTo(timeout) <= 0) {
       return this;
     }
 

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
@@ -195,7 +195,12 @@ public class FakeCallContext implements ApiCallContext {
 
   @Override
   public FakeCallContext withTimeout(Duration timeout) {
-    // Prevent expanding deadlines
+    // Default RetrySettings use 0 for RPC timeout. Treat that as disabled timeouts.
+    if (timeout != null && (timeout.isNegative() || timeout.isNegative())) {
+      timeout = null;
+    }
+
+    // Prevent expanding timeouts
     if (timeout != null && this.timeout != null && this.timeout.compareTo(timeout) > 0) {
       return this;
     }


### PR DESCRIPTION
This partially addresses #561.
Currently the concepts of an RPC timeout and a deadline are a bit mixed up. When a user calls `ApiContext.setTimeout(Duration)` their duration gets converted into an an absolute deadline. Which is then interpreted as a relative timeout by the retry logic. This results in the issues described in #561.

This PR tries to fix the situation by consistently treating `ApiContext.setTimeout(Duration)` as a relative RPC timeout. This timeout will be converted into a deadline right before it goes out to gRPC. The only remaining bug from #561 that this doesn't address is when the user sets an absolute deadline on grpc CallOptions and then wraps an ApiContext around it. That will be addressed in a future PR that will introduce absolute deadlines in addition to the relative timeouts introduced here.
