### PR TITLE
Fix the fake descriptor to present a more realistic method name.

### DIFF
--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/testing/FakeMethodDescriptor.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/testing/FakeMethodDescriptor.java
@@ -39,7 +39,7 @@ public class FakeMethodDescriptor {
   private FakeMethodDescriptor() {}
 
   public static <I, O> MethodDescriptor<I, O> create() {
-    return create(MethodDescriptor.MethodType.UNARY, "(default name)");
+    return create(MethodDescriptor.MethodType.UNARY, "FakeClient/fake-method");
   }
 
   public static <I, O> MethodDescriptor<I, O> create(


### PR DESCRIPTION
This is extracted from https://github.com/googleapis/gax-java/pull/613/files#diff-13d1e54be780cb9d5ec8bbe6a8f0ec9f.
It allows for easier testing of future opencensus integration