### PR TITLE
Shutdown GRPC managed channel properly on close

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcTransportChannel.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcTransportChannel.java
@@ -93,7 +93,7 @@ public abstract class GrpcTransportChannel implements TransportChannel {
   public void close() {
     getManagedChannel().shutdown();
     try {
-      getManagedChannel().awaitTermination(6, TimeUnit.MINUTES);
+      awaitTermination(6, TimeUnit.MINUTES);
     } catch (InterruptedException e) {
       throw new ResourceCloseException(e);
     }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcTransportChannel.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcTransportChannel.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.grpc;
 
 import com.google.api.core.InternalExtensionOnly;
+import com.google.api.gax.core.ResourceCloseException;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.auto.value.AutoValue;
 import io.grpc.Channel;
@@ -92,9 +93,9 @@ public abstract class GrpcTransportChannel implements TransportChannel {
   public void close() {
     getManagedChannel().shutdown();
     try {
-      getManagedChannel().awaitTermination(1, TimeUnit.HOURS);
+      getManagedChannel().awaitTermination(6, TimeUnit.MINUTES);
     } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+      throw new ResourceCloseException(e);
     }
   }
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcTransportChannel.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcTransportChannel.java
@@ -91,13 +91,11 @@ public abstract class GrpcTransportChannel implements TransportChannel {
   @Override
   public void close() {
     getManagedChannel().shutdown();
-    boolean terminated = false;
-    do {
-      try {
-        terminated = getManagedChannel().awaitTermination(1, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-      }
-    } while (!terminated);
+    try {
+      getManagedChannel().awaitTermination(1, TimeUnit.HOURS);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public static Builder newBuilder() {

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcTransportChannel.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcTransportChannel.java
@@ -91,6 +91,13 @@ public abstract class GrpcTransportChannel implements TransportChannel {
   @Override
   public void close() {
     getManagedChannel().shutdown();
+    boolean terminated = false;
+    do {
+      try {
+        terminated = getManagedChannel().awaitTermination(1, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+      }
+    } while (!terminated);
   }
 
   public static Builder newBuilder() {

--- a/gax/src/main/java/com/google/api/gax/core/ResourceCloseException.java
+++ b/gax/src/main/java/com/google/api/gax/core/ResourceCloseException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.core;
+
+/** An exception occurs when some background resource is not able to close properly. */
+public class ResourceCloseException extends RuntimeException {
+
+  private static final long serialVersionUID = -283748743873637484L;
+
+  public ResourceCloseException(Exception exception) {
+    super(exception);
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/core/ResourceCloseException.java
+++ b/gax/src/main/java/com/google/api/gax/core/ResourceCloseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are


### PR DESCRIPTION
Fix #[3912](https://github.com/googleapis/google-cloud-java/issues/3912), [3693](https://github.com/googleapis/google-cloud-java/issues/3693) & [3648](https://github.com/googleapis/google-cloud-java/issues/3648)  Shutdown GRPC Managed channel properly on closing of background resources.