### PR TITLE
Add plumbing for tracing

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -385,18 +385,20 @@ public final class GrpcCallContext implements ApiCallContext {
     return withCallOptions(newCallOptions);
   }
 
+  /** {@inheritDoc} */
   @Override
   @Nonnull
   public ApiTracer getTracer() {
     ApiTracer tracer = callOptions.getOption(TRACER_KEY);
     if (tracer == null) {
-      tracer = NoopApiTracer.create();
+      tracer = NoopApiTracer.getInstance();
     }
     return tracer;
   }
 
+  /** {@inheritDoc} */
   @Override
-  public ApiCallContext withTracer(@Nonnull ApiTracer tracer) {
+  public GrpcCallContext withTracer(@Nonnull ApiTracer tracer) {
     Preconditions.checkNotNull(tracer);
     return withCallOptions(callOptions.withOption(TRACER_KEY, tracer));
   }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -34,11 +34,14 @@ import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.api.gax.rpc.internal.Headers;
+import com.google.api.gax.tracing.ApiTracer;
+import com.google.api.gax.tracing.NoopApiTracer;
 import com.google.auth.Credentials;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
+import io.grpc.CallOptions.Key;
 import io.grpc.Channel;
 import io.grpc.Deadline;
 import io.grpc.Metadata;
@@ -46,6 +49,7 @@ import io.grpc.auth.MoreCallCredentials;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
@@ -60,6 +64,8 @@ import org.threeten.bp.Duration;
 @BetaApi("Reference ApiCallContext instead - this class is likely to experience breaking changes")
 @InternalExtensionOnly
 public final class GrpcCallContext implements ApiCallContext {
+  private static final CallOptions.Key<ApiTracer> TRACER_KEY = Key.create("gax.tracer");
+
   private final Channel channel;
   private final CallOptions callOptions;
   @Nullable private final Duration timeout;
@@ -254,6 +260,11 @@ public final class GrpcCallContext implements ApiCallContext {
       newCallCredentials = this.callOptions.getCredentials();
     }
 
+    ApiTracer newTracer = grpcCallContext.callOptions.getOption(TRACER_KEY);
+    if (newTracer == null) {
+      newTracer = this.callOptions.getOption(TRACER_KEY);
+    }
+
     Duration newTimeout = grpcCallContext.timeout;
     if (newTimeout == null) {
       newTimeout = this.timeout;
@@ -282,6 +293,10 @@ public final class GrpcCallContext implements ApiCallContext {
             .callOptions
             .withCallCredentials(newCallCredentials)
             .withDeadline(newDeadline);
+
+    if (newTracer != null) {
+      newCallOptions = newCallOptions.withOption(TRACER_KEY, newTracer);
+    }
 
     return new GrpcCallContext(
         newChannel,
@@ -368,6 +383,22 @@ public final class GrpcCallContext implements ApiCallContext {
         CallOptionsUtil.putRequestParamsDynamicHeaderOption(callOptions, requestParams);
 
     return withCallOptions(newCallOptions);
+  }
+
+  @Override
+  @Nonnull
+  public ApiTracer getTracer() {
+    ApiTracer tracer = callOptions.getOption(TRACER_KEY);
+    if (tracer == null) {
+      tracer = NoopApiTracer.create();
+    }
+    return tracer;
+  }
+
+  @Override
+  public ApiCallContext withTracer(@Nonnull ApiTracer tracer) {
+    Preconditions.checkNotNull(tracer);
+    return withCallOptions(callOptions.withOption(TRACER_KEY, tracer));
   }
 
   @Override

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -307,15 +307,15 @@ public class GrpcCallContextTest {
     GrpcCallContext ctxWithDefaultTracer = GrpcCallContext.createDefault();
     ApiTracer defaultTracer = ctxWithDefaultTracer.getTracer();
 
-    // Explicit tracers override default tracers
+    // Explicit tracer overrides the default tracer.
     Truth.assertThat(ctxWithDefaultTracer.merge(ctxWithExplicitTracer).getTracer())
         .isSameAs(explicitTracer);
 
-    // Default tracer do not override explicit tracers
+    // Default tracer does not override an explicit tracer.
     Truth.assertThat(ctxWithExplicitTracer.merge(ctxWithDefaultTracer).getTracer())
         .isSameAs(explicitTracer);
 
-    // Default tracer does not override another default tracer
+    // Default tracer does not override another default tracer.
     Truth.assertThat(ctxWithDefaultTracer.merge(GrpcCallContext.createDefault()).getTracer())
         .isSameAs(defaultTracer);
   }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -35,6 +35,7 @@ import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.testing.FakeCallContext;
 import com.google.api.gax.rpc.testing.FakeChannel;
 import com.google.api.gax.rpc.testing.FakeTransportChannel;
+import com.google.api.gax.tracing.ApiTracer;
 import com.google.auth.Credentials;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.truth.Truth;
@@ -295,6 +296,28 @@ public class GrpcCallContextTest {
         createTestExtraHeaders(
             "key1", "value1", "key1", "value2", "key1", "value2", "key2", "value2");
     Truth.assertThat(gotExtraHeaders).containsExactlyEntriesIn(expectedExtraHeaders);
+  }
+
+  @Test
+  public void testMergeWithTracer() {
+    ApiTracer explicitTracer = Mockito.mock(ApiTracer.class);
+    GrpcCallContext ctxWithExplicitTracer =
+        GrpcCallContext.createDefault().withTracer(explicitTracer);
+
+    GrpcCallContext ctxWithDefaultTracer = GrpcCallContext.createDefault();
+    ApiTracer defaultTracer = ctxWithDefaultTracer.getTracer();
+
+    // Explicit tracers override default tracers
+    Truth.assertThat(ctxWithDefaultTracer.merge(ctxWithExplicitTracer).getTracer())
+        .isSameAs(explicitTracer);
+
+    // Default tracer do not override explicit tracers
+    Truth.assertThat(ctxWithExplicitTracer.merge(ctxWithDefaultTracer).getTracer())
+        .isSameAs(explicitTracer);
+
+    // Default tracer does not override another default tracer
+    Truth.assertThat(ctxWithDefaultTracer.merge(GrpcCallContext.createDefault()).getTracer())
+        .isSameAs(defaultTracer);
   }
 
   private static Map<String, List<String>> createTestExtraHeaders(String... keyValues) {

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -255,13 +255,14 @@ public final class HttpJsonCallContext implements ApiCallContext {
   @Override
   public ApiTracer getTracer() {
     if (tracer == null) {
-      return NoopApiTracer.create();
+      return NoopApiTracer.getInstance();
     }
     return tracer;
   }
 
+  /** {@inheritDoc} */
   @Override
-  public ApiCallContext withTracer(@Nonnull ApiTracer newTracer) {
+  public HttpJsonCallContext withTracer(@Nonnull ApiTracer newTracer) {
     Preconditions.checkNotNull(newTracer);
 
     return new HttpJsonCallContext(

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -34,6 +34,8 @@ import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.api.gax.rpc.internal.Headers;
+import com.google.api.gax.tracing.ApiTracer;
+import com.google.api.gax.tracing.NoopApiTracer;
 import com.google.auth.Credentials;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -61,10 +63,12 @@ public final class HttpJsonCallContext implements ApiCallContext {
   private final Instant deadline;
   private final Credentials credentials;
   private final ImmutableMap<String, List<String>> extraHeaders;
+  private final ApiTracer tracer;
 
   /** Returns an empty instance. */
   public static HttpJsonCallContext createDefault() {
-    return new HttpJsonCallContext(null, null, null, null, ImmutableMap.<String, List<String>>of());
+    return new HttpJsonCallContext(
+        null, null, null, null, ImmutableMap.<String, List<String>>of(), null);
   }
 
   private HttpJsonCallContext(
@@ -72,12 +76,14 @@ public final class HttpJsonCallContext implements ApiCallContext {
       Duration timeout,
       Instant deadline,
       Credentials credentials,
-      ImmutableMap<String, List<String>> extraHeaders) {
+      ImmutableMap<String, List<String>> extraHeaders,
+      ApiTracer tracer) {
     this.channel = channel;
     this.timeout = timeout;
     this.deadline = deadline;
     this.credentials = credentials;
     this.extraHeaders = extraHeaders;
+    this.tracer = tracer;
   }
 
   /**
@@ -137,14 +143,19 @@ public final class HttpJsonCallContext implements ApiCallContext {
     ImmutableMap<String, List<String>> newExtraHeaders =
         Headers.mergeHeaders(extraHeaders, httpJsonCallContext.extraHeaders);
 
+    ApiTracer newTracer = httpJsonCallContext.tracer;
+    if (newTracer == null) {
+      newTracer = this.tracer;
+    }
+
     return new HttpJsonCallContext(
-        newChannel, newTimeout, newDeadline, newCredentials, newExtraHeaders);
+        newChannel, newTimeout, newDeadline, newCredentials, newExtraHeaders, newTracer);
   }
 
   @Override
   public HttpJsonCallContext withCredentials(Credentials newCredentials) {
     return new HttpJsonCallContext(
-        this.channel, this.timeout, this.deadline, newCredentials, this.extraHeaders);
+        this.channel, this.timeout, this.deadline, newCredentials, this.extraHeaders, this.tracer);
   }
 
   @Override
@@ -171,7 +182,7 @@ public final class HttpJsonCallContext implements ApiCallContext {
     }
 
     return new HttpJsonCallContext(
-        this.channel, timeout, this.deadline, this.credentials, this.extraHeaders);
+        this.channel, timeout, this.deadline, this.credentials, this.extraHeaders, this.tracer);
   }
 
   @Nullable
@@ -208,7 +219,8 @@ public final class HttpJsonCallContext implements ApiCallContext {
     Preconditions.checkNotNull(extraHeaders);
     ImmutableMap<String, List<String>> newExtraHeaders =
         Headers.mergeHeaders(this.extraHeaders, extraHeaders);
-    return new HttpJsonCallContext(channel, timeout, deadline, credentials, newExtraHeaders);
+    return new HttpJsonCallContext(
+        channel, timeout, deadline, credentials, newExtraHeaders, this.tracer);
   }
 
   @BetaApi("The surface for extra headers is not stable yet and may change in the future.")
@@ -230,11 +242,30 @@ public final class HttpJsonCallContext implements ApiCallContext {
   }
 
   public HttpJsonCallContext withChannel(HttpJsonChannel newChannel) {
-    return new HttpJsonCallContext(newChannel, timeout, deadline, credentials, extraHeaders);
+    return new HttpJsonCallContext(
+        newChannel, timeout, deadline, credentials, extraHeaders, this.tracer);
   }
 
   public HttpJsonCallContext withDeadline(Instant newDeadline) {
-    return new HttpJsonCallContext(channel, timeout, newDeadline, credentials, extraHeaders);
+    return new HttpJsonCallContext(
+        channel, timeout, newDeadline, credentials, extraHeaders, this.tracer);
+  }
+
+  @Nonnull
+  @Override
+  public ApiTracer getTracer() {
+    if (tracer == null) {
+      return NoopApiTracer.create();
+    }
+    return tracer;
+  }
+
+  @Override
+  public ApiCallContext withTracer(@Nonnull ApiTracer newTracer) {
+    Preconditions.checkNotNull(newTracer);
+
+    return new HttpJsonCallContext(
+        channel, timeout, deadline, credentials, extraHeaders, newTracer);
   }
 
   @Override
@@ -250,11 +281,12 @@ public final class HttpJsonCallContext implements ApiCallContext {
         && Objects.equals(timeout, that.timeout)
         && Objects.equals(deadline, that.deadline)
         && Objects.equals(credentials, that.credentials)
-        && Objects.equals(extraHeaders, that.extraHeaders);
+        && Objects.equals(extraHeaders, that.extraHeaders)
+        && Objects.equals(tracer, that.tracer);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(channel, timeout, deadline, credentials, extraHeaders);
+    return Objects.hash(channel, timeout, deadline, credentials, extraHeaders, tracer);
   }
 }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallContextTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallContextTest.java
@@ -163,15 +163,15 @@ public class HttpJsonCallContextTest {
     HttpJsonCallContext ctxWithDefaultTracer = HttpJsonCallContext.createDefault();
     ApiTracer defaultTracer = ctxWithDefaultTracer.getTracer();
 
-    // Explicit tracers override default tracers
+    // Explicit tracer overrides the default tracer.
     Truth.assertThat(ctxWithDefaultTracer.merge(ctxWithExplicitTracer).getTracer())
         .isSameAs(explicitTracer);
 
-    // Default tracer do not override explicit tracers
+    // Default tracer does not override an explicit tracer.
     Truth.assertThat(ctxWithExplicitTracer.merge(ctxWithDefaultTracer).getTracer())
         .isSameAs(explicitTracer);
 
-    // Default tracer does not override another default tracer
+    // Default tracer does not override another default tracer.
     Truth.assertThat(ctxWithDefaultTracer.merge(HttpJsonCallContext.createDefault()).getTracer())
         .isSameAs(defaultTracer);
   }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallContextTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallContextTest.java
@@ -32,6 +32,7 @@ package com.google.api.gax.httpjson;
 import com.google.api.gax.rpc.testing.FakeCallContext;
 import com.google.api.gax.rpc.testing.FakeChannel;
 import com.google.api.gax.rpc.testing.FakeTransportChannel;
+import com.google.api.gax.tracing.ApiTracer;
 import com.google.auth.Credentials;
 import com.google.common.truth.Truth;
 import org.junit.Rule;
@@ -151,5 +152,27 @@ public class HttpJsonCallContextTest {
     HttpJsonCallContext ctx2 = HttpJsonCallContext.createDefault().withTimeout(timeout);
 
     Truth.assertThat(ctx1.merge(ctx2).getTimeout()).isEqualTo(timeout);
+  }
+
+  @Test
+  public void testMergeWithTracer() {
+    ApiTracer explicitTracer = Mockito.mock(ApiTracer.class);
+    HttpJsonCallContext ctxWithExplicitTracer =
+        HttpJsonCallContext.createDefault().withTracer(explicitTracer);
+
+    HttpJsonCallContext ctxWithDefaultTracer = HttpJsonCallContext.createDefault();
+    ApiTracer defaultTracer = ctxWithDefaultTracer.getTracer();
+
+    // Explicit tracers override default tracers
+    Truth.assertThat(ctxWithDefaultTracer.merge(ctxWithExplicitTracer).getTracer())
+        .isSameAs(explicitTracer);
+
+    // Default tracer do not override explicit tracers
+    Truth.assertThat(ctxWithExplicitTracer.merge(ctxWithDefaultTracer).getTracer())
+        .isSameAs(explicitTracer);
+
+    // Default tracer does not override another default tracer
+    Truth.assertThat(ctxWithDefaultTracer.merge(HttpJsonCallContext.createDefault()).getTracer())
+        .isSameAs(defaultTracer);
   }
 }

--- a/gax/src/main/java/com/google/api/gax/retrying/NoopRetryingContext.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/NoopRetryingContext.java
@@ -45,9 +45,10 @@ class NoopRetryingContext implements RetryingContext {
     return new NoopRetryingContext();
   }
 
+  /** {@inheritDoc} */
   @Nonnull
   @Override
   public ApiTracer getTracer() {
-    return NoopApiTracer.create();
+    return NoopApiTracer.getInstance();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/retrying/RetryingContext.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetryingContext.java
@@ -40,6 +40,7 @@ import javax.annotation.Nonnull;
  */
 @BetaApi("The surface for passing per operation state is not yet stable")
 public interface RetryingContext {
+  /** Returns the {@link ApiTracer} associated with the current operation. */
   @Nonnull
   ApiTracer getTracer();
 }

--- a/gax/src/main/java/com/google/api/gax/retrying/RetryingContext.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetryingContext.java
@@ -30,6 +30,8 @@
 package com.google.api.gax.retrying;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.tracing.ApiTracer;
+import javax.annotation.Nonnull;
 
 /**
  * Context for a retryable operation.
@@ -37,4 +39,7 @@ import com.google.api.core.BetaApi;
  * <p>It provides state to individual {@link RetryingFuture}s via the {@link RetryingExecutor}.
  */
 @BetaApi("The surface for passing per operation state is not yet stable")
-public interface RetryingContext {}
+public interface RetryingContext {
+  @Nonnull
+  ApiTracer getTracer();
+}

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -32,9 +32,11 @@ package com.google.api.gax.rpc;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.retrying.RetryingContext;
+import com.google.api.gax.tracing.ApiTracer;
 import com.google.auth.Credentials;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
@@ -129,6 +131,13 @@ public interface ApiCallContext extends RetryingContext {
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nullable
   Duration getStreamIdleTimeout();
+
+  @BetaApi("The surface for tracing is not stable yet and may change in the future")
+  @Nonnull
+  ApiTracer getTracer();
+
+  @BetaApi("The surface for tracing is not stable yet and may change in the future")
+  ApiCallContext withTracer(@Nonnull ApiTracer tracer);
 
   /** If inputContext is not null, returns it; if it is null, returns the present instance. */
   ApiCallContext nullToSelf(ApiCallContext inputContext);

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -132,10 +132,24 @@ public interface ApiCallContext extends RetryingContext {
   @Nullable
   Duration getStreamIdleTimeout();
 
+  /**
+   * The {@link ApiTracer} that was previously set for this context.
+   *
+   * <p>The {@link ApiTracer} will be used to trace the current operation and to annotate various
+   * events like retries.
+   */
   @BetaApi("The surface for tracing is not stable yet and may change in the future")
   @Nonnull
   ApiTracer getTracer();
 
+  /**
+   * Returns a new {@link ApiCallContext} with the given {@link ApiTracer}.
+   *
+   * <p>The {@link ApiTracer} will be used to trace the current operation and to annotate various
+   * events like retries.
+   *
+   * @param tracer the {@link ApiTracer} to set.
+   */
   @BetaApi("The surface for tracing is not stable yet and may change in the future")
   ApiCallContext withTracer(@Nonnull ApiTracer tracer);
 

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -35,6 +35,8 @@ import com.google.api.core.NanoClock;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.ExecutorAsBackgroundResource;
 import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.tracing.ApiTracerFactory;
+import com.google.api.gax.tracing.NoopApiTracerFactory;
 import com.google.auth.Credentials;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
@@ -93,6 +95,10 @@ public abstract class ClientContext {
   @Nullable
   public abstract String getEndpoint();
 
+  @BetaApi("The surface for tracing is not stable yet and may change in the future.")
+  @Nonnull
+  public abstract ApiTracerFactory getTracerFactory();
+
   public static Builder newBuilder() {
     return new AutoValue_ClientContext.Builder()
         .setBackgroundResources(Collections.<BackgroundResource>emptyList())
@@ -101,7 +107,8 @@ public abstract class ClientContext {
         .setInternalHeaders(Collections.<String, String>emptyMap())
         .setClock(NanoClock.getDefaultClock())
         .setStreamWatchdog(null)
-        .setStreamWatchdogCheckInterval(Duration.ZERO);
+        .setStreamWatchdogCheckInterval(Duration.ZERO)
+        .setTracerFactory(new NoopApiTracerFactory());
   }
 
   public abstract Builder toBuilder();
@@ -186,6 +193,7 @@ public abstract class ClientContext {
         .setEndpoint(settings.getEndpoint())
         .setStreamWatchdog(watchdog)
         .setStreamWatchdogCheckInterval(settings.getStreamWatchdogCheckInterval())
+        .setTracerFactory(settings.getTracerFactory())
         .build();
   }
 
@@ -217,6 +225,9 @@ public abstract class ClientContext {
 
     @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     public abstract Builder setStreamWatchdogCheckInterval(Duration duration);
+
+    @BetaApi("The surface for tracing is not stable yet and may change in the future.")
+    public abstract Builder setTracerFactory(ApiTracerFactory tracerFactory);
 
     public abstract ClientContext build();
   }

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -95,6 +95,7 @@ public abstract class ClientContext {
   @Nullable
   public abstract String getEndpoint();
 
+  /** Gets the {@link ApiTracerFactory} that will be used to generate traces for operations. */
   @BetaApi("The surface for tracing is not stable yet and may change in the future.")
   @Nonnull
   public abstract ApiTracerFactory getTracerFactory();
@@ -108,7 +109,7 @@ public abstract class ClientContext {
         .setClock(NanoClock.getDefaultClock())
         .setStreamWatchdog(null)
         .setStreamWatchdogCheckInterval(Duration.ZERO)
-        .setTracerFactory(new NoopApiTracerFactory());
+        .setTracerFactory(NoopApiTracerFactory.getInstance());
   }
 
   public abstract Builder toBuilder();
@@ -226,6 +227,11 @@ public abstract class ClientContext {
     @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     public abstract Builder setStreamWatchdogCheckInterval(Duration duration);
 
+    /**
+     * Set the {@link ApiTracerFactory} that will be used to generate traces for operations.
+     *
+     * @param tracerFactory an instance {@link ApiTracerFactory}.
+     */
     @BetaApi("The surface for tracing is not stable yet and may change in the future.")
     public abstract Builder setTracerFactory(ApiTracerFactory tracerFactory);
 

--- a/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -127,6 +127,10 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     return streamWatchdogCheckInterval;
   }
 
+  /**
+   * Gets the configured {@link ApiTracerFactory} that will be used to generate traces for
+   * operations.
+   */
   @BetaApi("The surface for tracing is not stable yet and may change in the future.")
   @Nonnull
   public ApiTracerFactory getTracerFactory() {
@@ -189,7 +193,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         this.endpoint = null;
         this.streamWatchdogProvider = InstantiatingWatchdogProvider.create();
         this.streamWatchdogCheckInterval = Duration.ofSeconds(10);
-        this.tracerFactory = new NoopApiTracerFactory();
+        this.tracerFactory = NoopApiTracerFactory.getInstance();
       } else {
         this.executorProvider = FixedExecutorProvider.create(clientContext.getExecutor());
         this.transportChannelProvider =
@@ -305,7 +309,11 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       return self();
     }
 
-    /** Configures the tracing implementation. */
+    /**
+     * Configures the {@link ApiTracerFactory} that will be used to generate traces.
+     *
+     * @param tracerFactory an instance of {@link ApiTracerFactory} to set.
+     */
     @BetaApi("The surface for tracing is not stable yet and may change in the future.")
     public B setTracerFactory(@Nonnull ApiTracerFactory tracerFactory) {
       Preconditions.checkNotNull(tracerFactory);

--- a/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -39,6 +39,8 @@ import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.core.FixedExecutorProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
 import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.tracing.ApiTracerFactory;
+import com.google.api.gax.tracing.NoopApiTracerFactory;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
@@ -67,6 +69,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
   private final String endpoint;
   @Nullable private final WatchdogProvider streamWatchdogProvider;
   @Nonnull private final Duration streamWatchdogCheckInterval;
+  @Nonnull private final ApiTracerFactory tracerFactory;
 
   /** Constructs an instance of StubSettings. */
   protected StubSettings(Builder builder) {
@@ -79,6 +82,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     this.endpoint = builder.endpoint;
     this.streamWatchdogProvider = builder.streamWatchdogProvider;
     this.streamWatchdogCheckInterval = builder.streamWatchdogCheckInterval;
+    this.tracerFactory = builder.tracerFactory;
   }
 
   public final ExecutorProvider getExecutorProvider() {
@@ -123,6 +127,12 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     return streamWatchdogCheckInterval;
   }
 
+  @BetaApi("The surface for tracing is not stable yet and may change in the future.")
+  @Nonnull
+  public ApiTracerFactory getTracerFactory() {
+    return tracerFactory;
+  }
+
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("executorProvider", executorProvider)
@@ -134,6 +144,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         .add("endpoint", endpoint)
         .add("streamWatchdogProvider", streamWatchdogProvider)
         .add("streamWatchdogCheckInterval", streamWatchdogCheckInterval)
+        .add("tracerFactory", tracerFactory)
         .toString();
   }
 
@@ -151,6 +162,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     private String endpoint;
     @Nullable private WatchdogProvider streamWatchdogProvider;
     @Nonnull private Duration streamWatchdogCheckInterval;
+    @Nonnull private ApiTracerFactory tracerFactory;
 
     /** Create a builder from a StubSettings object. */
     protected Builder(StubSettings settings) {
@@ -163,6 +175,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       this.endpoint = settings.endpoint;
       this.streamWatchdogProvider = settings.streamWatchdogProvider;
       this.streamWatchdogCheckInterval = settings.streamWatchdogCheckInterval;
+      this.tracerFactory = settings.tracerFactory;
     }
 
     protected Builder(ClientContext clientContext) {
@@ -176,6 +189,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         this.endpoint = null;
         this.streamWatchdogProvider = InstantiatingWatchdogProvider.create();
         this.streamWatchdogCheckInterval = Duration.ofSeconds(10);
+        this.tracerFactory = new NoopApiTracerFactory();
       } else {
         this.executorProvider = FixedExecutorProvider.create(clientContext.getExecutor());
         this.transportChannelProvider =
@@ -189,6 +203,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         this.streamWatchdogProvider =
             FixedWatchdogProvider.create(clientContext.getStreamWatchdog());
         this.streamWatchdogCheckInterval = clientContext.getStreamWatchdogCheckInterval();
+        this.tracerFactory = clientContext.getTracerFactory();
       }
     }
 
@@ -290,6 +305,14 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       return self();
     }
 
+    /** Configures the tracing implementation. */
+    @BetaApi("The surface for tracing is not stable yet and may change in the future.")
+    public B setTracerFactory(@Nonnull ApiTracerFactory tracerFactory) {
+      Preconditions.checkNotNull(tracerFactory);
+      this.tracerFactory = tracerFactory;
+      return self();
+    }
+
     /** Gets the ExecutorProvider that was previously set on this Builder. */
     public ExecutorProvider getExecutorProvider() {
       return executorProvider;
@@ -339,6 +362,12 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       return streamWatchdogCheckInterval;
     }
 
+    @BetaApi("The surface for tracing is not stable yet and may change in the future.")
+    @Nonnull
+    public ApiTracerFactory getTracerFactory() {
+      return tracerFactory;
+    }
+
     /** Applies the given settings updater function to the given method settings builders. */
     protected static void applyToAllUnaryMethods(
         Iterable<UnaryCallSettings.Builder<?, ?>> methodSettingsBuilders,
@@ -361,6 +390,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
           .add("endpoint", endpoint)
           .add("streamWatchdogProvider", streamWatchdogProvider)
           .add("streamWatchdogCheckInterval", streamWatchdogCheckInterval)
+          .add("tracerFactory", tracerFactory)
           .toString();
     }
   }

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
@@ -59,15 +59,23 @@ public interface ApiTracer {
   /**
    * Signals that the overall operation has failed and no further attempts will be made. The tracer
    * is now considered closed and should no longer be used.
+   *
+   * @param error the final error that caused the operation to fail.
    */
   void operationFailed(Throwable error);
 
-  /** Annotates the operation with selected connection id from the {@code ChannelPool}. */
+  /**
+   * Annotates the operation with selected connection id from the {@code ChannelPool}.
+   *
+   * @param id the local connection identifier of the selected connection.
+   */
   void connectionSelected(int id);
 
   /**
    * Adds an annotation that an attempt is about to start. In general this should occur at the very
    * start of the operation. The attemptNumber is zero based. So the initial attempt will be 0.
+   *
+   * @param attemptNumber the zero based sequential attempt number.
    */
   void attemptStarted(int attemptNumber);
 
@@ -76,6 +84,9 @@ public interface ApiTracer {
 
   /**
    * Adds an annotation that the attempt failed, but another attempt will be made after the delay.
+   *
+   * @param error the transient error that caused the attempt to fail.
+   * @param delay the amount of time to wait before the next attempt will start.
    */
   void attemptFailed(Throwable error, Duration delay);
 
@@ -88,6 +99,8 @@ public interface ApiTracer {
   /**
    * Adds an annotation that the attempt failed and that no further attempts will be made because
    * the last error was not retryable.
+   *
+   * @param error the error that caused the final attempt to fail.
    */
   void attemptPermanentFailure(Throwable error);
 
@@ -97,7 +110,12 @@ public interface ApiTracer {
   /** Adds an annotation that a streaming request has been sent. */
   void requestSent();
 
-  /** Adds an annotation that a batch of writes has been flushed. */
+  /**
+   * Adds an annotation that a batch of writes has been flushed.
+   *
+   * @param elementCount the number of elements in the batch.
+   * @param requestSize the size of the batch in bytes.
+   */
   void batchRequestSent(long elementCount, long requestSize);
 
   /**

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
+import org.threeten.bp.Duration;
+
+/**
+ * Implementations of this class trace the logical flow of a google cloud client.
+ *
+ * <p>A single instance of a tracer represents a logical operation that can be annotated throughout
+ * its lifecycle. Constructing an instance of a subclass will implicitly signal the start of a new
+ * operation.
+ */
+@BetaApi("Surface for tracing is not yet stable")
+@InternalExtensionOnly
+public interface ApiTracer {
+  /**
+   * Asks the underlying implementation to install itself as a thread local. This allows for interop
+   * between clients using gax and external resources to share the same implementation of the
+   * tracing. For example OpenCensus will install a thread local that can read by the GRPC.
+   */
+  Scope inScope();
+
+  /**
+   * Signals that the overall operation has finished successfully. The tracer is now considered
+   * closed and should no longer be used.
+   */
+  void operationSucceeded();
+
+  /**
+   * Signals that the overall operation has failed and no further attempts will be made. The tracer
+   * is now considered closed and should no longer be used.
+   */
+  void operationFailed(Throwable error);
+
+  /** Annotates the operation with selected connection id from the {@code ChannelPool}. */
+  void connectionSelected(int id);
+
+  /**
+   * Adds an annotation that an attempt is about to start. In general this should occur at the very
+   * start of the operation. The attemptNumber is zero based. So the initial attempt will be 0.
+   */
+  void startAttempt(int attemptNumber);
+
+  /** Adds an annotation that the attempt succeeded. */
+  void attemptSucceeded();
+
+  /**
+   * Adds an annotation that the attempt failed, but another attempt will be made after the delay.
+   */
+  void retryableFailure(Throwable error, Duration delay);
+
+  /**
+   * Adds an annotation that the attempt failed and that no further attempts will be made because
+   * retry limits have been reached.
+   */
+  void retriesExhausted();
+
+  /**
+   * Adds an annotation that the attempt failed and that no further attempts will be made because
+   * the last error was not retryable.
+   */
+  void permanentFailure(Throwable error);
+
+  /** Adds an annotation that a streaming response has been received. */
+  void receivedResponse();
+
+  /** Adds an annotation that a streaming request has been sent. */
+  void sentRequest();
+
+  /** Adds an annotation that a batch of writes has been flushed. */
+  void sentBatchRequest(long elementCount, long requestSize);
+
+  /**
+   * A context class to be used with {@link #inScope()} and a try-with-resources block. Closing a
+   * {@link Scope} removes any context that the underlying implementation might've set in {@link
+   * #inScope()}.
+   */
+  interface Scope extends AutoCloseable {
+    @Override
+    void close();
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
@@ -69,7 +69,7 @@ public interface ApiTracer {
    * Adds an annotation that an attempt is about to start. In general this should occur at the very
    * start of the operation. The attemptNumber is zero based. So the initial attempt will be 0.
    */
-  void startAttempt(int attemptNumber);
+  void attemptStarted(int attemptNumber);
 
   /** Adds an annotation that the attempt succeeded. */
   void attemptSucceeded();
@@ -77,28 +77,28 @@ public interface ApiTracer {
   /**
    * Adds an annotation that the attempt failed, but another attempt will be made after the delay.
    */
-  void retryableFailure(Throwable error, Duration delay);
+  void attemptFailed(Throwable error, Duration delay);
 
   /**
    * Adds an annotation that the attempt failed and that no further attempts will be made because
    * retry limits have been reached.
    */
-  void retriesExhausted();
+  void attemptFailedRetriesExhausted();
 
   /**
    * Adds an annotation that the attempt failed and that no further attempts will be made because
    * the last error was not retryable.
    */
-  void permanentFailure(Throwable error);
+  void attemptPermanentFailure(Throwable error);
 
   /** Adds an annotation that a streaming response has been received. */
-  void receivedResponse();
+  void responseReceived();
 
   /** Adds an annotation that a streaming request has been sent. */
-  void sentRequest();
+  void requestSent();
 
   /** Adds an annotation that a batch of writes has been flushed. */
-  void sentBatchRequest(long elementCount, long requestSize);
+  void batchRequestSent(long elementCount, long requestSize);
 
   /**
    * A context class to be used with {@link #inScope()} and a try-with-resources block. Closing a

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2017 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -27,27 +27,19 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.google.api.gax.retrying;
+package com.google.api.gax.tracing;
 
-// TODO(igorbernstein2): Remove this class once RetryingExecutor#createFuture(Callable) is
-// deprecated and removed.
-
-import com.google.api.gax.tracing.ApiTracer;
-import com.google.api.gax.tracing.NoopApiTracer;
-import javax.annotation.Nonnull;
+import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 
 /**
- * Backwards compatibility class to aid in transition to adding operation state to {@link
- * RetryingFuture} implementations.
+ * A factory to create new instances of {@link ApiTracer}s.
+ *
+ * <p>In general a single instance of an {@link ApiTracer} will correspond to a single logical
+ * operation.
  */
-class NoopRetryingContext implements RetryingContext {
-  public static RetryingContext create() {
-    return new NoopRetryingContext();
-  }
-
-  @Nonnull
-  @Override
-  public ApiTracer getTracer() {
-    return NoopApiTracer.create();
-  }
+@BetaApi("Surface for tracing is not yet stable")
+@InternalExtensionOnly
+public interface ApiTracerFactory {
+  ApiTracer newTracer(SpanName spanName);
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
@@ -33,7 +33,7 @@ import com.google.api.core.InternalApi;
 import org.threeten.bp.Duration;
 
 /**
- * A fake implementation of {@link ApiTracer} that does nothing.
+ * An implementation of {@link ApiTracer} that does nothing.
  *
  * <p>For internal use only.
  */
@@ -51,7 +51,7 @@ public final class NoopApiTracer implements ApiTracer {
 
   private NoopApiTracer() {}
 
-  public static ApiTracer create() {
+  public static ApiTracer getInstance() {
     return INSTANCE;
   }
 

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
@@ -27,27 +27,92 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.google.api.gax.retrying;
+package com.google.api.gax.tracing;
 
-// TODO(igorbernstein2): Remove this class once RetryingExecutor#createFuture(Callable) is
-// deprecated and removed.
-
-import com.google.api.gax.tracing.ApiTracer;
-import com.google.api.gax.tracing.NoopApiTracer;
-import javax.annotation.Nonnull;
+import com.google.api.core.InternalApi;
+import org.threeten.bp.Duration;
 
 /**
- * Backwards compatibility class to aid in transition to adding operation state to {@link
- * RetryingFuture} implementations.
+ * A fake implementation of {@link ApiTracer} that does nothing.
+ *
+ * <p>For internal use only.
  */
-class NoopRetryingContext implements RetryingContext {
-  public static RetryingContext create() {
-    return new NoopRetryingContext();
+@InternalApi
+public final class NoopApiTracer implements ApiTracer {
+  private static final ApiTracer INSTANCE = new NoopApiTracer();
+
+  private static final Scope NOOP_SCOPE =
+      new Scope() {
+        @Override
+        public void close() {
+          // noop
+        }
+      };
+
+  private NoopApiTracer() {}
+
+  public static ApiTracer create() {
+    return INSTANCE;
   }
 
-  @Nonnull
   @Override
-  public ApiTracer getTracer() {
-    return NoopApiTracer.create();
+  public Scope inScope() {
+    return NOOP_SCOPE;
+  }
+
+  @Override
+  public void operationSucceeded() {
+    // noop
+  }
+
+  @Override
+  public void operationFailed(Throwable error) {
+    // noop
+  }
+
+  @Override
+  public void connectionSelected(int id) {
+    // noop
+  }
+
+  @Override
+  public void startAttempt(int attemptNumber) {
+    // noop
+  }
+
+  @Override
+  public void attemptSucceeded() {
+    // noop
+  }
+
+  @Override
+  public void retryableFailure(Throwable error, Duration delay) {
+    // noop
+  }
+
+  @Override
+  public void retriesExhausted() {
+    // noop
+  }
+
+  @Override
+  public void permanentFailure(Throwable error) {
+    // noop
+
+  }
+
+  @Override
+  public void receivedResponse() {
+    // noop
+  }
+
+  @Override
+  public void sentRequest() {
+    // noop
+  }
+
+  @Override
+  public void sentBatchRequest(long elementCount, long requestSize) {
+    // noop
   }
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
@@ -76,7 +76,7 @@ public final class NoopApiTracer implements ApiTracer {
   }
 
   @Override
-  public void startAttempt(int attemptNumber) {
+  public void attemptStarted(int attemptNumber) {
     // noop
   }
 
@@ -86,33 +86,33 @@ public final class NoopApiTracer implements ApiTracer {
   }
 
   @Override
-  public void retryableFailure(Throwable error, Duration delay) {
+  public void attemptFailed(Throwable error, Duration delay) {
     // noop
   }
 
   @Override
-  public void retriesExhausted() {
+  public void attemptFailedRetriesExhausted() {
     // noop
   }
 
   @Override
-  public void permanentFailure(Throwable error) {
+  public void attemptPermanentFailure(Throwable error) {
     // noop
 
   }
 
   @Override
-  public void receivedResponse() {
+  public void responseReceived() {
     // noop
   }
 
   @Override
-  public void sentRequest() {
+  public void requestSent() {
     // noop
   }
 
   @Override
-  public void sentBatchRequest(long elementCount, long requestSize) {
+  public void batchRequestSent(long elementCount, long requestSize) {
     // noop
   }
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
@@ -32,25 +32,23 @@ package com.google.api.gax.tracing;
 import com.google.api.core.InternalApi;
 
 /**
- * Factory that will build fake {@link ApiTracer}s.
+ * Factory that will build {@link ApiTracer}s that do nothing.
  *
  * <p>For internal use only.
  */
 @InternalApi
 public final class NoopApiTracerFactory implements ApiTracerFactory {
+  private static final NoopApiTracerFactory INSTANCE = new NoopApiTracerFactory();
+
+  public static NoopApiTracerFactory getInstance() {
+    return INSTANCE;
+  }
+
+  private NoopApiTracerFactory() {}
+
   /** {@inheritDoc} */
   @Override
   public ApiTracer newTracer(SpanName spanName) {
-    return NoopApiTracer.create();
-  }
-
-  @Override
-  public int hashCode() {
-    return 1;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    return obj instanceof NoopApiTracerFactory;
+    return NoopApiTracer.getInstance();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
@@ -27,27 +27,30 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.google.api.gax.retrying;
+package com.google.api.gax.tracing;
 
-// TODO(igorbernstein2): Remove this class once RetryingExecutor#createFuture(Callable) is
-// deprecated and removed.
-
-import com.google.api.gax.tracing.ApiTracer;
-import com.google.api.gax.tracing.NoopApiTracer;
-import javax.annotation.Nonnull;
+import com.google.api.core.InternalApi;
 
 /**
- * Backwards compatibility class to aid in transition to adding operation state to {@link
- * RetryingFuture} implementations.
+ * Factory that will build fake {@link ApiTracer}s.
+ *
+ * <p>For internal use only.
  */
-class NoopRetryingContext implements RetryingContext {
-  public static RetryingContext create() {
-    return new NoopRetryingContext();
+@InternalApi
+public final class NoopApiTracerFactory implements ApiTracerFactory {
+  /** {@inheritDoc} */
+  @Override
+  public ApiTracer newTracer(SpanName spanName) {
+    return NoopApiTracer.create();
   }
 
-  @Nonnull
   @Override
-  public ApiTracer getTracer() {
-    return NoopApiTracer.create();
+  public int hashCode() {
+    return 1;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof NoopApiTracerFactory;
   }
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/SpanName.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/SpanName.java
@@ -30,18 +30,20 @@
 package com.google.api.gax.tracing;
 
 import com.google.api.core.BetaApi;
-import com.google.api.core.InternalExtensionOnly;
+import com.google.api.core.InternalApi;
 import com.google.auto.value.AutoValue;
 
 /** A value class to represent the name of the operation in an {@link ApiTracer}. */
 @BetaApi("Surface for tracing is not yet stable")
-@InternalExtensionOnly
+@InternalApi("For google-cloud-java client use only")
 @AutoValue
 public abstract class SpanName {
   /**
    * Creates a new instance of the name.
    *
-   * @param clientName The name of the client.
+   * @param clientName The name of the client. In general this will be GAPIC generated client name.
+   *     However, in some cases, when the GAPIC generated client is wrapped, this will be overridden
+   *     to specify the manually written wrapper's name.
    * @param methodName The name of the logical operation being traced.
    */
   public static SpanName of(String clientName, String methodName) {

--- a/gax/src/main/java/com/google/api/gax/tracing/SpanName.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/SpanName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -41,8 +41,8 @@ public abstract class SpanName {
   /**
    * Creates a new instance of the name.
    *
-   * @param clientName The name of the client. ie BigtableData
-   * @param methodName The name of the logical operation being traced. ie. ReadRows.
+   * @param clientName The name of the client.
+   * @param methodName The name of the logical operation being traced.
    */
   public static SpanName of(String clientName, String methodName) {
     return new AutoValue_SpanName(clientName, methodName);

--- a/gax/src/main/java/com/google/api/gax/tracing/SpanName.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/SpanName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2017 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -27,27 +27,40 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.google.api.gax.retrying;
+package com.google.api.gax.tracing;
 
-// TODO(igorbernstein2): Remove this class once RetryingExecutor#createFuture(Callable) is
-// deprecated and removed.
+import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
+import com.google.auto.value.AutoValue;
 
-import com.google.api.gax.tracing.ApiTracer;
-import com.google.api.gax.tracing.NoopApiTracer;
-import javax.annotation.Nonnull;
-
-/**
- * Backwards compatibility class to aid in transition to adding operation state to {@link
- * RetryingFuture} implementations.
- */
-class NoopRetryingContext implements RetryingContext {
-  public static RetryingContext create() {
-    return new NoopRetryingContext();
+/** A value class to represent the name of the operation in an {@link ApiTracer}. */
+@BetaApi("Surface for tracing is not yet stable")
+@InternalExtensionOnly
+@AutoValue
+public abstract class SpanName {
+  /**
+   * Creates a new instance of the name.
+   *
+   * @param clientName The name of the client. ie BigtableData
+   * @param methodName The name of the logical operation being traced. ie. ReadRows.
+   */
+  public static SpanName of(String clientName, String methodName) {
+    return new AutoValue_SpanName(clientName, methodName);
   }
 
-  @Nonnull
-  @Override
-  public ApiTracer getTracer() {
-    return NoopApiTracer.create();
+  /** The name of the client. ie BigtableData */
+  public abstract String getClientName();
+
+  /** The name of the logical operation being traced. ie. ReadRows. */
+  public abstract String getMethodName();
+
+  /** Creates a new instance with the clientName overriden. */
+  public SpanName withClientName(String clientName) {
+    return of(clientName, getMethodName());
+  }
+
+  /** Creates a new instance with the methodName overriden. */
+  public SpanName withMethodName(String methodName) {
+    return of(getClientName(), methodName);
   }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
@@ -272,12 +272,14 @@ public class FakeCallContext implements ApiCallContext {
     return this.extraHeaders;
   }
 
+  /** {@inheritDoc} */
   @Override
   @Nonnull
   public ApiTracer getTracer() {
     return tracer;
   }
 
+  /** {@inheritDoc} */
   @Override
   public ApiCallContext withTracer(@Nonnull ApiTracer tracer) {
     Preconditions.checkNotNull(tracer);

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
@@ -34,6 +34,7 @@ import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.api.gax.rpc.internal.Headers;
+import com.google.api.gax.tracing.ApiTracer;
 import com.google.auth.Credentials;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -51,6 +52,7 @@ public class FakeCallContext implements ApiCallContext {
   private final Duration streamWaitTimeout;
   private final Duration streamIdleTimeout;
   private final ImmutableMap<String, List<String>> extraHeaders;
+  private final ApiTracer tracer;
 
   private FakeCallContext(
       Credentials credentials,
@@ -58,18 +60,20 @@ public class FakeCallContext implements ApiCallContext {
       Duration timeout,
       Duration streamWaitTimeout,
       Duration streamIdleTimeout,
-      ImmutableMap<String, List<String>> extraHeaders) {
+      ImmutableMap<String, List<String>> extraHeaders,
+      ApiTracer tracer) {
     this.credentials = credentials;
     this.channel = channel;
     this.timeout = timeout;
     this.streamWaitTimeout = streamWaitTimeout;
     this.streamIdleTimeout = streamIdleTimeout;
     this.extraHeaders = extraHeaders;
+    this.tracer = tracer;
   }
 
   public static FakeCallContext createDefault() {
     return new FakeCallContext(
-        null, null, null, null, null, ImmutableMap.<String, List<String>>of());
+        null, null, null, null, null, ImmutableMap.<String, List<String>>of(), null);
   }
 
   @Override
@@ -125,6 +129,11 @@ public class FakeCallContext implements ApiCallContext {
       newStreamIdleTimeout = streamIdleTimeout;
     }
 
+    ApiTracer newTracer = fakeCallContext.tracer;
+    if (newTracer == null) {
+      newTracer = this.tracer;
+    }
+
     ImmutableMap<String, List<String>> newExtraHeaders =
         Headers.mergeHeaders(extraHeaders, fakeCallContext.extraHeaders);
     return new FakeCallContext(
@@ -133,7 +142,8 @@ public class FakeCallContext implements ApiCallContext {
         newTimeout,
         newStreamWaitTimeout,
         newStreamIdleTimeout,
-        newExtraHeaders);
+        newExtraHeaders,
+        newTracer);
   }
 
   public Credentials getCredentials() {
@@ -169,7 +179,8 @@ public class FakeCallContext implements ApiCallContext {
         this.timeout,
         this.streamWaitTimeout,
         this.streamIdleTimeout,
-        this.extraHeaders);
+        this.extraHeaders,
+        this.tracer);
   }
 
   @Override
@@ -190,7 +201,8 @@ public class FakeCallContext implements ApiCallContext {
         this.timeout,
         this.streamWaitTimeout,
         this.streamIdleTimeout,
-        this.extraHeaders);
+        this.extraHeaders,
+        this.tracer);
   }
 
   @Override
@@ -211,23 +223,24 @@ public class FakeCallContext implements ApiCallContext {
         timeout,
         this.streamWaitTimeout,
         this.streamIdleTimeout,
-        this.extraHeaders);
+        this.extraHeaders,
+        this.tracer);
   }
 
   @Override
-  public ApiCallContext withStreamWaitTimeout(@Nonnull Duration streamWaitTimeout) {
-    Preconditions.checkNotNull(streamWaitTimeout);
+  public ApiCallContext withStreamWaitTimeout(@Nullable Duration streamWaitTimeout) {
     return new FakeCallContext(
         this.credentials,
         this.channel,
         this.timeout,
         streamWaitTimeout,
         this.streamIdleTimeout,
-        this.extraHeaders);
+        this.extraHeaders,
+        this.tracer);
   }
 
   @Override
-  public ApiCallContext withStreamIdleTimeout(@Nonnull Duration streamIdleTimeout) {
+  public ApiCallContext withStreamIdleTimeout(@Nullable Duration streamIdleTimeout) {
     Preconditions.checkNotNull(streamIdleTimeout);
     return new FakeCallContext(
         this.credentials,
@@ -235,7 +248,8 @@ public class FakeCallContext implements ApiCallContext {
         this.timeout,
         this.streamWaitTimeout,
         streamIdleTimeout,
-        this.extraHeaders);
+        this.extraHeaders,
+        this.tracer);
   }
 
   @Override
@@ -244,12 +258,38 @@ public class FakeCallContext implements ApiCallContext {
     ImmutableMap<String, List<String>> newExtraHeaders =
         Headers.mergeHeaders(this.extraHeaders, extraHeaders);
     return new FakeCallContext(
-        credentials, channel, timeout, streamWaitTimeout, streamIdleTimeout, newExtraHeaders);
+        credentials,
+        channel,
+        timeout,
+        streamWaitTimeout,
+        streamIdleTimeout,
+        newExtraHeaders,
+        this.tracer);
   }
 
   @Override
   public Map<String, List<String>> getExtraHeaders() {
     return this.extraHeaders;
+  }
+
+  @Override
+  @Nonnull
+  public ApiTracer getTracer() {
+    return tracer;
+  }
+
+  @Override
+  public ApiCallContext withTracer(@Nonnull ApiTracer tracer) {
+    Preconditions.checkNotNull(tracer);
+
+    return new FakeCallContext(
+        this.credentials,
+        this.channel,
+        this.timeout,
+        this.streamWaitTimeout,
+        this.streamIdleTimeout,
+        this.extraHeaders,
+        tracer);
   }
 
   public static FakeCallContext create(ClientContext clientContext) {


### PR DESCRIPTION
This has been extracted from #613

This doesn't provide any extra functionality. Instead it just sets up the foundation for integrating tracing in to gax.
The general idea is to add a tracing abstraction layer that all parts of gax can call into. This is accomplished by introducing
- ApiTracer interface that has methods for all annotations that a span should contain
- ApiTracerFactory interface: since an ApiTracer is stateful and has a 1:1 mapping with operations, a factory is introduced to cleanly switch implementations of the tracer

By default a NoopApiTracerFactory is configured that will return NoopApiTracers. In the future a parallel OpenCensusApiTracerFactory will be added. A client implementation will be able to opt into tracing by setting the factory in StubSettings. The actual ApiTracer will be propagated by CallContext.