### PR TITLE
Opencensus Tracing: Start tracing bidi streaming callables.

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.grpc;
 
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.BidiStreamingCallable;
@@ -46,9 +47,12 @@ import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.StreamingCallSettings;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.gax.tracing.SpanName;
+import com.google.api.gax.tracing.TracedBidiCallable;
 import com.google.common.collect.ImmutableSet;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
+import io.grpc.MethodDescriptor;
 
 /** Class with utility methods to create grpc-based direct callables. */
 @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
@@ -188,6 +192,12 @@ public class GrpcCallableFactory {
     callable =
         new GrpcExceptionBidiStreamingCallable<>(callable, ImmutableSet.<StatusCode.Code>of());
 
+    callable =
+        new TracedBidiCallable<>(
+            callable,
+            clientContext.getTracerFactory(),
+            getSpanName(grpcCallSettings.getMethodDescriptor()));
+
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
   }
 
@@ -275,5 +285,17 @@ public class GrpcCallableFactory {
         new GrpcExceptionClientStreamingCallable<>(callable, ImmutableSet.<StatusCode.Code>of());
 
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
+  }
+
+  @InternalApi("Visible for testing")
+  static SpanName getSpanName(MethodDescriptor<?, ?> methodDescriptor) {
+    int index = methodDescriptor.getFullMethodName().lastIndexOf('/');
+    String fullServiceName = methodDescriptor.getFullMethodName().substring(0, index);
+    String methodName = methodDescriptor.getFullMethodName().substring(index + 1);
+
+    int serviceIndex = fullServiceName.lastIndexOf('.');
+    String clientName = fullServiceName.substring(serviceIndex + 1);
+
+    return SpanName.of(clientName, methodName);
   }
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedBidiCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedBidiCallable.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientStream;
+import com.google.api.gax.rpc.ClientStreamReadyObserver;
+import com.google.api.gax.rpc.ResponseObserver;
+import com.google.api.gax.rpc.StreamController;
+import com.google.common.base.Preconditions;
+import javax.annotation.Nonnull;
+
+/**
+ * A wrapper callable that will wrap a callable chain in a trace.
+ *
+ * <p>This class is meant to be an internal implementation google-cloud-java clients only.
+ */
+@BetaApi("The surface for tracing is not stable and might change in the future")
+@InternalApi("For internal use by google-cloud-java clients only")
+public class TracedBidiCallable<RequestT, ResponseT>
+    extends BidiStreamingCallable<RequestT, ResponseT> {
+
+  @Nonnull private final ApiTracerFactory tracerFactory;
+  @Nonnull private final SpanName spanName;
+  @Nonnull private final BidiStreamingCallable<RequestT, ResponseT> innerCallable;
+
+  public TracedBidiCallable(
+      @Nonnull BidiStreamingCallable<RequestT, ResponseT> innerCallable,
+      @Nonnull ApiTracerFactory tracerFactory,
+      @Nonnull SpanName spanName) {
+    this.tracerFactory = Preconditions.checkNotNull(tracerFactory, "tracerFactory can't be null");
+    this.spanName = Preconditions.checkNotNull(spanName, "spanName can't be null");
+    this.innerCallable = Preconditions.checkNotNull(innerCallable, "innerCallable can't be null");
+  }
+
+  @Override
+  public ClientStream<RequestT> internalCall(
+      ResponseObserver<ResponseT> responseObserver,
+      ClientStreamReadyObserver<RequestT> onReady,
+      ApiCallContext context) {
+
+    ApiTracer tracer = tracerFactory.newTracer(spanName);
+    context = context.withTracer(tracer);
+
+    ResponseObserver<ResponseT> tracedObserver =
+        new TracingResponseObserver<>(tracer, responseObserver);
+    ClientStreamReadyObserver<RequestT> tracedReadyObserver =
+        new TracingClientStreamReadyObserver<>(tracer, onReady);
+
+    try {
+      ClientStream<RequestT> clientStream =
+          innerCallable.internalCall(tracedObserver, tracedReadyObserver, context);
+      return new TracingClientStream<>(tracer, clientStream);
+    } catch (RuntimeException e) {
+      tracer.operationFailed(e);
+      throw e;
+    }
+  }
+
+  /**
+   * {@link ResponseObserver} wrapper to annotate the current trace with received messages and to
+   * close the current trace upon completion of the RPC.
+   */
+  private static class TracingResponseObserver<ResponseT> implements ResponseObserver<ResponseT> {
+    private final ApiTracer tracer;
+    private final ResponseObserver<ResponseT> innerObserver;
+
+    private TracingResponseObserver(ApiTracer tracer, ResponseObserver<ResponseT> innerObserver) {
+      this.tracer = tracer;
+      this.innerObserver = innerObserver;
+    }
+
+    @Override
+    public void onStart(StreamController controller) {
+      innerObserver.onStart(controller);
+    }
+
+    @Override
+    public void onResponse(ResponseT response) {
+      tracer.responseReceived();
+      innerObserver.onResponse(response);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      tracer.operationFailed(t);
+      innerObserver.onError(t);
+    }
+
+    @Override
+    public void onComplete() {
+      tracer.operationSucceeded();
+      innerObserver.onComplete();
+    }
+  }
+
+  private static class TracingClientStreamReadyObserver<RequestT>
+      implements ClientStreamReadyObserver<RequestT> {
+    private final ApiTracer tracer;
+    private final ClientStreamReadyObserver<RequestT> innerObserver;
+
+    TracingClientStreamReadyObserver(
+        ApiTracer tracer, ClientStreamReadyObserver<RequestT> innerObserver) {
+      this.tracer = tracer;
+      this.innerObserver = innerObserver;
+    }
+
+    @Override
+    public void onReady(ClientStream<RequestT> stream) {
+      innerObserver.onReady(new TracingClientStream<>(tracer, stream));
+    }
+  }
+
+  /** {@link ClientStream} wrapper that annotates traces with sent messages. */
+  private static class TracingClientStream<RequestT> implements ClientStream<RequestT> {
+    private final ApiTracer tracer;
+    private final ClientStream<RequestT> innerStream;
+
+    private TracingClientStream(ApiTracer tracer, ClientStream<RequestT> innerStream) {
+      this.tracer = tracer;
+      this.innerStream = innerStream;
+    }
+
+    @Override
+    public void send(RequestT request) {
+      tracer.requestSent();
+      innerStream.send(request);
+    }
+
+    @Override
+    public void closeSendWithError(Throwable t) {
+      innerStream.closeSendWithError(t);
+    }
+
+    @Override
+    public void closeSend() {
+      innerStream.closeSend();
+    }
+
+    @Override
+    public boolean isSendReady() {
+      return innerStream.isSendReady();
+    }
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedBidiCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedBidiCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedBidiCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedBidiCallable.java
@@ -1,17 +1,17 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
  *
- *     Redistributions of source code must retain the above copyright
+ *     * Redistributions of source code must retain the above copyright
  * notice, this list of conditions and the following disclaimer.
- *     Redistributions in binary form must reproduce the above
+ *     * Redistributions in binary form must reproduce the above
  * copyright notice, this list of conditions and the following disclaimer
  * in the documentation and/or other materials provided with the
  * distribution.
- *     Neither the name of Google LLC nor the names of its
+ *     * Neither the name of Google LLC nor the names of its
  * contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
  *
@@ -73,9 +73,9 @@ public class TracedBidiCallable<RequestT, ResponseT>
     context = context.withTracer(tracer);
 
     ResponseObserver<ResponseT> tracedObserver =
-        new TracingResponseObserver<>(tracer, responseObserver);
+        new TracedResponseObserver<>(tracer, responseObserver);
     ClientStreamReadyObserver<RequestT> tracedReadyObserver =
-        new TracingClientStreamReadyObserver<>(tracer, onReady);
+        new TracedClientStreamReadyObserver<>(tracer, onReady);
 
     try {
       ClientStream<RequestT> clientStream =
@@ -91,11 +91,11 @@ public class TracedBidiCallable<RequestT, ResponseT>
    * {@link ResponseObserver} wrapper to annotate the current trace with received messages and to
    * close the current trace upon completion of the RPC.
    */
-  private static class TracingResponseObserver<ResponseT> implements ResponseObserver<ResponseT> {
+  private static class TracedResponseObserver<ResponseT> implements ResponseObserver<ResponseT> {
     private final ApiTracer tracer;
     private final ResponseObserver<ResponseT> innerObserver;
 
-    private TracingResponseObserver(ApiTracer tracer, ResponseObserver<ResponseT> innerObserver) {
+    private TracedResponseObserver(ApiTracer tracer, ResponseObserver<ResponseT> innerObserver) {
       this.tracer = tracer;
       this.innerObserver = innerObserver;
     }
@@ -124,12 +124,12 @@ public class TracedBidiCallable<RequestT, ResponseT>
     }
   }
 
-  private static class TracingClientStreamReadyObserver<RequestT>
+  private static class TracedClientStreamReadyObserver<RequestT>
       implements ClientStreamReadyObserver<RequestT> {
     private final ApiTracer tracer;
     private final ClientStreamReadyObserver<RequestT> innerObserver;
 
-    TracingClientStreamReadyObserver(
+    TracedClientStreamReadyObserver(
         ApiTracer tracer, ClientStreamReadyObserver<RequestT> innerObserver) {
       this.tracer = tracer;
       this.innerObserver = innerObserver;

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedBidiCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedBidiCallableTest.java
@@ -30,7 +30,9 @@
 package com.google.api.gax.tracing;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.BidiStream;
@@ -41,7 +43,7 @@ import com.google.api.gax.rpc.ClientStreamReadyObserver;
 import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.StreamController;
 import com.google.api.gax.rpc.testing.FakeCallContext;
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import org.junit.Before;
@@ -102,7 +104,6 @@ public class TracedBidiCallableTest {
   @Test
   public void testOperationCancelled2() {
     BidiStream<String, String> stream = tracedCallable.call(outerCallContext);
-    FakeStreamController innerController = new FakeStreamController();
 
     stream.cancel();
     innerCallable.responseObserver.onError(
@@ -211,7 +212,7 @@ public class TracedBidiCallableTest {
   }
 
   private static class FakeClientStream implements ClientStream<String> {
-    private List<String> sent = Lists.newArrayList();
+    private List<String> sent = new ArrayList<>();
     private Throwable closeError;
     private boolean closed;
 
@@ -238,11 +239,11 @@ public class TracedBidiCallableTest {
   }
 
   private static class FakeBidiObserver implements BidiStreamObserver<String, String> {
-    ClientStream<String> clientStream;
-    StreamController streamController;
-    List<String> responses = Lists.newArrayList();
-    Throwable error;
-    boolean complete;
+    private ClientStream<String> clientStream;
+    private StreamController streamController;
+    private List<String> responses = new ArrayList<>();
+    private Throwable error;
+    private boolean complete;
 
     @Override
     public void onReady(ClientStream<String> stream) {
@@ -272,7 +273,7 @@ public class TracedBidiCallableTest {
   }
 
   private static class FakeStreamController implements StreamController {
-    boolean wasCancelled;
+    private boolean wasCancelled;
 
     @Override
     public void cancel() {

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedBidiCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedBidiCallableTest.java
@@ -1,17 +1,17 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
  *
- *     Redistributions of source code must retain the above copyright
+ *     * Redistributions of source code must retain the above copyright
  * notice, this list of conditions and the following disclaimer.
- *     Redistributions in binary form must reproduce the above
+ *     * Redistributions in binary form must reproduce the above
  * copyright notice, this list of conditions and the following disclaimer
  * in the documentation and/or other materials provided with the
  * distribution.
- *     Neither the name of Google LLC nor the names of its
+ *     * Neither the name of Google LLC nor the names of its
  * contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
  *
@@ -27,12 +27,12 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package com.google.api.gax.tracing;
 
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.BidiStream;
 import com.google.api.gax.rpc.BidiStreamObserver;
 import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.ClientStream;
@@ -125,6 +125,16 @@ public class TracedBidiCallableTest {
     tracedCallable.call(outerObserver, outerCallContext);
     outerObserver.clientStream.send("request1");
     outerObserver.clientStream.send("request2");
+
+    Mockito.verify(tracer, Mockito.times(2)).requestSent();
+    assertThat(innerCallable.clientStream.sent).containsExactly("request1", "request2");
+  }
+
+  @Test
+  public void testRequestNotify2() {
+    BidiStream<String, String> stream = tracedCallable.call(outerCallContext);
+    stream.send("request1");
+    stream.send("request2");
 
     Mockito.verify(tracer, Mockito.times(2)).requestSent();
     assertThat(innerCallable.clientStream.sent).containsExactly("request1", "request2");

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedBidiCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedBidiCallableTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.api.gax.tracing;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.BidiStreamObserver;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientStream;
+import com.google.api.gax.rpc.ClientStreamReadyObserver;
+import com.google.api.gax.rpc.ResponseObserver;
+import com.google.api.gax.rpc.StreamController;
+import com.google.api.gax.rpc.testing.FakeCallContext;
+import com.google.common.collect.Lists;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class TracedBidiCallableTest {
+  private static final SpanName SPAN_NAME = SpanName.of("fake-client", "fake-method");
+  public @Rule MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  private FakeBidiObserver outerObserver;
+  private FakeCallContext outerCallContext;
+
+  @Mock private ApiTracerFactory tracerFactory;
+  @Mock private ApiTracer tracer;
+
+  private TracedBidiCallable<String, String> tracedCallable;
+
+  private FakeBidiCallable innerCallable;
+
+  @Before
+  public void setUp() {
+    outerObserver = new FakeBidiObserver();
+    outerCallContext = FakeCallContext.createDefault();
+
+    Mockito.when(tracerFactory.newTracer(SPAN_NAME)).thenReturn(tracer);
+
+    innerCallable = new FakeBidiCallable();
+    tracedCallable = new TracedBidiCallable<>(innerCallable, tracerFactory, SPAN_NAME);
+  }
+
+  @Test
+  public void testTracerCreated() {
+    tracedCallable.call(outerObserver, outerCallContext);
+
+    Mockito.verify(tracerFactory, Mockito.times(1)).newTracer(SPAN_NAME);
+  }
+
+  @Test
+  public void testOperationFinished() {
+    tracedCallable.call(outerObserver, outerCallContext);
+    innerCallable.responseObserver.onComplete();
+
+    Mockito.verify(tracer, Mockito.times(1)).operationSucceeded();
+    assertThat(outerObserver.complete).isTrue();
+  }
+
+  @Test
+  public void testOperationFailed() {
+    RuntimeException expectedException = new RuntimeException("fake");
+
+    tracedCallable.call(outerObserver, outerCallContext);
+    innerCallable.responseObserver.onError(expectedException);
+
+    Mockito.verify(tracer, Mockito.times(1)).operationFailed(expectedException);
+    assertThat(outerObserver.complete).isTrue();
+    assertThat(outerObserver.error).isEqualTo(expectedException);
+  }
+
+  @Test
+  public void testSyncError() {
+    RuntimeException expectedException = new RuntimeException("fake");
+    innerCallable.syncError = expectedException;
+
+    try {
+      tracedCallable.call(outerObserver, outerCallContext);
+    } catch (RuntimeException e) {
+      // noop
+    }
+
+    Mockito.verify(tracer, Mockito.times(1)).operationFailed(expectedException);
+  }
+
+  @Test
+  public void testRequestNotify() {
+    tracedCallable.call(outerObserver, outerCallContext);
+    outerObserver.clientStream.send("request1");
+    outerObserver.clientStream.send("request2");
+
+    Mockito.verify(tracer, Mockito.times(2)).requestSent();
+    assertThat(innerCallable.clientStream.sent).containsExactly("request1", "request2");
+  }
+
+  @Test
+  public void testResponseNotify() {
+    tracedCallable.call(outerObserver, outerCallContext);
+
+    innerCallable.responseObserver.onResponse("response1");
+    innerCallable.responseObserver.onResponse("response2");
+
+    Mockito.verify(tracer, Mockito.times(2)).responseReceived();
+    assertThat(outerObserver.responses).containsExactly("response1", "response2");
+  }
+
+  private static class FakeBidiCallable extends BidiStreamingCallable<String, String> {
+    RuntimeException syncError;
+
+    ResponseObserver<String> responseObserver;
+    ClientStreamReadyObserver<String> onReady;
+    ApiCallContext callContext;
+    FakeClientStream clientStream;
+
+    @Override
+    public ClientStream<String> internalCall(
+        ResponseObserver<String> responseObserver,
+        ClientStreamReadyObserver<String> onReady,
+        ApiCallContext context) {
+
+      if (syncError != null) {
+        throw syncError;
+      }
+
+      this.responseObserver = responseObserver;
+      this.onReady = onReady;
+      this.callContext = context;
+      this.clientStream = new FakeClientStream();
+
+      onReady.onReady(clientStream);
+      return clientStream;
+    }
+  }
+
+  private static class FakeClientStream implements ClientStream<String> {
+    private List<String> sent = Lists.newArrayList();
+    private Throwable closeError;
+    private boolean closed;
+
+    @Override
+    public void send(String request) {
+      sent.add(request);
+    }
+
+    @Override
+    public void closeSendWithError(Throwable t) {
+      closed = true;
+      closeError = t;
+    }
+
+    @Override
+    public void closeSend() {
+      closed = true;
+    }
+
+    @Override
+    public boolean isSendReady() {
+      return true;
+    }
+  }
+
+  private static class FakeBidiObserver implements BidiStreamObserver<String, String> {
+    ClientStream<String> clientStream;
+    StreamController streamController;
+    List<String> responses = Lists.newArrayList();
+    Throwable error;
+    boolean complete;
+
+    @Override
+    public void onReady(ClientStream<String> stream) {
+      this.clientStream = stream;
+    }
+
+    @Override
+    public void onStart(StreamController controller) {
+      this.streamController = controller;
+    }
+
+    @Override
+    public void onResponse(String response) {
+      responses.add(response);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      this.error = t;
+      this.complete = true;
+    }
+
+    @Override
+    public void onComplete() {
+      this.complete = true;
+    }
+  }
+}


### PR DESCRIPTION
This depends on #633 and is extracted from #613.

This introduces TracedBidiCallables that will create a trace and complete it. It is inserted as one of the outermost links in the callable chain to allow all other callables to contribute their annotations.
google-cloud-java that extend the chains (like cloud bigtable) will also use this class to trace their extensions.
