### PR TITLE
Opencensus Tracing: Start tracing unary callable.

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -61,6 +61,9 @@ import javax.annotation.Nonnull;
 /** Class with utility methods to create grpc-based direct callables. */
 @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
 public class GrpcCallableFactory {
+  // Used to extract service and method name from a grpc MethodDescriptor.
+  private static final Pattern FULL_METHOD_NAME_REGEX = Pattern.compile("^.*?([^./]+)/([^./]+)$");
+
   private GrpcCallableFactory() {}
 
   /**
@@ -294,8 +297,7 @@ public class GrpcCallableFactory {
 
   @InternalApi("Visible for testing")
   static SpanName getSpanName(@Nonnull MethodDescriptor<?, ?> methodDescriptor) {
-    Pattern pattern = Pattern.compile("^.*?([^./]+)/([^./]+)$");
-    Matcher matcher = pattern.matcher(methodDescriptor.getFullMethodName());
+    Matcher matcher = FULL_METHOD_NAME_REGEX.matcher(methodDescriptor.getFullMethodName());
 
     Preconditions.checkArgument(matcher.matches(), "Invalid fullMethodName");
     return SpanName.of(matcher.group(1), matcher.group(2));

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -54,7 +54,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import io.grpc.MethodDescriptor;
-import io.opencensus.trace.SpanBuilder;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.grpc;
 
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.BidiStreamingCallable;
@@ -46,9 +47,12 @@ import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.StreamingCallSettings;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.gax.tracing.SpanName;
+import com.google.api.gax.tracing.TracedUnaryCallable;
 import com.google.common.collect.ImmutableSet;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
+import io.grpc.MethodDescriptor;
 
 /** Class with utility methods to create grpc-based direct callables. */
 @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
@@ -90,6 +94,13 @@ public class GrpcCallableFactory {
       ClientContext clientContext) {
     UnaryCallable<RequestT, ResponseT> callable =
         createBaseUnaryCallable(grpcCallSettings, callSettings, clientContext);
+
+    callable =
+        new TracedUnaryCallable<>(
+            callable,
+            clientContext.getTracerFactory(),
+            getSpanName(grpcCallSettings.getMethodDescriptor()));
+
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
   }
 
@@ -275,5 +286,17 @@ public class GrpcCallableFactory {
         new GrpcExceptionClientStreamingCallable<>(callable, ImmutableSet.<StatusCode.Code>of());
 
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
+  }
+
+  @InternalApi("Visible for testing")
+  static SpanName getSpanName(MethodDescriptor<?, ?> methodDescriptor) {
+    int index = methodDescriptor.getFullMethodName().lastIndexOf('/');
+    String fullServiceName = methodDescriptor.getFullMethodName().substring(0, index);
+    String methodName = methodDescriptor.getFullMethodName().substring(index + 1);
+
+    int serviceIndex = fullServiceName.lastIndexOf('.');
+    String clientName = fullServiceName.substring(serviceIndex + 1);
+
+    return SpanName.of(clientName, methodName);
   }
 }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallableFactoryTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallableFactoryTest.java
@@ -38,17 +38,22 @@ import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.ServerStreamingCallSettings;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.api.gax.tracing.SpanName;
 import com.google.common.truth.Truth;
 import com.google.type.Color;
 import com.google.type.Money;
 import io.grpc.CallOptions;
 import io.grpc.ManagedChannel;
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.Marshaller;
+import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
 import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
@@ -133,5 +138,20 @@ public class GrpcCallableFactoryTest {
     }
     Truth.assertThat(actualError2).isInstanceOf(InvalidArgumentException.class);
     Truth.assertThat(((InvalidArgumentException) actualError2).isRetryable()).isTrue();
+  }
+
+  @Test
+  public void testGetSpanName() {
+    @SuppressWarnings("unchecked")
+    MethodDescriptor descriptor =
+        MethodDescriptor.newBuilder()
+            .setType(MethodType.SERVER_STREAMING)
+            .setFullMethodName("google.bigtable.v2.Bigtable/ReadRows")
+            .setRequestMarshaller(Mockito.mock(Marshaller.class))
+            .setResponseMarshaller(Mockito.mock(Marshaller.class))
+            .build();
+
+    SpanName actualSpanName = GrpcCallableFactory.getSpanName(descriptor);
+    Truth.assertThat(actualSpanName).isEqualTo(SpanName.of("Bigtable", "ReadRows"));
   }
 }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallableFactoryTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallableFactoryTest.java
@@ -176,10 +176,7 @@ public class GrpcCallableFactoryTest {
 
   @Test
   public void testGetSpanNameInvalid() {
-    List<String> invalidNames = ImmutableList.of(
-        "BareMethod",
-        "/MethodWithoutService"
-    );
+    List<String> invalidNames = ImmutableList.of("BareMethod", "/MethodWithoutService");
 
     for (String invalidName : invalidNames) {
       @SuppressWarnings("unchecked")

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
@@ -37,6 +37,7 @@ import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.PagedCallSettings;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.gax.tracing.SpanName;
 import com.google.api.gax.tracing.TracedUnaryCallable;
 import javax.annotation.Nonnull;
 
@@ -78,9 +79,11 @@ public class HttpJsonCallableFactory {
     UnaryCallable<RequestT, ResponseT> innerCallable =
         createDirectUnaryCallable(httpJsonCallSettings);
 
-    innerCallable = new TracedUnaryCallable<>(
-        innerCallable, clientContext.getTracerFactory(),
-        getSpanName(httpJsonCallSettings.getMethodDescriptor()));
+    innerCallable =
+        new TracedUnaryCallable<>(
+            innerCallable,
+            clientContext.getTracerFactory(),
+            getSpanName(httpJsonCallSettings.getMethodDescriptor()));
 
     return createUnaryCallable(innerCallable, callSettings, clientContext);
   }

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
@@ -47,6 +47,10 @@ import javax.annotation.Nonnull;
 /** Class with utility methods to create http/json-based direct callables. */
 @BetaApi
 public class HttpJsonCallableFactory {
+  // Used to extract service and method name from a grpc MethodDescriptor.
+  // fullMethodName has the format: service.resource.action
+  // For example: compute.instances.addAccessConfig
+  private static final Pattern FULL_METHOD_NAME_REGEX = Pattern.compile("^(.+)\\.(.+)$");
 
   private HttpJsonCallableFactory() {}
 
@@ -134,10 +138,7 @@ public class HttpJsonCallableFactory {
 
   @InternalApi("Visible for testing")
   static SpanName getSpanName(@Nonnull ApiMethodDescriptor<?, ?> methodDescriptor) {
-    // fullMethodName has the format: service.resource.action
-    // For example: compute.instances.addAccessConfig
-    Pattern pattern = Pattern.compile("^(.+)\\.(.+)$");
-    Matcher matcher = pattern.matcher(methodDescriptor.getFullMethodName());
+    Matcher matcher = FULL_METHOD_NAME_REGEX.matcher(methodDescriptor.getFullMethodName());
 
     Preconditions.checkArgument(matcher.matches(), "Invalid fullMethodName");
     return SpanName.of(matcher.group(1), matcher.group(2));

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
@@ -39,6 +39,9 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.gax.tracing.SpanName;
 import com.google.api.gax.tracing.TracedUnaryCallable;
+import com.google.common.base.Preconditions;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 
 /** Class with utility methods to create http/json-based direct callables. */
@@ -133,10 +136,10 @@ public class HttpJsonCallableFactory {
   static SpanName getSpanName(@Nonnull ApiMethodDescriptor<?, ?> methodDescriptor) {
     // fullMethodName has the format: service.resource.action
     // For example: compute.instances.addAccessConfig
-    int index = methodDescriptor.getFullMethodName().indexOf('.');
-    String serviceName = methodDescriptor.getFullMethodName().substring(0, index);
-    String methodName = methodDescriptor.getFullMethodName().substring(index + 1);
+    Pattern pattern = Pattern.compile("^(.+)\\.(.+)$");
+    Matcher matcher = pattern.matcher(methodDescriptor.getFullMethodName());
 
-    return SpanName.of(serviceName, methodName);
+    Preconditions.checkArgument(matcher.matches(), "Invalid fullMethodName");
+    return SpanName.of(matcher.group(1), matcher.group(2));
   }
 }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallableFactoryTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallableFactoryTest.java
@@ -48,10 +48,10 @@ import org.mockito.Mockito;
 public class HttpJsonCallableFactoryTest {
   @Test
   public void testGetSpanName() {
-    Map<String, SpanName> validNames = ImmutableMap.of(
-        "compute.projects.disableXpnHost", SpanName.of("compute.projects", "disableXpnHost"),
-        "client.method", SpanName.of("client", "disableXpnHost")
-    );
+    Map<String, SpanName> validNames =
+        ImmutableMap.of(
+            "compute.projects.disableXpnHost", SpanName.of("compute.projects", "disableXpnHost"),
+            "client.method", SpanName.of("client", "method"));
 
     for (Entry<String, SpanName> entry : validNames.entrySet()) {
       @SuppressWarnings("unchecked")
@@ -70,10 +70,7 @@ public class HttpJsonCallableFactoryTest {
 
   @Test
   public void testGetSpanNameInvalid() {
-    List<String> invalidNames = ImmutableList.of(
-        "no_split",
-        ".no_client"
-    );
+    List<String> invalidNames = ImmutableList.of("no_split", ".no_client");
 
     for (String invalidName : invalidNames) {
       @SuppressWarnings("unchecked")
@@ -95,6 +92,5 @@ public class HttpJsonCallableFactoryTest {
       }
       assertThat(actualError).isNotNull();
     }
-
   }
 }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallableFactoryTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallableFactoryTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.httpjson;
+
+import com.google.api.client.http.HttpMethods;
+import com.google.api.gax.tracing.SpanName;
+import com.google.common.truth.Truth;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public class HttpJsonCallableFactoryTest {
+  @Test
+  public void testGetSpanName() {
+    @SuppressWarnings("unchecked")
+    ApiMethodDescriptor descriptor =
+        ApiMethodDescriptor.newBuilder()
+            .setFullMethodName("compute.projects.disableXpnHost")
+            .setHttpMethod(HttpMethods.POST)
+            .setRequestFormatter(Mockito.mock(HttpRequestFormatter.class))
+            .setResponseParser(Mockito.mock(HttpResponseParser.class))
+            .build();
+
+    SpanName actualSpanName = HttpJsonCallableFactory.getSpanName(descriptor);
+    Truth.assertThat(actualSpanName).isEqualTo(SpanName.of("compute", "projects.disableXpnHost"));
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
@@ -57,6 +57,12 @@ public interface ApiTracer {
   void operationSucceeded();
 
   /**
+   * Signals that the operation was cancelled by the user. The tracer is now considered closed and
+   * should no longer be used.
+   */
+  void operationCancelled();
+
+  /**
    * Signals that the overall operation has failed and no further attempts will be made. The tracer
    * is now considered closed and should no longer be used.
    *

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
@@ -66,6 +66,11 @@ public final class NoopApiTracer implements ApiTracer {
   }
 
   @Override
+  public void operationCancelled() {
+    // noop
+  }
+
+  @Override
   public void operationFailed(Throwable error) {
     // noop
   }

--- a/gax/src/main/java/com/google/api/gax/tracing/TraceFinisher.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TraceFinisher.java
@@ -32,7 +32,7 @@ package com.google.api.gax.tracing;
 import com.google.api.core.ApiFutureCallback;
 
 /** An {@link ApiFutureCallback} to mark a started operation trace as finished. */
-class TraceFinisher implements ApiFutureCallback<Object> {
+class TraceFinisher<T> implements ApiFutureCallback<T> {
   private final ApiTracer tracer;
 
   TraceFinisher(ApiTracer tracer) {
@@ -45,7 +45,7 @@ class TraceFinisher implements ApiFutureCallback<Object> {
   }
 
   @Override
-  public void onSuccess(Object responseT) {
+  public void onSuccess(T responseT) {
     tracer.operationSucceeded();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/TraceFinisher.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TraceFinisher.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.tracing;
 
 import com.google.api.core.ApiFutureCallback;
+import java.util.concurrent.CancellationException;
 
 /** An {@link ApiFutureCallback} to mark a started operation trace as finished. */
 class TraceFinisher<T> implements ApiFutureCallback<T> {
@@ -41,7 +42,11 @@ class TraceFinisher<T> implements ApiFutureCallback<T> {
 
   @Override
   public void onFailure(Throwable throwable) {
-    tracer.operationFailed(throwable);
+    if (throwable instanceof CancellationException) {
+      tracer.operationCancelled();
+    } else {
+      tracer.operationFailed(throwable);
+    }
   }
 
   @Override

--- a/gax/src/main/java/com/google/api/gax/tracing/TraceFinisher.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TraceFinisher.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import com.google.api.core.ApiFutureCallback;
+
+/** An {@link ApiFutureCallback} to mark a started operation trace as finished. */
+class TraceFinisher implements ApiFutureCallback<Object> {
+  private final ApiTracer tracer;
+
+  TraceFinisher(ApiTracer tracer) {
+    this.tracer = tracer;
+  }
+
+  @Override
+  public void onFailure(Throwable throwable) {
+    tracer.operationFailed(throwable);
+  }
+
+  @Override
+  public void onSuccess(Object responseT) {
+    tracer.operationSucceeded();
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedUnaryCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedUnaryCallable.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.util.concurrent.MoreExecutors;
+
+/**
+ * A wrapper callable that will wrap a callable chain in a trace.
+ *
+ * <p>This class is meant to be an internal implementation google-cloud-java clients only.
+ */
+@BetaApi("The surface for tracing is not stable and might change in the future")
+@InternalApi("For internal use by google-cloud-java clients only")
+public final class TracedUnaryCallable<RequestT, ResponseT>
+    extends UnaryCallable<RequestT, ResponseT> {
+  private final UnaryCallable<RequestT, ResponseT> innerCallable;
+  private final ApiTracerFactory tracerFactory;
+  private final SpanName spanName;
+
+  public TracedUnaryCallable(
+      UnaryCallable<RequestT, ResponseT> innerCallable,
+      ApiTracerFactory tracerFactory,
+      SpanName spanName) {
+    this.innerCallable = innerCallable;
+    this.tracerFactory = tracerFactory;
+    this.spanName = spanName;
+  }
+
+  /** Calls the wrapped {@link UnaryCallable} within the context of a new trace. */
+  @Override
+  public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext context) {
+    ApiTracer tracer = tracerFactory.newTracer(spanName);
+    TraceFinisher finisher = new TraceFinisher(tracer);
+
+    try {
+      context = context.withTracer(tracer);
+      ApiFuture<ResponseT> future = innerCallable.futureCall(request, context);
+      ApiFutures.addCallback(future, finisher, MoreExecutors.directExecutor());
+
+      return future;
+    } catch (RuntimeException e) {
+      finisher.onFailure(e);
+      throw e;
+    }
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedUnaryCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedUnaryCallable.java
@@ -38,7 +38,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.common.util.concurrent.MoreExecutors;
 
 /**
- * A wrapper callable that will wrap a callable chain in a trace.
+ * This callable wraps a callable chain in a {@link ApiTracer}.
  *
  * <p>This class is meant to be an internal implementation google-cloud-java clients only.
  */
@@ -59,7 +59,12 @@ public final class TracedUnaryCallable<RequestT, ResponseT>
     this.spanName = spanName;
   }
 
-  /** Calls the wrapped {@link UnaryCallable} within the context of a new trace. */
+  /**
+   * Calls the wrapped {@link UnaryCallable} within the context of a new trace.
+   *
+   * @param request the request to send.
+   * @param context {@link ApiCallContext} to make the call with.
+   */
   @Override
   public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext context) {
     ApiTracer tracer = tracerFactory.newTracer(spanName);

--- a/gax/src/test/java/com/google/api/gax/tracing/TraceFinisherTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TraceFinisherTest.java
@@ -29,6 +29,9 @@
  */
 package com.google.api.gax.tracing;
 
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -37,7 +40,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
@@ -53,7 +55,16 @@ public class TraceFinisherTest {
     ApiFutures.addCallback(
         future, new TraceFinisher<String>(mockTracer), MoreExecutors.directExecutor());
 
-    Mockito.verify(mockTracer, Mockito.times(1)).operationSucceeded();
+    verify(mockTracer, times(1)).operationSucceeded();
+  }
+
+  @Test
+  public void testCancellation() {
+    ApiFuture<String> future = ApiFutures.immediateCancelledFuture();
+    ApiFutures.addCallback(
+        future, new TraceFinisher<String>(mockTracer), MoreExecutors.directExecutor());
+
+    verify(mockTracer, times(1)).operationCancelled();
   }
 
   @Test
@@ -63,6 +74,6 @@ public class TraceFinisherTest {
     ApiFutures.addCallback(
         future, new TraceFinisher<String>(mockTracer), MoreExecutors.directExecutor());
 
-    Mockito.verify(mockTracer, Mockito.times(1)).operationFailed(expectedError);
+    verify(mockTracer, times(1)).operationFailed(expectedError);
   }
 }

--- a/gax/src/test/java/com/google/api/gax/tracing/TraceFinisherTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TraceFinisherTest.java
@@ -40,10 +40,11 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 @RunWith(JUnit4.class)
 public class TraceFinisherTest {
-  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
   @Mock private ApiTracer mockTracer;
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedUnaryCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedUnaryCallableTest.java
@@ -42,12 +42,14 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 @RunWith(JUnit4.class)
 public class TracedUnaryCallableTest {
   private static final SpanName SPAN_NAME = SpanName.of("FakeClient", "FakeRpc");
 
-  @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
 
   @Mock private ApiTracerFactory tracerFactory;
   @Mock private ApiTracer tracer;

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedUnaryCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedUnaryCallableTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.gax.rpc.testing.FakeCallContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class TracedUnaryCallableTest {
+  private static final SpanName SPAN_NAME = SpanName.of("FakeClient", "FakeRpc");
+
+  @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock private ApiTracerFactory tracerFactory;
+  @Mock private ApiTracer tracer;
+  @Mock private UnaryCallable<String, String> innerCallable;
+  private SettableApiFuture<String> innerResult;
+
+  private TracedUnaryCallable<String, String> tracedUnaryCallable;
+  private FakeCallContext callContext;
+
+  @Before
+  public void setUp() {
+    // Wire the mock tracer factory
+    Mockito.when(tracerFactory.newTracer(Mockito.any(SpanName.class))).thenReturn(tracer);
+
+    // Wire the mock inner callable
+    innerResult = SettableApiFuture.create();
+    Mockito.when(innerCallable.futureCall(Mockito.anyString(), Mockito.any(ApiCallContext.class)))
+        .thenReturn(innerResult);
+
+    // Build the system under test
+    tracedUnaryCallable = new TracedUnaryCallable<>(innerCallable, tracerFactory, SPAN_NAME);
+    callContext = FakeCallContext.createDefault();
+  }
+
+  @Test
+  public void testTracerCreated() {
+    tracedUnaryCallable.futureCall("test", callContext);
+    Mockito.verify(tracerFactory, Mockito.times(1)).newTracer(SPAN_NAME);
+  }
+
+  @Test
+  public void testOperationFinish() {
+    innerResult.set("successful result");
+    tracedUnaryCallable.futureCall("test", callContext);
+
+    Mockito.verify(tracer, Mockito.times(1)).attemptSucceeded();
+  }
+
+  @Test
+  public void testOperationFailed() {
+    RuntimeException fakeError = new RuntimeException("fake error");
+    innerResult.setException(fakeError);
+    tracedUnaryCallable.futureCall("test", callContext);
+
+    Mockito.verify(tracer, Mockito.times(1)).operationFailed(fakeError);
+  }
+
+  @Test
+  public void testSyncError() {
+    RuntimeException fakeError = new RuntimeException("fake error");
+    Mockito.when(
+            innerCallable.futureCall(Mockito.eq("failing test"), Mockito.any(ApiCallContext.class)))
+        .thenThrow(fakeError);
+
+    try {
+      tracedUnaryCallable.futureCall("failing test", callContext);
+    } catch (RuntimeException e) {
+      // ignored
+    }
+
+    Mockito.verify(tracer, Mockito.times(1)).operationFailed(fakeError);
+  }
+}

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedUnaryCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedUnaryCallableTest.java
@@ -83,7 +83,7 @@ public class TracedUnaryCallableTest {
     innerResult.set("successful result");
     tracedUnaryCallable.futureCall("test", callContext);
 
-    Mockito.verify(tracer, Mockito.times(1)).attemptSucceeded();
+    Mockito.verify(tracer, Mockito.times(1)).operationSucceeded();
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedUnaryCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedUnaryCallableTest.java
@@ -98,6 +98,12 @@ public class TracedUnaryCallableTest {
   @Test
   public void testSyncError() {
     RuntimeException fakeError = new RuntimeException("fake error");
+
+    // Reset the irrelevant expectations from setup. (only needed to silence the warnings).
+    @SuppressWarnings("unchecked")
+    UnaryCallable<String, String>[] innerCallableWrapper = new UnaryCallable[] {innerCallable};
+    Mockito.reset(innerCallableWrapper);
+
     Mockito.when(
             innerCallable.futureCall(Mockito.eq("failing test"), Mockito.any(ApiCallContext.class)))
         .thenThrow(fakeError);


### PR DESCRIPTION
This depends on #633 and is extracted from  #613.

This introduces TracedUnaryCallables that will create a trace and complete it. It is inserted as one of the outermost links in the callable chain to allow all other callables to contribute their annotations.
google-cloud-java that extend the chains (like cloud bigtable) will also use this class to trace their extensions.