### PR TITLE
WIP: Opencensus integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ ext {
   grpcVersion = '1.15.0'
   commonProtosVersion = '1.12.0'
   authVersion = '0.11.0'
+  opencensusVersion = '0.15.0'
   // Project names not used for release
   nonReleaseProjects = ['benchmark']
   // Project names not using the default publication configuration
@@ -109,6 +110,7 @@ subprojects {
   ext {
     grpcVersion = grpcVersion
     commonProtosVersion = commonProtosVersion
+    opencensusVersion = opencensusVersion
 
     // Shortcuts for libraries we are using
     libraries = [
@@ -126,6 +128,7 @@ subprojects {
         authCredentials: "com.google.auth:google-auth-library-credentials:${authVersion}",
         commonProtos: "com.google.api.grpc:proto-google-common-protos:${commonProtosVersion}",
         apiCommon: "com.google.api:api-common:1.7.0",
+        opencensusApi: "io.opencensus:opencensus-api:${opencensusVersion}",
 
         // Testing
         junit: 'junit:junit:4.12',

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -34,11 +34,14 @@ import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.api.gax.rpc.internal.Headers;
+import com.google.api.gax.tracing.NoopTracer;
+import com.google.api.gax.tracing.Tracer;
 import com.google.auth.Credentials;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
+import io.grpc.CallOptions.Key;
 import io.grpc.Channel;
 import io.grpc.Deadline;
 import io.grpc.Metadata;
@@ -46,6 +49,7 @@ import io.grpc.auth.MoreCallCredentials;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
@@ -60,6 +64,8 @@ import org.threeten.bp.Duration;
 @BetaApi("Reference ApiCallContext instead - this class is likely to experience breaking changes")
 @InternalExtensionOnly
 public final class GrpcCallContext implements ApiCallContext {
+  private static final CallOptions.Key<Tracer> TRACER_KEY = Key.create("gax.tracer");
+
   private final Channel channel;
   private final CallOptions callOptions;
   @Nullable private final Duration timeout;
@@ -254,6 +260,11 @@ public final class GrpcCallContext implements ApiCallContext {
       newCallCredentials = this.callOptions.getCredentials();
     }
 
+    Tracer newTracer = grpcCallContext.callOptions.getOption(TRACER_KEY);
+    if (newTracer == null) {
+      newTracer = this.callOptions.getOption(TRACER_KEY);
+    }
+
     Duration newTimeout = grpcCallContext.timeout;
     if (newTimeout == null) {
       newTimeout = this.timeout;
@@ -282,6 +293,10 @@ public final class GrpcCallContext implements ApiCallContext {
             .callOptions
             .withCallCredentials(newCallCredentials)
             .withDeadline(newDeadline);
+
+    if (newTracer != null) {
+      newCallOptions = newCallOptions.withOption(TRACER_KEY, newTracer);
+    }
 
     return new GrpcCallContext(
         newChannel,
@@ -368,6 +383,22 @@ public final class GrpcCallContext implements ApiCallContext {
         CallOptionsUtil.putRequestParamsDynamicHeaderOption(callOptions, requestParams);
 
     return withCallOptions(newCallOptions);
+  }
+
+  @Nonnull
+  @Override
+  public Tracer getTracer() {
+    Tracer tracer = callOptions.getOption(TRACER_KEY);
+    if (tracer == null) {
+      tracer = NoopTracer.create();
+    }
+    return tracer;
+  }
+
+  @Override
+  public ApiCallContext withTracer(@Nonnull Tracer tracer) {
+    Preconditions.checkNotNull(tracer);
+    return withCallOptions(callOptions.withOption(TRACER_KEY, tracer));
   }
 
   @Override

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -46,9 +46,11 @@ import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.StreamingCallSettings;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.gax.tracing.SpanName;
 import com.google.common.collect.ImmutableSet;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
+import io.grpc.MethodDescriptor;
 
 /** Class with utility methods to create grpc-based direct callables. */
 @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
@@ -275,5 +277,18 @@ public class GrpcCallableFactory {
         new GrpcExceptionClientStreamingCallable<>(callable, ImmutableSet.<StatusCode.Code>of());
 
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
+  }
+
+  private static SpanName getSpanName(GrpcCallSettings<?, ?> grpcCallSettings) {
+    MethodDescriptor<?, ?> methodDescriptor = grpcCallSettings.getMethodDescriptor();
+
+    int index = methodDescriptor.getFullMethodName().lastIndexOf('/');
+    String fullServiceName = methodDescriptor.getFullMethodName().substring(0, index);
+    String methodName = methodDescriptor.getFullMethodName().substring(index + 1);
+
+    int serviceIndex = fullServiceName.lastIndexOf('.');
+    String clientName = fullServiceName.substring(serviceIndex + 1);
+
+    return SpanName.of(clientName, methodName);
   }
 }

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -34,6 +34,8 @@ import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.api.gax.rpc.internal.Headers;
+import com.google.api.gax.tracing.NoopTracer;
+import com.google.api.gax.tracing.Tracer;
 import com.google.auth.Credentials;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -61,10 +63,12 @@ public final class HttpJsonCallContext implements ApiCallContext {
   private final Instant deadline;
   private final Credentials credentials;
   private final ImmutableMap<String, List<String>> extraHeaders;
+  private final Tracer tracer;
 
   /** Returns an empty instance. */
   public static HttpJsonCallContext createDefault() {
-    return new HttpJsonCallContext(null, null, null, null, ImmutableMap.<String, List<String>>of());
+    return new HttpJsonCallContext(
+        null, null, null, null, ImmutableMap.<String, List<String>>of(), null);
   }
 
   private HttpJsonCallContext(
@@ -72,12 +76,14 @@ public final class HttpJsonCallContext implements ApiCallContext {
       Duration timeout,
       Instant deadline,
       Credentials credentials,
-      ImmutableMap<String, List<String>> extraHeaders) {
+      ImmutableMap<String, List<String>> extraHeaders,
+      Tracer tracer) {
     this.channel = channel;
     this.timeout = timeout;
     this.deadline = deadline;
     this.credentials = credentials;
     this.extraHeaders = extraHeaders;
+    this.tracer = tracer;
   }
 
   /**
@@ -137,14 +143,19 @@ public final class HttpJsonCallContext implements ApiCallContext {
     ImmutableMap<String, List<String>> newExtraHeaders =
         Headers.mergeHeaders(extraHeaders, httpJsonCallContext.extraHeaders);
 
+    Tracer newTracer = httpJsonCallContext.tracer;
+    if (newTracer == null) {
+      newTracer = this.tracer;
+    }
+
     return new HttpJsonCallContext(
-        newChannel, newTimeout, newDeadline, newCredentials, newExtraHeaders);
+        newChannel, newTimeout, newDeadline, newCredentials, newExtraHeaders, newTracer);
   }
 
   @Override
   public HttpJsonCallContext withCredentials(Credentials newCredentials) {
     return new HttpJsonCallContext(
-        this.channel, this.timeout, this.deadline, newCredentials, this.extraHeaders);
+        this.channel, this.timeout, this.deadline, newCredentials, this.extraHeaders, this.tracer);
   }
 
   @Override
@@ -171,7 +182,7 @@ public final class HttpJsonCallContext implements ApiCallContext {
     }
 
     return new HttpJsonCallContext(
-        this.channel, timeout, this.deadline, this.credentials, this.extraHeaders);
+        this.channel, timeout, this.deadline, this.credentials, this.extraHeaders, tracer);
   }
 
   @Nullable
@@ -208,7 +219,8 @@ public final class HttpJsonCallContext implements ApiCallContext {
     Preconditions.checkNotNull(extraHeaders);
     ImmutableMap<String, List<String>> newExtraHeaders =
         Headers.mergeHeaders(this.extraHeaders, extraHeaders);
-    return new HttpJsonCallContext(channel, timeout, deadline, credentials, newExtraHeaders);
+    return new HttpJsonCallContext(
+        channel, timeout, deadline, credentials, newExtraHeaders, tracer);
   }
 
   @BetaApi("The surface for extra headers is not stable yet and may change in the future.")
@@ -230,11 +242,30 @@ public final class HttpJsonCallContext implements ApiCallContext {
   }
 
   public HttpJsonCallContext withChannel(HttpJsonChannel newChannel) {
-    return new HttpJsonCallContext(newChannel, timeout, deadline, credentials, extraHeaders);
+    return new HttpJsonCallContext(
+        newChannel, timeout, deadline, credentials, extraHeaders, tracer);
   }
 
   public HttpJsonCallContext withDeadline(Instant newDeadline) {
-    return new HttpJsonCallContext(channel, timeout, newDeadline, credentials, extraHeaders);
+    return new HttpJsonCallContext(
+        channel, timeout, newDeadline, credentials, extraHeaders, tracer);
+  }
+
+  @Nonnull
+  @Override
+  public Tracer getTracer() {
+    if (tracer == null) {
+      return NoopTracer.create();
+    }
+    return tracer;
+  }
+
+  @Override
+  public ApiCallContext withTracer(@Nonnull Tracer newTracer) {
+    Preconditions.checkNotNull(newTracer);
+
+    return new HttpJsonCallContext(
+        channel, timeout, deadline, credentials, extraHeaders, newTracer);
   }
 
   @Override

--- a/gax/build.gradle
+++ b/gax/build.gradle
@@ -19,7 +19,8 @@ dependencies {
     libraries.jsr305,
     libraries.threetenbp,
     libraries.auth,
-    libraries.apiCommon
+    libraries.apiCommon,
+    libraries.opencensusApi
 
   compileOnly libraries.autovalue
 

--- a/gax/src/main/java/com/google/api/gax/retrying/NoopRetryingContext.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/NoopRetryingContext.java
@@ -31,6 +31,11 @@ package com.google.api.gax.retrying;
 
 // TODO(igorbernstein2): Remove this class once RetryingExecutor#createFuture(Callable) is
 // deprecated and removed.
+
+import com.google.api.gax.tracing.NoopTracer;
+import com.google.api.gax.tracing.Tracer;
+import javax.annotation.Nonnull;
+
 /**
  * Backwards compatibility class to aid in transition to adding operation state to {@link
  * RetryingFuture} implementations.
@@ -38,5 +43,11 @@ package com.google.api.gax.retrying;
 class NoopRetryingContext implements RetryingContext {
   public static RetryingContext create() {
     return new NoopRetryingContext();
+  }
+
+  @Nonnull
+  @Override
+  public Tracer getTracer() {
+    return NoopTracer.create();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/retrying/RetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetryAlgorithm.java
@@ -96,6 +96,23 @@ public class RetryAlgorithm<ResponseT> {
   }
 
   /**
+   * Returns {@code true} if the result of the last attempt is retryable, or {@code false}
+   * otherwise.
+   *
+   * @param prevThrowable exception thrown by the previous attempt or null if a result was returned
+   *     instead
+   * @param prevResponse response returned by the previous attempt or null if an exception was
+   *     thrown instead
+   */
+  public boolean couldRetry(Throwable prevThrowable, ResponseT prevResponse) {
+    try {
+      return resultAlgorithm.shouldRetry(prevThrowable, prevResponse);
+    } catch (CancellationException ignored) {
+      return false;
+    }
+  }
+
+  /**
    * Returns {@code true} if another attempt should be made, or {@code false} otherwise.
    *
    * @param prevThrowable exception thrown by the previous attempt or null if a result was returned

--- a/gax/src/main/java/com/google/api/gax/retrying/RetryingContext.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetryingContext.java
@@ -30,6 +30,8 @@
 package com.google.api.gax.retrying;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.tracing.Tracer;
+import javax.annotation.Nonnull;
 
 /**
  * Context for a retryable operation.
@@ -37,4 +39,7 @@ import com.google.api.core.BetaApi;
  * <p>It provides state to individual {@link RetryingFuture}s via the {@link RetryingExecutor}.
  */
 @BetaApi("The surface for passing per operation state is not yet stable")
-public interface RetryingContext {}
+public interface RetryingContext {
+  @Nonnull
+  public abstract Tracer getTracer();
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -32,9 +32,11 @@ package com.google.api.gax.rpc;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.retrying.RetryingContext;
+import com.google.api.gax.tracing.Tracer;
 import com.google.auth.Credentials;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
@@ -129,6 +131,13 @@ public interface ApiCallContext extends RetryingContext {
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nullable
   Duration getStreamIdleTimeout();
+
+  @BetaApi("The surface for tracing is not stable yet and may change in the future")
+  @Nonnull
+  Tracer getTracer();
+
+  @BetaApi("The surface for tracing is not stable yet and may change in the future")
+  ApiCallContext withTracer(@Nonnull Tracer tracer);
 
   /** If inputContext is not null, returns it; if it is null, returns the present instance. */
   ApiCallContext nullToSelf(ApiCallContext inputContext);

--- a/gax/src/main/java/com/google/api/gax/rpc/AttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/AttemptCallable.java
@@ -33,6 +33,7 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.gax.retrying.NonCancellableFuture;
 import com.google.api.gax.retrying.RetryingFuture;
+import com.google.api.gax.tracing.Tracer.Scope;
 import com.google.common.base.Preconditions;
 import java.util.concurrent.Callable;
 import org.threeten.bp.Duration;
@@ -68,7 +69,8 @@ class AttemptCallable<RequestT, ResponseT> implements Callable<ResponseT> {
   public ResponseT call() {
     ApiCallContext callContext = originalCallContext;
 
-    try {
+    try (Scope ignored = callContext.getTracer().inScope()) {
+      callContext.getTracer().startAttempt();
       Duration rpcTimeout = externalFuture.getAttemptSettings().getRpcTimeout();
       if (!rpcTimeout.isZero()) {
         callContext = callContext.withTimeout(rpcTimeout);

--- a/gax/src/main/java/com/google/api/gax/rpc/CheckingAttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/CheckingAttemptCallable.java
@@ -33,6 +33,7 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.gax.retrying.NonCancellableFuture;
 import com.google.api.gax.retrying.RetryingFuture;
+import com.google.api.gax.tracing.Tracer.Scope;
 import com.google.common.base.Preconditions;
 import java.util.concurrent.Callable;
 import org.threeten.bp.Duration;
@@ -65,7 +66,9 @@ class CheckingAttemptCallable<RequestT, ResponseT> implements Callable<ResponseT
   public ResponseT call() {
     ApiCallContext callContext = originalCallContext;
 
-    try {
+    try (Scope ignored = callContext.getTracer().inScope()) {
+      callContext.getTracer().startAttempt();
+
       Duration rpcTimeout = externalFuture.getAttemptSettings().getRpcTimeout();
       if (!rpcTimeout.isZero()) {
         callContext = callContext.withTimeout(rpcTimeout);

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -35,6 +35,8 @@ import com.google.api.core.NanoClock;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.ExecutorAsBackgroundResource;
 import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.tracing.NoopTracerFactory;
+import com.google.api.gax.tracing.TracerFactory;
 import com.google.auth.Credentials;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
@@ -93,6 +95,9 @@ public abstract class ClientContext {
   @Nullable
   public abstract String getEndpoint();
 
+  @BetaApi("The surface for tracing is not stable yet and may change in the future.")
+  public abstract TracerFactory getTracerFactory();
+
   public static Builder newBuilder() {
     return new AutoValue_ClientContext.Builder()
         .setBackgroundResources(Collections.<BackgroundResource>emptyList())
@@ -101,7 +106,9 @@ public abstract class ClientContext {
         .setInternalHeaders(Collections.<String, String>emptyMap())
         .setClock(NanoClock.getDefaultClock())
         .setStreamWatchdog(null)
-        .setStreamWatchdogCheckInterval(Duration.ZERO);
+        .setStreamWatchdogCheckInterval(Duration.ZERO)
+        // TODO(igorbernstein2): switch this to OpencensusTracingFactory once everything is ready
+        .setTracerFactory(new NoopTracerFactory());
   }
 
   public abstract Builder toBuilder();
@@ -186,6 +193,7 @@ public abstract class ClientContext {
         .setEndpoint(settings.getEndpoint())
         .setStreamWatchdog(watchdog)
         .setStreamWatchdogCheckInterval(settings.getStreamWatchdogCheckInterval())
+        .setTracerFactory(settings.getTracerFactory())
         .build();
   }
 
@@ -217,6 +225,9 @@ public abstract class ClientContext {
 
     @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     public abstract Builder setStreamWatchdogCheckInterval(Duration duration);
+
+    @BetaApi("The surface for tracing is not stable yet and may change in the future.")
+    public abstract Builder setTracerFactory(TracerFactory tracerFactory);
 
     public abstract ClientContext build();
   }

--- a/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -39,6 +39,8 @@ import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.core.FixedExecutorProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
 import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.tracing.NoopTracerFactory;
+import com.google.api.gax.tracing.TracerFactory;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
@@ -57,7 +59,6 @@ import org.threeten.bp.Duration;
  * a default executor.
  */
 public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
-
   private final ExecutorProvider executorProvider;
   private final CredentialsProvider credentialsProvider;
   private final HeaderProvider headerProvider;
@@ -67,6 +68,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
   private final String endpoint;
   @Nullable private final WatchdogProvider streamWatchdogProvider;
   @Nonnull private final Duration streamWatchdogCheckInterval;
+  private final TracerFactory tracerFactory;
 
   /** Constructs an instance of StubSettings. */
   protected StubSettings(Builder builder) {
@@ -79,6 +81,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     this.endpoint = builder.endpoint;
     this.streamWatchdogProvider = builder.streamWatchdogProvider;
     this.streamWatchdogCheckInterval = builder.streamWatchdogCheckInterval;
+    this.tracerFactory = builder.tracerFactory;
   }
 
   public final ExecutorProvider getExecutorProvider() {
@@ -123,6 +126,11 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     return streamWatchdogCheckInterval;
   }
 
+  @BetaApi("The surface for tracing is not stable yet and may change in the future.")
+  public TracerFactory getTracerFactory() {
+    return tracerFactory;
+  }
+
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("executorProvider", executorProvider)
@@ -134,6 +142,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         .add("endpoint", endpoint)
         .add("streamWatchdogProvider", streamWatchdogProvider)
         .add("streamWatchdogCheckInterval", streamWatchdogCheckInterval)
+        .add("tracerFactory", tracerFactory)
         .toString();
   }
 
@@ -151,6 +160,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     private String endpoint;
     @Nullable private WatchdogProvider streamWatchdogProvider;
     @Nonnull private Duration streamWatchdogCheckInterval;
+    private TracerFactory tracerFactory;
 
     /** Create a builder from a StubSettings object. */
     protected Builder(StubSettings settings) {
@@ -163,6 +173,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       this.endpoint = settings.endpoint;
       this.streamWatchdogProvider = settings.streamWatchdogProvider;
       this.streamWatchdogCheckInterval = settings.streamWatchdogCheckInterval;
+      this.tracerFactory = settings.tracerFactory;
     }
 
     protected Builder(ClientContext clientContext) {
@@ -176,6 +187,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         this.endpoint = null;
         this.streamWatchdogProvider = InstantiatingWatchdogProvider.create();
         this.streamWatchdogCheckInterval = Duration.ofSeconds(10);
+        this.tracerFactory = new NoopTracerFactory();
       } else {
         this.executorProvider = FixedExecutorProvider.create(clientContext.getExecutor());
         this.transportChannelProvider =
@@ -189,6 +201,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         this.streamWatchdogProvider =
             FixedWatchdogProvider.create(clientContext.getStreamWatchdog());
         this.streamWatchdogCheckInterval = clientContext.getStreamWatchdogCheckInterval();
+        this.tracerFactory = clientContext.getTracerFactory();
       }
     }
 
@@ -290,6 +303,13 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       return self();
     }
 
+    /** Configures the tracing implementation. */
+    @BetaApi("The surface for tracing is not stable yet and may change in the future.")
+    public B setTracerFactory(TracerFactory tracerFactory) {
+      this.tracerFactory = tracerFactory;
+      return self();
+    }
+
     /** Gets the ExecutorProvider that was previously set on this Builder. */
     public ExecutorProvider getExecutorProvider() {
       return executorProvider;
@@ -339,6 +359,11 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       return streamWatchdogCheckInterval;
     }
 
+    @BetaApi("The surface for tracing is not stable yet and may change in the future.")
+    public TracerFactory getTracerFactory() {
+      return tracerFactory;
+    }
+
     /** Applies the given settings updater function to the given method settings builders. */
     protected static void applyToAllUnaryMethods(
         Iterable<UnaryCallSettings.Builder<?, ?>> methodSettingsBuilders,
@@ -361,6 +386,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
           .add("endpoint", endpoint)
           .add("streamWatchdogProvider", streamWatchdogProvider)
           .add("streamWatchdogCheckInterval", streamWatchdogCheckInterval)
+          .add("tracerFactory", tracerFactory)
           .toString();
     }
   }

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopTracer.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import org.threeten.bp.Duration;
+
+public class NoopTracer implements Tracer {
+  public static Tracer create() {
+    return new NoopTracer();
+  }
+
+  @Override
+  public Scope inScope() {
+    return new NoopScope();
+  }
+
+  @Override
+  public void operationSucceeded() {}
+
+  @Override
+  public void operationFailed(Throwable error) {}
+
+  @Override
+  public void connectionSelected(int id) {}
+
+  @Override
+  public void startAttempt() {}
+
+  @Override
+  public void attemptSucceeded() {}
+
+  @Override
+  public void retryableFailure(Throwable error, Duration delay) {}
+
+  @Override
+  public void retriesExhausted() {}
+
+  @Override
+  public void permanentFailure(Throwable error) {}
+
+  @Override
+  public void receivedResponse() {}
+
+  @Override
+  public void sentRequest() {}
+
+  @Override
+  public void sentBatchRequest(long elementCount, long requestSize) {}
+
+  private static class NoopScope implements Scope {
+    @Override
+    public void close() {}
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopTracerFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import com.google.api.core.InternalApi;
+import com.google.api.gax.tracing.Tracer.Type;
+
+@InternalApi
+public final class NoopTracerFactory implements TracerFactory {
+  @Override
+  public Tracer newTracer(Type type, SpanName spanName) {
+    return NoopTracer.create();
+  }
+
+  @Override
+  public int hashCode() {
+    return 1;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof NoopTracerFactory;
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracer.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2017 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import io.opencensus.trace.AttributeValue;
+import io.opencensus.trace.EndSpanOptions;
+import io.opencensus.trace.Span;
+import io.opencensus.trace.Status;
+import io.opencensus.trace.Status.CanonicalCode;
+import java.util.HashMap;
+import java.util.Map;
+import org.threeten.bp.Duration;
+
+public class OpencensusTracer implements Tracer {
+  private final io.opencensus.trace.Tracer tracer;
+  private final Span span;
+  private Type type;
+
+  private int attempts = 0;
+  private long attemptRequests = 0;
+  private long attemptResponses = 0;
+  private long totalAttemptRequests = 0;
+  private long totalAttemptResponses = 0;
+
+  OpencensusTracer(io.opencensus.trace.Tracer tracer, Span span, Type type) {
+    this.tracer = tracer;
+    this.span = span;
+    this.type = type;
+  }
+
+  @Override
+  public Scope inScope() {
+    final io.opencensus.common.Scope scope = tracer.withSpan(span);
+
+    return new Scope() {
+      @Override
+      public void close() {
+        scope.close();
+      }
+    };
+  }
+
+  @Override
+  public void operationSucceeded() {
+    span.putAttributes(baseAttemptAttributes());
+    span.end();
+  }
+
+  @Override
+  public void operationFailed(Throwable error) {
+    span.putAttributes(baseAttemptAttributes());
+    span.end(EndSpanOptions.builder().setStatus(convertErrorToStatus(error)).build());
+  }
+
+  private Map<String, AttributeValue> baseOperationAttributes() {
+    HashMap<String, AttributeValue> attributes = Maps.newHashMap();
+
+    if (type.getCountRequests()) {
+      attributes.put(
+          "total request count", AttributeValue.longAttributeValue(totalAttemptRequests));
+    }
+    if (type.getCountResponses()) {
+      attributes.put(
+          "total response count", AttributeValue.longAttributeValue(totalAttemptResponses));
+    }
+    return attributes;
+  }
+
+  @Override
+  public void connectionSelected(int id) {
+    span.addAnnotation(
+        "Connection selected", ImmutableMap.of("id", AttributeValue.longAttributeValue(id)));
+  }
+
+  @Override
+  public void startAttempt() {
+    HashMap<String, AttributeValue> attributes = Maps.newHashMap();
+    attributes.put("attempt", AttributeValue.longAttributeValue(attempts));
+
+    attempts++;
+    attemptRequests = attemptResponses = 0;
+
+    span.addAnnotation(
+        "Attempt started", ImmutableMap.of("attempt", AttributeValue.longAttributeValue(attempts)));
+  }
+
+  @Override
+  public void attemptSucceeded() {
+    Map<String, AttributeValue> attributes = baseAttemptAttributes();
+    span.addAnnotation("Attempt succeeded", attributes);
+  }
+
+  @Override
+  public void retryableFailure(Throwable error, Duration delay) {
+    Map<String, AttributeValue> attributes = baseAttemptAttributes();
+    attributes.put("delay ms", AttributeValue.longAttributeValue(delay.toMillis()));
+
+    String msg = error != null ? "Attempt failed" : "Operation incomplete";
+    span.addAnnotation(msg + ", scheduling next attempt", attributes);
+  }
+
+  @Override
+  public void retriesExhausted() {
+    Map<String, AttributeValue> attributes = baseAttemptAttributes();
+    span.addAnnotation("Attempts exhausted", attributes);
+  }
+
+  @Override
+  public void permanentFailure(Throwable error) {
+    Map<String, AttributeValue> attributes = baseAttemptAttributes();
+    span.addAnnotation("Attempt failed, error not retryable ", attributes);
+  }
+
+  @Override
+  public void receivedResponse() {
+    attemptResponses++;
+    totalAttemptResponses++;
+  }
+
+  private Map<String, AttributeValue> baseAttemptAttributes() {
+    HashMap<String, AttributeValue> attributes = Maps.newHashMap();
+    attributes.put("attempt", AttributeValue.longAttributeValue(attempts));
+
+    if (type.getCountRequests()) {
+      attributes.put("attempt request count", AttributeValue.longAttributeValue(attemptRequests));
+    }
+    if (type.getCountResponses()) {
+      attributes.put("attempt response count", AttributeValue.longAttributeValue(attemptResponses));
+    }
+
+    return attributes;
+  }
+
+  @Override
+  public void sentRequest() {
+    attemptRequests++;
+    totalAttemptRequests++;
+  }
+
+  @Override
+  public void sentBatchRequest(long elementCount, long requestSize) {
+    span.putAttribute("batch count", AttributeValue.longAttributeValue(elementCount));
+    span.putAttribute("request size", AttributeValue.longAttributeValue(requestSize));
+  }
+
+  private static Status convertErrorToStatus(Throwable error) {
+    if (!(error instanceof ApiException)) {
+      return Status.UNKNOWN.withDescription(error.getMessage());
+    }
+
+    ApiException apiException = (ApiException) error;
+
+    Status.CanonicalCode code;
+    try {
+      code = Status.CanonicalCode.valueOf(apiException.getStatusCode().getCode().name());
+    } catch (IllegalArgumentException e) {
+      code = CanonicalCode.UNKNOWN;
+    }
+
+    return code.toStatus().withDescription(error.getMessage());
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracerFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import com.google.api.core.InternalApi;
+import com.google.api.gax.tracing.Tracer.Type;
+import com.google.common.base.Objects;
+import io.opencensus.trace.Span;
+import io.opencensus.trace.Tracing;
+import javax.annotation.Nullable;
+
+@InternalApi
+public final class OpencensusTracerFactory implements TracerFactory {
+  @Nullable private final String clientNameOverride;
+
+  public OpencensusTracerFactory() {
+    this(null);
+  }
+
+  public OpencensusTracerFactory(@Nullable String clientNameOverride) {
+    this.clientNameOverride = clientNameOverride;
+  }
+
+  @Override
+  public Tracer newTracer(Type type, SpanName spanName) {
+    io.opencensus.trace.Tracer tracer = Tracing.getTracer();
+    Span span = tracer.spanBuilder(spanName.toString()).setRecordEvents(true).startSpan();
+
+    return new OpencensusTracer(tracer, span, type);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    OpencensusTracerFactory that = (OpencensusTracerFactory) o;
+    return Objects.equal(clientNameOverride, that.clientNameOverride);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(clientNameOverride);
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/tracing/SpanName.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/SpanName.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class SpanName {
+  public static SpanName of(String clientName, String methodName) {
+    return new AutoValue_SpanName(clientName, methodName);
+  }
+
+  public abstract String getClientName();
+
+  public abstract String getMethodName();
+
+  public SpanName withClientName(String clientName) {
+    return of(clientName, getMethodName());
+  }
+
+  public SpanName withMethodName(String methodName) {
+    return of(getClientName(), methodName);
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedBatchCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedBatchCallable.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.InternalApi;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.BatchingDescriptor;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.util.concurrent.MoreExecutors;
+
+@InternalApi
+public class TracedBatchCallable<RequestT, ResponseT> extends UnaryCallable<RequestT, ResponseT> {
+  private final TracerFactory tracerFactory;
+  private final SpanName spanName;
+  private final BatchingDescriptor<RequestT, ResponseT> batchingDescriptor;
+  private final UnaryCallable<RequestT, ResponseT> innerCallable;
+
+  public TracedBatchCallable(
+      UnaryCallable<RequestT, ResponseT> innerCallable,
+      TracerFactory tracerFactory,
+      SpanName spanName,
+      BatchingDescriptor<RequestT, ResponseT> batchingDescriptor) {
+    this.tracerFactory = tracerFactory;
+    this.spanName = spanName;
+    this.batchingDescriptor = batchingDescriptor;
+    this.innerCallable = innerCallable;
+  }
+
+  @Override
+  public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext context) {
+    Tracer tracer = tracerFactory.newTracer(Tracer.Type.Batched, spanName);
+    TraceFinisher finisher = new TraceFinisher(tracer);
+
+    try {
+      long elementCount = batchingDescriptor.countElements(request);
+      long requestSize = batchingDescriptor.countBytes(request);
+
+      tracer.sentBatchRequest(elementCount, requestSize);
+
+      context = context.withTracer(tracer);
+      ApiFuture<ResponseT> future = innerCallable.futureCall(request, context);
+      ApiFutures.addCallback(future, finisher, MoreExecutors.directExecutor());
+
+      return future;
+    } catch (RuntimeException e) {
+      finisher.onFailure(e);
+      throw e;
+    }
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedBidiCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedBidiCallable.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientStream;
+import com.google.api.gax.rpc.ClientStreamReadyObserver;
+import com.google.api.gax.rpc.ResponseObserver;
+import com.google.api.gax.rpc.StreamController;
+import com.google.api.gax.tracing.Tracer.Scope;
+
+public class TracedBidiCallable<RequestT, ResponseT>
+    extends BidiStreamingCallable<RequestT, ResponseT> {
+
+  private final TracerFactory tracerFactory;
+  private final SpanName spanName;
+  private final BidiStreamingCallable<RequestT, ResponseT> innerCallable;
+
+  public TracedBidiCallable(
+      BidiStreamingCallable<RequestT, ResponseT> innerCallable,
+      TracerFactory tracerFactory,
+      SpanName spanName) {
+    this.tracerFactory = tracerFactory;
+    this.spanName = spanName;
+    this.innerCallable = innerCallable;
+  }
+
+  @Override
+  public ClientStream<RequestT> internalCall(
+      ResponseObserver<ResponseT> responseObserver,
+      ClientStreamReadyObserver<RequestT> onReady,
+      ApiCallContext context) {
+
+    Tracer tracer = tracerFactory.newTracer(Tracer.Type.Bidi, spanName);
+    context = context.withTracer(tracer);
+
+    ResponseObserver<ResponseT> tracedObserver =
+        new TracingResponseObserver<>(tracer, responseObserver);
+    ClientStreamReadyObserver<RequestT> tracedReadyObserver =
+        new TracingClientStreamReadyObserver<>(tracer, onReady);
+
+    try (Scope scope = tracer.inScope()) {
+      ClientStream<RequestT> clientStream =
+          innerCallable.internalCall(tracedObserver, tracedReadyObserver, context);
+      return new TracingClientStream<>(tracer, clientStream);
+    }
+  }
+
+  private static class TracingResponseObserver<ResponseT> implements ResponseObserver<ResponseT> {
+    private final Tracer tracer;
+    private final ResponseObserver<ResponseT> innerObserver;
+
+    public TracingResponseObserver(Tracer tracer, ResponseObserver<ResponseT> innerObserver) {
+      this.tracer = tracer;
+      this.innerObserver = innerObserver;
+    }
+
+    @Override
+    public void onStart(StreamController controller) {
+      innerObserver.onStart(controller);
+    }
+
+    @Override
+    public void onResponse(ResponseT response) {
+      tracer.receivedResponse();
+      innerObserver.onResponse(response);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      tracer.operationFailed(t);
+      innerObserver.onError(t);
+    }
+
+    @Override
+    public void onComplete() {
+      tracer.operationSucceeded();
+      innerObserver.onComplete();
+    }
+  }
+
+  private static class TracingClientStreamReadyObserver<RequestT>
+      implements ClientStreamReadyObserver<RequestT> {
+    private final Tracer tracer;
+    private final ClientStreamReadyObserver<RequestT> innerObserver;
+
+    public TracingClientStreamReadyObserver(
+        Tracer tracer, ClientStreamReadyObserver<RequestT> innerObserver) {
+      this.tracer = tracer;
+      this.innerObserver = innerObserver;
+    }
+
+    @Override
+    public void onReady(ClientStream<RequestT> stream) {
+      innerObserver.onReady(new TracingClientStream<>(tracer, stream));
+    }
+  }
+
+  private static class TracingClientStream<RequestT> implements ClientStream<RequestT> {
+    private final Tracer tracer;
+    private final ClientStream<RequestT> innerStream;
+
+    public TracingClientStream(Tracer tracer, ClientStream<RequestT> innerStream) {
+      this.tracer = tracer;
+      this.innerStream = innerStream;
+    }
+
+    @Override
+    public void send(RequestT request) {
+      tracer.sentRequest();
+      innerStream.send(request);
+    }
+
+    @Override
+    public void closeSendWithError(Throwable t) {
+      innerStream.closeSendWithError(t);
+    }
+
+    @Override
+    public void closeSend() {
+      innerStream.closeSend();
+    }
+
+    @Override
+    public boolean isSendReady() {
+      return innerStream.isSendReady();
+    }
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedClientStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedClientStreamingCallable.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import com.google.api.core.InternalApi;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.ClientStreamingCallable;
+import com.google.api.gax.tracing.Tracer.Type;
+
+@InternalApi
+public class TracedClientStreamingCallable<RequestT, ResponseT>
+    extends ClientStreamingCallable<RequestT, ResponseT> {
+  private final ClientStreamingCallable<RequestT, ResponseT> innerCallable;
+  private final TracerFactory tracerFactory;
+  private final SpanName spanName;
+
+  public TracedClientStreamingCallable(
+      ClientStreamingCallable<RequestT, ResponseT> innerCallable,
+      TracerFactory tracerFactory,
+      SpanName spanName) {
+    this.innerCallable = innerCallable;
+    this.tracerFactory = tracerFactory;
+    this.spanName = spanName;
+  }
+
+  @Override
+  public ApiStreamObserver<RequestT> clientStreamingCall(
+      ApiStreamObserver<ResponseT> responseObserver, ApiCallContext context) {
+
+    Tracer tracer = tracerFactory.newTracer(Type.ClientStreaming, spanName);
+    context = context.withTracer(tracer);
+
+    try {
+      ApiStreamObserver<ResponseT> innerResponseObserver =
+          new TracedResponseObserver<>(tracer, responseObserver);
+      ApiStreamObserver<RequestT> innerRequestObserver =
+          innerCallable.clientStreamingCall(innerResponseObserver, context);
+
+      return new TracedRequestObserver<>(tracer, innerRequestObserver);
+    } catch (RuntimeException e) {
+      tracer.operationFailed(e);
+      throw e;
+    }
+  }
+
+  private static class TracedRequestObserver<RequestT> implements ApiStreamObserver<RequestT> {
+    private final Tracer tracer;
+    private final ApiStreamObserver<RequestT> innerObserver;
+
+    TracedRequestObserver(Tracer tracer, ApiStreamObserver<RequestT> innerObserver) {
+      this.tracer = tracer;
+      this.innerObserver = innerObserver;
+    }
+
+    @Override
+    public void onNext(RequestT value) {
+      tracer.sentRequest();
+      innerObserver.onNext(value);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      innerObserver.onError(t);
+    }
+
+    @Override
+    public void onCompleted() {
+      innerObserver.onCompleted();
+    }
+  }
+
+  private static class TracedResponseObserver<RequestT> implements ApiStreamObserver<RequestT> {
+    private final Tracer tracer;
+    private final ApiStreamObserver<RequestT> innerObserver;
+
+    TracedResponseObserver(Tracer tracer, ApiStreamObserver<RequestT> innerObserver) {
+      this.tracer = tracer;
+      this.innerObserver = innerObserver;
+    }
+
+    @Override
+    public void onNext(RequestT value) {
+      this.tracer.receivedResponse();
+      innerObserver.onNext(value);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      tracer.operationFailed(t);
+      innerObserver.onError(t);
+    }
+
+    @Override
+    public void onCompleted() {
+      tracer.operationSucceeded();
+      innerObserver.onCompleted();
+    }
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedOperationCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedOperationCallable.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.OperationCallable;
+import com.google.api.gax.tracing.Tracer.Scope;
+import com.google.common.util.concurrent.MoreExecutors;
+
+public class TracedOperationCallable<RequestT, ResponseT, MetadataT>
+    extends OperationCallable<RequestT, ResponseT, MetadataT> {
+  private OperationCallable<RequestT, ResponseT, MetadataT> innerCallable;
+  private final TracerFactory tracerFactory;
+  private SpanName spanName;
+
+  public TracedOperationCallable(
+      OperationCallable<RequestT, ResponseT, MetadataT> innerCallable,
+      TracerFactory tracerFactory,
+      SpanName spanName) {
+    this.innerCallable = innerCallable;
+    this.tracerFactory = tracerFactory;
+    this.spanName = spanName;
+  }
+
+  @Override
+  public OperationFuture<ResponseT, MetadataT> futureCall(
+      RequestT request, ApiCallContext context) {
+    Tracer tracer = tracerFactory.newTracer(Tracer.Type.LongRunning, spanName);
+    TraceFinisher finisher = new TraceFinisher(tracer);
+
+    context = context.withTracer(tracer);
+
+    try (Scope ignored = tracer.inScope()) {
+      OperationFuture<ResponseT, MetadataT> future = innerCallable.futureCall(request, context);
+
+      ApiFutures.addCallback(future, finisher, MoreExecutors.directExecutor());
+
+      return future;
+    } catch (RuntimeException e) {
+      finisher.onFailure(e);
+      throw e;
+    }
+  }
+
+  @Override
+  public OperationFuture<ResponseT, MetadataT> resumeFutureCall(
+      String operationName, ApiCallContext context) {
+    Tracer tracer =
+        tracerFactory.newTracer(
+            Tracer.Type.LongRunning, spanName.withMethodName(spanName.getMethodName() + ".Resume"));
+    TraceFinisher finisher = new TraceFinisher(tracer);
+
+    context = context.withTracer(tracer);
+
+    try (Scope ignored = tracer.inScope()) {
+      OperationFuture<ResponseT, MetadataT> future =
+          innerCallable.resumeFutureCall(operationName, context);
+
+      ApiFutures.addCallback(future, finisher, MoreExecutors.directExecutor());
+
+      return future;
+    } catch (RuntimeException e) {
+      finisher.onFailure(e);
+      throw e;
+    }
+  }
+
+  @Override
+  public ApiFuture<Void> cancel(String operationName, ApiCallContext context) {
+    Tracer tracer =
+        tracerFactory.newTracer(
+            Tracer.Type.Unary, spanName.withMethodName(spanName.getMethodName() + ".Resume"));
+    TraceFinisher finisher = new TraceFinisher(tracer);
+
+    context = context.withTracer(tracer);
+
+    try (Scope ignored = tracer.inScope()) {
+      ApiFuture<Void> future = innerCallable.cancel(operationName, context);
+
+      ApiFutures.addCallback(future, finisher, MoreExecutors.directExecutor());
+
+      return future;
+    } catch (RuntimeException e) {
+      finisher.onFailure(e);
+      throw e;
+    }
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedServerStreamingCallable.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ResponseObserver;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StreamController;
+
+public class TracedServerStreamingCallable<RequestT, ResponseT>
+    extends ServerStreamingCallable<RequestT, ResponseT> {
+
+  private final TracerFactory tracerFactory;
+  private final SpanName spanName;
+  private final ServerStreamingCallable<RequestT, ResponseT> innerCallable;
+
+  public TracedServerStreamingCallable(
+      ServerStreamingCallable<RequestT, ResponseT> innerCallable,
+      TracerFactory tracerFactory,
+      SpanName spanName) {
+    this.tracerFactory = tracerFactory;
+    this.spanName = spanName;
+    this.innerCallable = innerCallable;
+  }
+
+  @Override
+  public void call(
+      RequestT request, ResponseObserver<ResponseT> responseObserver, ApiCallContext context) {
+
+    Tracer tracer = tracerFactory.newTracer(Tracer.Type.ServerStreaming, spanName);
+    TracedResponseObserver<ResponseT> tracedObserver =
+        new TracedResponseObserver<>(tracer, responseObserver);
+
+    context = context.withTracer(tracer);
+
+    try {
+      innerCallable.call(request, tracedObserver, context);
+    } catch (RuntimeException e) {
+      tracedObserver.onError(e);
+      throw e;
+    }
+  }
+
+  private static class TracedResponseObserver<ResponseT> implements ResponseObserver<ResponseT> {
+    private final Tracer tracer;
+    private final ResponseObserver<ResponseT> innerObserver;
+
+    public TracedResponseObserver(Tracer tracer, ResponseObserver<ResponseT> innerObserver) {
+      this.tracer = tracer;
+      this.innerObserver = innerObserver;
+    }
+
+    @Override
+    public void onStart(StreamController controller) {
+      innerObserver.onStart(controller);
+    }
+
+    @Override
+    public void onResponse(ResponseT response) {
+      tracer.receivedResponse();
+      innerObserver.onResponse(response);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      tracer.operationFailed(t);
+      innerObserver.onError(t);
+    }
+
+    @Override
+    public void onComplete() {
+      tracer.operationSucceeded();
+      innerObserver.onComplete();
+    }
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/tracing/Tracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/Tracer.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import org.threeten.bp.Duration;
+
+public interface Tracer {
+  Scope inScope();
+
+  void operationSucceeded();
+
+  void operationFailed(Throwable error);
+
+  void connectionSelected(int id);
+
+  void startAttempt();
+
+  void attemptSucceeded();
+
+  void retryableFailure(Throwable error, Duration delay);
+
+  void retriesExhausted();
+
+  void permanentFailure(Throwable error);
+
+  void receivedResponse();
+
+  void sentRequest();
+
+  void sentBatchRequest(long elementCount, long requestSize);
+
+  interface Scope extends AutoCloseable {
+    @Override
+    void close();
+  }
+
+  enum Type {
+    Unary(false, false),
+    ServerStreaming(false, true),
+    ClientStreaming(true, false),
+    Bidi(true, true),
+    LongRunning(false, false),
+    Batched(false, false);
+
+    private boolean countRequests;
+    private boolean countResponses;
+
+    Type(boolean countRequests, boolean countResponses) {
+      this.countRequests = countRequests;
+      this.countResponses = countResponses;
+    }
+
+    boolean getCountRequests() {
+      return countRequests;
+    }
+
+    boolean getCountResponses() {
+      return countResponses;
+    }
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/tracing/TracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracerFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import com.google.api.core.BetaApi;
+
+@BetaApi
+public interface TracerFactory {
+  Tracer newTracer(Tracer.Type type, SpanName spanName);
+}

--- a/gax/src/test/java/com/google/api/gax/retrying/AbstractRetryingExecutorTest.java
+++ b/gax/src/test/java/com/google/api/gax/retrying/AbstractRetryingExecutorTest.java
@@ -45,21 +45,26 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.threeten.bp.Duration;
 
 @RunWith(MockitoJUnitRunner.class)
 public abstract class AbstractRetryingExecutorTest {
-  @Mock protected RetryingContext retryingContext;
+  protected RetryingContext retryingContext;
 
   protected abstract RetryingExecutorWithContext<String> getExecutor(
       RetryAlgorithm<String> retryAlgorithm);
 
   protected abstract RetryAlgorithm<String> getAlgorithm(
       RetrySettings retrySettings, int apocalypseCountDown, RuntimeException apocalypseException);
+
+  @Before
+  public void setUp() {
+    retryingContext = NoopRetryingContext.create();
+  }
 
   @Test
   public void testSuccess() throws Exception {


### PR DESCRIPTION
DON'T MERGE

This is a rough sketch of opencensus integration. I wanted to get some early feedback on the direction I'm taking. 

The general idea here is to create an opencensus span for each toplevel operation the user invokes. Then to annotate that span with various interesting events like retry attempts.

All of the logic to create spans and annotations is centralized in a `Tracer`. A `Tracer` wraps an opencensus `Span`.  The `Tracer` is generally created by outer callables like `TracedUnaryCallable` and is passed through the callable chains via the `ApiCallContext`.

The main things I would like to get some feedback on are:
1. `Tracer` interface: it centralizes all of the annotations as opposed to exposing the raw opencensus apis.
2. The statefulness of the `OpencensusTracer` impl. It's has some smarts like counting requests and responses that it will use in a future annotation. 
3. Keeping all tracing related classes in the `tracing` package (including the `Callable` impls)
4. The addition of `couldRetry` to the RetryAlgorithm` to disambiguate between running out of retry attempts and the error not being retryable

TODO
- [ ] Finish implementation
- [ ] Add tracing for HTTP
- [ ] Add credentials refresh annotations
- [ ] Figure out what to do about traces generated by opentracing stubs
