### PR TITLE
Track overall attempt counts in TimedAttemptSettings

### DIFF
--- a/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
@@ -72,6 +72,7 @@ public class ExponentialRetryAlgorithm implements TimedRetryAlgorithm {
         .setRpcTimeout(globalSettings.getInitialRpcTimeout())
         .setRandomizedRetryDelay(Duration.ZERO)
         .setAttemptCount(0)
+        .setOverallAttemptCount(0)
         .setFirstAttemptStartTimeNanos(clock.nanoTime())
         .build();
   }
@@ -113,6 +114,7 @@ public class ExponentialRetryAlgorithm implements TimedRetryAlgorithm {
         .setRpcTimeout(Duration.ofMillis(newRpcTimeout))
         .setRandomizedRetryDelay(Duration.ofMillis(nextRandomLong(newRetryDelay)))
         .setAttemptCount(prevSettings.getAttemptCount() + 1)
+        .setOverallAttemptCount(prevSettings.getOverallAttemptCount() + 1)
         .setFirstAttemptStartTimeNanos(prevSettings.getFirstAttemptStartTimeNanos())
         .build();
   }

--- a/gax/src/main/java/com/google/api/gax/retrying/StreamingRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/StreamingRetryAlgorithm.java
@@ -68,6 +68,7 @@ public final class StreamingRetryAlgorithm<ResponseT> extends RetryAlgorithm<Res
             createFirstAttempt()
                 .toBuilder()
                 .setFirstAttemptStartTimeNanos(prevSettings.getFirstAttemptStartTimeNanos())
+                .setOverallAttemptCount(prevSettings.getOverallAttemptCount())
                 .build();
       }
     }

--- a/gax/src/main/java/com/google/api/gax/retrying/TimedAttemptSettings.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/TimedAttemptSettings.java
@@ -80,7 +80,8 @@ public abstract class TimedAttemptSettings {
   public abstract Builder toBuilder();
 
   public static Builder newBuilder() {
-    return new AutoValue_TimedAttemptSettings.Builder();
+    return new AutoValue_TimedAttemptSettings.Builder()
+        .setOverallAttemptCount(0);
   }
 
   @AutoValue.Builder

--- a/gax/src/main/java/com/google/api/gax/retrying/TimedAttemptSettings.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/TimedAttemptSettings.java
@@ -58,8 +58,18 @@ public abstract class TimedAttemptSettings {
    */
   public abstract Duration getRandomizedRetryDelay();
 
-  /** The attempt count. It is a zero-based value (first attempt will have this value set to 0). */
+  /**
+   * The attempt count. It is a zero-based value (first attempt will have this value set to 0). For
+   * streamed RPCs this will be reset after every successful message.
+   */
   public abstract int getAttemptCount();
+
+  /**
+   * The overall attempt count. It is a zero-based value (first attempt will have this value set to
+   * 0). This will be the sum of all attempt counts for a streaming RPC and will be equal to {@link
+   * #getAttemptCount()} for unary RPCs.
+   */
+  public abstract int getOverallAttemptCount();
 
   /**
    * The start time of the first attempt. Note that this value is dependent on the actual {@link
@@ -98,6 +108,12 @@ public abstract class TimedAttemptSettings {
      * 0).
      */
     public abstract Builder setAttemptCount(int value);
+
+    /**
+     * Set the overall attempt count. It is a zero-based value (first attempt will have this value
+     * set to 0).
+     */
+    public abstract Builder setOverallAttemptCount(int value);
 
     /**
      * Set the start time of the first attempt. Note that this value is dependent on the actual

--- a/gax/src/main/java/com/google/api/gax/retrying/TimedAttemptSettings.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/TimedAttemptSettings.java
@@ -80,8 +80,7 @@ public abstract class TimedAttemptSettings {
   public abstract Builder toBuilder();
 
   public static Builder newBuilder() {
-    return new AutoValue_TimedAttemptSettings.Builder()
-        .setOverallAttemptCount(0);
+    return new AutoValue_TimedAttemptSettings.Builder().setOverallAttemptCount(0);
   }
 
   @AutoValue.Builder

--- a/gax/src/test/java/com/google/api/gax/retrying/ExponentialRetryAlgorithmTest.java
+++ b/gax/src/test/java/com/google/api/gax/retrying/ExponentialRetryAlgorithmTest.java
@@ -63,6 +63,7 @@ public class ExponentialRetryAlgorithmTest {
 
     // Checking only the most core values, to not make this test too implementation specific.
     assertEquals(0, attempt.getAttemptCount());
+    assertEquals(0, attempt.getOverallAttemptCount());
     assertEquals(Duration.ZERO, attempt.getRetryDelay());
     assertEquals(Duration.ZERO, attempt.getRandomizedRetryDelay());
     assertEquals(Duration.ofMillis(1L), attempt.getRpcTimeout());
@@ -76,6 +77,7 @@ public class ExponentialRetryAlgorithmTest {
 
     // Checking only the most core values, to not make this test too implementation specific.
     assertEquals(1, secondAttempt.getAttemptCount());
+    assertEquals(1, secondAttempt.getOverallAttemptCount());
     assertEquals(Duration.ofMillis(1L), secondAttempt.getRetryDelay());
     assertEquals(Duration.ofMillis(1L), secondAttempt.getRandomizedRetryDelay());
     assertEquals(Duration.ofMillis(2L), secondAttempt.getRpcTimeout());

--- a/gax/src/test/java/com/google/api/gax/rpc/AttemptCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/AttemptCallableTest.java
@@ -64,6 +64,7 @@ public class AttemptCallableTest {
         TimedAttemptSettings.newBuilder()
             .setGlobalSettings(RetrySettings.newBuilder().build())
             .setAttemptCount(0)
+            .setOverallAttemptCount(0)
             .setFirstAttemptStartTimeNanos(0)
             .setRetryDelay(Duration.ofSeconds(1))
             .setRandomizedRetryDelay(Duration.ofSeconds(1))

--- a/gax/src/test/java/com/google/api/gax/rpc/CheckingAttemptCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/CheckingAttemptCallableTest.java
@@ -64,6 +64,7 @@ public class CheckingAttemptCallableTest {
         TimedAttemptSettings.newBuilder()
             .setGlobalSettings(RetrySettings.newBuilder().build())
             .setAttemptCount(0)
+            .setOverallAttemptCount(0)
             .setFirstAttemptStartTimeNanos(0)
             .setRetryDelay(Duration.ofSeconds(1))
             .setRandomizedRetryDelay(Duration.ofSeconds(1))

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingAttemptCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingAttemptCallableTest.java
@@ -399,6 +399,7 @@ public class ServerStreamingAttemptCallableTest {
                   RetrySettings.newBuilder().setTotalTimeout(Duration.ofHours(1)).build())
               .setFirstAttemptStartTimeNanos(0)
               .setAttemptCount(0)
+              .setOverallAttemptCount(0)
               .setRandomizedRetryDelay(Duration.ofMillis(1))
               .setRetryDelay(Duration.ofMillis(1))
               .setRpcTimeout(Duration.ofMinutes(1))


### PR DESCRIPTION
This is extracted from https://github.com/googleapis/gax-java/pull/613#discussion_r229900863.
Currently for streaming RPCs TimedAttemptSettings only tracks how many attempts occurred trying to receive the next message. Once the message is received, the attempt count is reset.
This adds a new field to TimedAttemptSettings that will track overall count so that it can be used in a future integration with opencensus (or be used in a new retry algorithm)