### PR TITLE
Adding gax-bom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,8 @@ buildscript {
   dependencies {
     classpath "net.ltgt.gradle:gradle-apt-plugin:0.10",
       "com.github.jengelman.gradle.plugins:shadow:1.2.4",
-      "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.8.0"
+      "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.8.0",
+      "gradle.plugin.com.dorongold.plugins:task-tree:1.3.1"
 
     classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.6"
   }
@@ -30,6 +31,8 @@ ext {
   authVersion = '0.11.0'
   // Project names not used for release
   nonReleaseProjects = ['benchmark']
+  // Project names not using the default publication configuration
+  noDefaultPublications = ['benchmark', 'gax-bom']
   libraryVendor = 'Google'
 }
 
@@ -93,6 +96,7 @@ subprojects {
   apply plugin: "net.ltgt.apt"
   apply plugin: 'com.github.johnrengelman.shadow'
   apply plugin: 'maven-publish'
+  apply plugin: 'com.dorongold.task-tree'
 
   group = "com.google.api"
 
@@ -280,7 +284,7 @@ subprojects {
   // ----------
 
   afterEvaluate {
-    if (!nonReleaseProjects.contains(project.name)) {
+    if (!noDefaultPublications.contains(project.name)) {
       publishing {
         publications {
           mavenJava(MavenPublication) {
@@ -338,7 +342,7 @@ subprojects {
     }
 
     signing {
-      if (!project.hasProperty('skip.signing') && !nonReleaseProjects.contains(project.name)) {
+      if (!project.hasProperty('skip.signing') && !noDefaultPublications.contains(project.name)) {
         sign publishing.publications.mavenJava
       }
     }

--- a/gax-bom/build.gradle
+++ b/gax-bom/build.gradle
@@ -19,6 +19,7 @@ ext {
   mavenJavaBomOutputFile = file(mavenJavaDir + "/pom-default.xml")
 }
 
+// Copy our pom.xml to the location where a generated POM would go
 task copyPom() {
   doLast {
     new File(mavenJavaDir).mkdirs()
@@ -32,6 +33,8 @@ task copyPom() {
 
 assemble.dependsOn copyPom
 
+// We want to use our own pom.xml instead of the generated one, so we disable
+// the pom.xml generation and have the publish tasks depend on `copyPom` instead.
 tasks.whenTaskAdded { task ->
   if (task.name == 'generatePomFileForMavenJavaPublication') {
     task.enabled = false
@@ -69,6 +72,9 @@ artifacts {
 }
 
 afterEvaluate {
+  // We can't use the `publishing` section from the main build.gradle because
+  // we don't want all the Java artifacts, and we want to use our own pom.xml
+  // instead of the generated one.
   publishing {
     publications {
       mavenJava(MavenPublication) {

--- a/gax-bom/build.gradle
+++ b/gax-bom/build.gradle
@@ -1,0 +1,95 @@
+
+buildscript {
+  repositories {
+    mavenLocal()
+    maven {
+      url 'https://plugins.gradle.org/m2/'
+    }
+    mavenCentral()
+    jcenter()
+  }
+}
+
+archivesBaseName = "gax-bom"
+
+project.version = "1.33.1-SNAPSHOT" // {x-version-update:gax-bom:current}
+
+ext {
+  mavenJavaDir = "$project.buildDir/publications/mavenJava"
+  mavenJavaBomOutputFile = file(mavenJavaDir + "/pom-default.xml")
+}
+
+task copyPom() {
+  doLast {
+    new File(mavenJavaDir).mkdirs()
+    copy {
+      from 'pom.xml'
+      into mavenJavaDir
+      rename 'pom.xml', 'pom-default.xml'
+    }
+  }
+}
+
+assemble.dependsOn copyPom
+
+tasks.whenTaskAdded { task ->
+  if (task.name == 'generatePomFileForMavenJavaPublication') {
+    task.enabled = false
+  } else if (task.name == 'publishMavenJavaPublicationToMavenLocal') {
+    task.dependsOn copyPom
+  } else if (task.name == 'publishMavenJavaPublicationToMavenRepository') {
+    task.dependsOn copyPom
+  }
+}
+
+jar.enabled = false
+
+// Remove the default jar archive which is added by the 'java' plugin.
+// We could avoid this by not applying the 'java' plugin to all submodules of
+// gax, but that would create a little bit of a mess, so we hack around it here.
+configurations.archives.artifacts.with { archives ->
+  def artifacts = []
+  archives.each {
+    if (it.file =~ 'jar') {
+      // We can't just call `archives.remove(it)` here because it triggers
+      // a `ConcurrentModificationException`, so we add matching artifacts
+      // to another list, then remove those elements outside of this iteration.
+      artifacts.add(it)
+    }
+  }
+  artifacts.each {
+    archives.remove(it)
+  }
+}
+
+artifacts {
+  archives(mavenJavaBomOutputFile) {
+    builtBy copyPom
+  }
+}
+
+afterEvaluate {
+  publishing {
+    publications {
+      mavenJava(MavenPublication) {
+        version = project.version
+        artifact mavenJavaBomOutputFile
+      }
+    }
+    repositories {
+      maven {
+        url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+        credentials {
+          username = project.hasProperty('ossrhUsername') ? project.getProperty('ossrhUsername') : null
+          password = project.hasProperty('ossrhPassword') ? project.getProperty('ossrhPassword') : null
+        }
+      }
+    }
+  }
+
+  signing {
+    if (!project.hasProperty('skip.signing')) {
+      sign publishing.publications.mavenJava
+    }
+  }
+}

--- a/gax-bom/pom.xml
+++ b/gax-bom/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.api</groupId>
+  <artifactId>gax-bom</artifactId>
+  <version>1.33.1-SNAPSHOT</version><!-- {x-version-update:gax-bom:current} -->
+  <packaging>pom</packaging>
+  <name>GAX (Google Api eXtensions) for Java</name>
+  <description>Google Api eXtensions for Java</description>
+  <url>https://github.com/googleapis/gax-java</url>
+  <licenses>
+    <license>
+      <name>BSD</name>
+      <url>https://github.com/googleapis/gax-java/blob/master/LICENSE</url>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>GoogleAPIs</id>
+      <name>GoogleAPIs</name>
+      <email>googleapis@googlegroups.com</email>
+      <url>https://github.com/googleapis/gax-java</url>
+      <organization>Google, LLC</organization>
+      <organizationUrl>https://www.google.com</organizationUrl>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:https://github.com/googleapis/gax-java.git</connection>
+    <url>https://github.com/googleapis/gax-java</url>
+  </scm>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax</artifactId>
+        <version>1.33.1-SNAPSHOT</version><!-- {x-version-update:gax:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax</artifactId>
+        <version>1.33.1-SNAPSHOT</version><!-- {x-version-update:gax:current} -->
+	<classifier>testlib</classifier>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-grpc</artifactId>
+        <version>1.33.1-SNAPSHOT</version><!-- {x-version-update:gax-grpc:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-grpc</artifactId>
+        <version>1.33.1-SNAPSHOT</version><!-- {x-version-update:gax-grpc:current} -->
+	<classifier>testlib</classifier>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-httpjson</artifactId>
+        <version>0.50.1-SNAPSHOT</version><!-- {x-version-update:gax-httpjson:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-httpjson</artifactId>
+        <version>0.50.1-SNAPSHOT</version><!-- {x-version-update:gax-httpjson:current} -->
+	<classifier>testlib</classifier>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 include "gax"
+include "gax-bom"
 include "gax-grpc"
 include "gax-httpjson"
 include "benchmark"

--- a/versions.txt
+++ b/versions.txt
@@ -2,6 +2,7 @@
 # module:released-version:current-version
 
 gax:1.33.0:1.33.1-SNAPSHOT
+gax-bom:1.33.0:1.33.1-SNAPSHOT
 gax-grpc:1.33.0:1.33.1-SNAPSHOT
 gax-httpjson:0.50.0:0.50.1-SNAPSHOT
 benchmark:0.35.0:0.35.1-SNAPSHOT


### PR DESCRIPTION
Fixes https://github.com/googleapis/gax-java/issues/594

Testing:

- Made sure `./gradlew publishToMavenLocal` works; verified that google-cloud-java can use the locally-installed gax-bom module in place of listing gax dependencies in google-cloud-bom
- Made sure `./gradlew publishMavenJavaPublicationToMavenRepository` works (checked the artifacts in Sonatype, but dropped the staged artifacts)
