### PR TITLE
Don't remove user configured rpc timeouts

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/AttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/AttemptCallable.java
@@ -34,6 +34,7 @@ import com.google.api.core.ApiFutures;
 import com.google.api.gax.retrying.NonCancellableFuture;
 import com.google.api.gax.retrying.RetryingFuture;
 import java.util.concurrent.Callable;
+import org.threeten.bp.Duration;
 
 /**
  * A callable representing an attempt to make an RPC call. This class is used from {@link
@@ -68,7 +69,10 @@ class AttemptCallable<RequestT, ResponseT> implements Callable<ResponseT> {
 
     try {
       if (callContext != null) {
-        callContext = callContext.withTimeout(externalFuture.getAttemptSettings().getRpcTimeout());
+        Duration rpcTimeout = externalFuture.getAttemptSettings().getRpcTimeout();
+        if (!rpcTimeout.isZero()) {
+          callContext = callContext.withTimeout(rpcTimeout);
+        }
       }
       externalFuture.setAttemptFuture(new NonCancellableFuture<ResponseT>());
       if (externalFuture.isDone()) {

--- a/gax/src/test/java/com/google/api/gax/rpc/AttemptCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/AttemptCallableTest.java
@@ -101,4 +101,18 @@ public class AttemptCallableTest {
     callable.call();
     assertThat(capturedCallContext.getValue().getTimeout()).isEqualTo(longerTimeout);
   }
+
+  @Test
+  public void testRpcTimeoutIsNotErased() {
+    Duration callerTimeout = Duration.ofMillis(10);
+    ApiCallContext callerCallContext = FakeCallContext.createDefault().withTimeout(callerTimeout);
+
+    AttemptCallable<String, String> callable =
+        new AttemptCallable<>(mockInnerCallable, "fake-request", callerCallContext);
+    callable.setExternalFuture(mockExternalFuture);
+
+    callable.call();
+
+    assertThat(capturedCallContext.getValue().getTimeout()).isEqualTo(callerTimeout);
+  }
 }


### PR DESCRIPTION
When RPC timeouts are not configured in RetrySettings, but a caller passes an RPC timeout, we should respect it.