### PR TITLE
Opencensus Tracing: Add annotations for retries

### DIFF
--- a/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
@@ -34,6 +34,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
+import com.google.api.gax.tracing.ApiTracer;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.Callable;
@@ -137,16 +138,18 @@ class BasicRetryingFuture<ResponseT> extends AbstractFuture<ResponseT>
 
   // "super." is used here to avoid infinite loops of callback chains
   void handleAttempt(Throwable throwable, ResponseT response) {
+    ApiTracer tracer = retryingContext.getTracer();
+
     synchronized (lock) {
       try {
         clearAttemptServiceData();
         if (throwable instanceof CancellationException) {
           // An attempt triggered cancellation.
-          retryingContext.getTracer().attemptFailedRetriesExhausted(throwable);
+          tracer.attemptFailedRetriesExhausted(throwable);
           super.cancel(false);
         } else if (throwable instanceof RejectedExecutionException) {
           // external executor cannot continue retrying
-          retryingContext.getTracer().attemptPermanentFailure(throwable);
+          tracer.attemptPermanentFailure(throwable);
           super.setException(throwable);
         }
         if (isDone()) {
@@ -157,32 +160,31 @@ class BasicRetryingFuture<ResponseT> extends AbstractFuture<ResponseT>
             retryAlgorithm.createNextAttempt(throwable, response, attemptSettings);
         boolean shouldRetry = retryAlgorithm.shouldRetry(throwable, response, nextAttemptSettings);
         if (shouldRetry) {
-          retryingContext
-              .getTracer()
+          tracer
               .attemptFailed(throwable, nextAttemptSettings.getRandomizedRetryDelay());
           attemptSettings = nextAttemptSettings;
           setAttemptResult(throwable, response, true);
           // a new attempt will be (must be) scheduled by an external executor
         } else if (throwable != null) {
           if (retryAlgorithm.getResultAlgorithm().shouldRetry(throwable, response)) {
-            retryingContext.getTracer().attemptFailedRetriesExhausted(throwable);
+            tracer.attemptFailedRetriesExhausted(throwable);
           } else {
-            retryingContext.getTracer().attemptPermanentFailure(throwable);
+            tracer.attemptPermanentFailure(throwable);
           }
           super.setException(throwable);
         } else {
-          retryingContext.getTracer().attemptSucceeded();
+          tracer.attemptSucceeded();
           super.set(response);
         }
       } catch (CancellationException e) {
         // A retry algorithm triggered cancellation.
-        retryingContext.getTracer().attemptFailedRetriesExhausted(e);
+        tracer.attemptFailedRetriesExhausted(e);
         super.cancel(false);
       } catch (Exception e) {
         // Should never happen, but still possible in case of buggy retry algorithm implementation.
         // Any bugs/exceptions (except CancellationException) in retry algorithms immediately
         // terminate retrying future and set the result to the thrown exception.
-        retryingContext.getTracer().attemptPermanentFailure(e);
+        tracer.attemptPermanentFailure(e);
         super.setException(e);
       }
     }

--- a/gax/src/main/java/com/google/api/gax/rpc/AttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/AttemptCallable.java
@@ -78,6 +78,11 @@ class AttemptCallable<RequestT, ResponseT> implements Callable<ResponseT> {
       if (externalFuture.isDone()) {
         return null;
       }
+
+      callContext
+          .getTracer()
+          .attemptStarted(externalFuture.getAttemptSettings().getOverallAttemptCount());
+
       ApiFuture<ResponseT> internalFuture = callable.futureCall(request, callContext);
       externalFuture.setAttemptFuture(internalFuture);
     } catch (Throwable e) {

--- a/gax/src/main/java/com/google/api/gax/rpc/CheckingAttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/CheckingAttemptCallable.java
@@ -75,6 +75,11 @@ class CheckingAttemptCallable<RequestT, ResponseT> implements Callable<ResponseT
       if (externalFuture.isDone()) {
         return null;
       }
+
+      callContext
+          .getTracer()
+          .attemptStarted(externalFuture.getAttemptSettings().getOverallAttemptCount());
+
       // NOTE: The callable here is an OperationCheckingCallable, which will compose its own
       // request using a resolved operation name and ignore anything that we pass here for the
       // request.

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
@@ -220,6 +220,10 @@ final class ServerStreamingAttemptCallable<RequestT, ResponseT> implements Calla
               outerRetryingFuture.getAttemptSettings().getRpcTimeout());
     }
 
+    attemptContext
+        .getTracer()
+        .attemptStarted(outerRetryingFuture.getAttemptSettings().getOverallAttemptCount());
+
     innerCallable.call(
         request,
         new StateCheckingResponseObserver<ResponseT>() {

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
@@ -93,8 +93,10 @@ public interface ApiTracer {
   /**
    * Adds an annotation that the attempt failed and that no further attempts will be made because
    * retry limits have been reached.
+   *
+   * @param error the last error received before retries were exhausted.
    */
-  void attemptFailedRetriesExhausted();
+  void attemptFailedRetriesExhausted(Throwable error);
 
   /**
    * Adds an annotation that the attempt failed and that no further attempts will be made because

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
@@ -82,6 +82,9 @@ public interface ApiTracer {
   /** Adds an annotation that the attempt succeeded. */
   void attemptSucceeded();
 
+  /** Add an annotation that the attempt was cancelled by the user. */
+  void attemptCancelled();
+
   /**
    * Adds an annotation that the attempt failed, but another attempt will be made after the delay.
    *

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
@@ -86,6 +86,11 @@ public final class NoopApiTracer implements ApiTracer {
   }
 
   @Override
+  public void attemptCancelled() {
+    // noop
+  }
+
+  @Override
   public void attemptFailed(Throwable error, Duration delay) {
     // noop
   }

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
@@ -91,7 +91,7 @@ public final class NoopApiTracer implements ApiTracer {
   }
 
   @Override
-  public void attemptFailedRetriesExhausted() {
+  public void attemptFailedRetriesExhausted(Throwable error) {
     // noop
   }
 

--- a/gax/src/test/java/com/google/api/gax/retrying/AbstractRetryingExecutorTest.java
+++ b/gax/src/test/java/com/google/api/gax/retrying/AbstractRetryingExecutorTest.java
@@ -40,26 +40,32 @@ import static org.junit.Assert.assertTrue;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.NanoClock;
 import com.google.api.gax.retrying.FailingCallable.CustomException;
+import com.google.api.gax.rpc.testing.FakeCallContext;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.threeten.bp.Duration;
 
 @RunWith(MockitoJUnitRunner.class)
 public abstract class AbstractRetryingExecutorTest {
-  @Mock protected RetryingContext retryingContext;
+  protected RetryingContext retryingContext;
 
   protected abstract RetryingExecutorWithContext<String> getExecutor(
       RetryAlgorithm<String> retryAlgorithm);
 
   protected abstract RetryAlgorithm<String> getAlgorithm(
       RetrySettings retrySettings, int apocalypseCountDown, RuntimeException apocalypseException);
+
+  @Before
+  public void setUp() {
+    retryingContext = FakeCallContext.createDefault();
+  }
 
   @Test
   public void testSuccess() throws Exception {

--- a/gax/src/test/java/com/google/api/gax/retrying/AbstractRetryingExecutorTest.java
+++ b/gax/src/test/java/com/google/api/gax/retrying/AbstractRetryingExecutorTest.java
@@ -36,6 +36,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.NanoClock;
@@ -53,7 +58,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.threeten.bp.Duration;
@@ -87,9 +91,9 @@ public abstract class AbstractRetryingExecutorTest {
     assertFutureSuccess(future);
     assertEquals(0, future.getAttemptSettings().getAttemptCount());
 
-    Mockito.verify(tracer, Mockito.times(1)).attemptStarted(0);
-    Mockito.verify(tracer, Mockito.times(1)).attemptSucceeded();
-    Mockito.verifyNoMoreInteractions(tracer);
+    verify(tracer, times(1)).attemptStarted(0);
+    verify(tracer, times(1)).attemptSucceeded();
+    verifyNoMoreInteractions(tracer);
   }
 
   @Test
@@ -103,11 +107,11 @@ public abstract class AbstractRetryingExecutorTest {
     assertFutureSuccess(future);
     assertEquals(5, future.getAttemptSettings().getAttemptCount());
 
-    Mockito.verify(tracer, Mockito.times(6)).attemptStarted(Mockito.anyInt());
-    Mockito.verify(tracer, Mockito.times(5))
-        .attemptFailed(Mockito.any(Throwable.class), Mockito.any(Duration.class));
-    Mockito.verify(tracer, Mockito.times(1)).attemptSucceeded();
-    Mockito.verifyNoMoreInteractions(tracer);
+    verify(tracer, times(6)).attemptStarted(anyInt());
+    verify(tracer, times(5))
+        .attemptFailed(any(Throwable.class), any(Duration.class));
+    verify(tracer, times(1)).attemptSucceeded();
+    verifyNoMoreInteractions(tracer);
   }
 
   @Test
@@ -147,12 +151,12 @@ public abstract class AbstractRetryingExecutorTest {
     assertFutureFail(future, CustomException.class);
     assertEquals(5, future.getAttemptSettings().getAttemptCount());
 
-    Mockito.verify(tracer, Mockito.times(6)).attemptStarted(Mockito.anyInt());
-    Mockito.verify(tracer, Mockito.times(5))
-        .attemptFailed(Mockito.any(Throwable.class), Mockito.any(Duration.class));
-    Mockito.verify(tracer, Mockito.times(1))
-        .attemptFailedRetriesExhausted(Mockito.any(Throwable.class));
-    Mockito.verifyNoMoreInteractions(tracer);
+    verify(tracer, times(6)).attemptStarted(anyInt());
+    verify(tracer, times(5))
+        .attemptFailed(any(Throwable.class), any(Duration.class));
+    verify(tracer, times(1))
+        .attemptFailedRetriesExhausted(any(Throwable.class));
+    verifyNoMoreInteractions(tracer);
   }
 
   @Test
@@ -172,10 +176,10 @@ public abstract class AbstractRetryingExecutorTest {
     assertFutureFail(future, CustomException.class);
     assertTrue(future.getAttemptSettings().getAttemptCount() < 4);
 
-    Mockito.verify(tracer, Mockito.times(1)).attemptStarted(Mockito.anyInt());
-    Mockito.verify(tracer, Mockito.times(1))
-        .attemptFailedRetriesExhausted(Mockito.any(Throwable.class));
-    Mockito.verifyNoMoreInteractions(tracer);
+    verify(tracer, times(1)).attemptStarted(anyInt());
+    verify(tracer, times(1))
+        .attemptFailedRetriesExhausted(any(Throwable.class));
+    verifyNoMoreInteractions(tracer);
   }
 
   @Test
@@ -201,7 +205,7 @@ public abstract class AbstractRetryingExecutorTest {
     assertFutureCancel(future);
     assertEquals(0, future.getAttemptSettings().getAttemptCount());
 
-    Mockito.verifyNoMoreInteractions(tracer);
+    verifyNoMoreInteractions(tracer);
   }
 
   @Test
@@ -215,14 +219,14 @@ public abstract class AbstractRetryingExecutorTest {
     assertFutureCancel(future);
     assertEquals(4, future.getAttemptSettings().getAttemptCount());
 
-    Mockito.verify(tracer, Mockito.times(5)).attemptStarted(Mockito.anyInt());
+    verify(tracer, times(5)).attemptStarted(anyInt());
     // Pre-apocalypse failures
-    Mockito.verify(tracer, Mockito.times(4))
-        .attemptFailed(Mockito.any(Throwable.class), Mockito.any(Duration.class));
+    verify(tracer, times(4))
+        .attemptFailed(any(Throwable.class), any(Duration.class));
     // Apocalypse failure
-    Mockito.verify(tracer, Mockito.times(1))
-        .attemptFailedRetriesExhausted(Mockito.any(CancellationException.class));
-    Mockito.verifyNoMoreInteractions(tracer);
+    verify(tracer, times(1))
+        .attemptFailedRetriesExhausted(any(CancellationException.class));
+    verifyNoMoreInteractions(tracer);
   }
 
   @Test
@@ -236,14 +240,14 @@ public abstract class AbstractRetryingExecutorTest {
     assertFutureFail(future, RuntimeException.class);
     assertEquals(4, future.getAttemptSettings().getAttemptCount());
 
-    Mockito.verify(tracer, Mockito.times(5)).attemptStarted(Mockito.anyInt());
+    verify(tracer, times(5)).attemptStarted(anyInt());
     // Pre-apocalypse failures
-    Mockito.verify(tracer, Mockito.times(4))
-        .attemptFailed(Mockito.any(Throwable.class), Mockito.any(Duration.class));
+    verify(tracer, times(4))
+        .attemptFailed(any(Throwable.class), any(Duration.class));
     // Apocalypse failure
-    Mockito.verify(tracer, Mockito.times(1))
-        .attemptPermanentFailure(Mockito.any(RuntimeException.class));
-    Mockito.verifyNoMoreInteractions(tracer);
+    verify(tracer, times(1))
+        .attemptPermanentFailure(any(RuntimeException.class));
+    verifyNoMoreInteractions(tracer);
   }
 
   @Test
@@ -268,10 +272,10 @@ public abstract class AbstractRetryingExecutorTest {
     assertFutureFail(future, PollException.class);
     assertTrue(future.getAttemptSettings().getAttemptCount() < 4);
 
-    Mockito.verify(tracer, Mockito.times(1)).attemptStarted(Mockito.anyInt());
-    Mockito.verify(tracer, Mockito.times(1))
-        .attemptPermanentFailure(Mockito.any(PollException.class));
-    Mockito.verifyNoMoreInteractions(tracer);
+    verify(tracer, times(1)).attemptStarted(anyInt());
+    verify(tracer, times(1))
+        .attemptPermanentFailure(any(PollException.class));
+    verifyNoMoreInteractions(tracer);
   }
 
   protected static class TestResultRetryAlgorithm<ResponseT>

--- a/gax/src/test/java/com/google/api/gax/retrying/AbstractRetryingExecutorTest.java
+++ b/gax/src/test/java/com/google/api/gax/retrying/AbstractRetryingExecutorTest.java
@@ -82,7 +82,7 @@ public abstract class AbstractRetryingExecutorTest {
 
   @Test
   public void testSuccess() throws Exception {
-    FailingCallable callable = new FailingCallable(tracer, 0, "SUCCESS");
+    FailingCallable callable = new FailingCallable(0, "SUCCESS", tracer);
     RetryingExecutorWithContext<String> executor =
         getExecutor(getAlgorithm(FAST_RETRY_SETTINGS, 0, null));
     RetryingFuture<String> future = executor.createFuture(callable, retryingContext);
@@ -98,7 +98,7 @@ public abstract class AbstractRetryingExecutorTest {
 
   @Test
   public void testSuccessWithFailures() throws Exception {
-    FailingCallable callable = new FailingCallable(tracer, 5, "SUCCESS");
+    FailingCallable callable = new FailingCallable(5, "SUCCESS", tracer);
     RetryingExecutorWithContext<String> executor =
         getExecutor(getAlgorithm(FAST_RETRY_SETTINGS, 0, null));
     RetryingFuture<String> future = executor.createFuture(callable, retryingContext);
@@ -116,7 +116,7 @@ public abstract class AbstractRetryingExecutorTest {
 
   @Test
   public void testSuccessWithFailuresPeekGetAttempt() throws Exception {
-    FailingCallable callable = new FailingCallable(tracer, 5, "SUCCESS");
+    FailingCallable callable = new FailingCallable(5, "SUCCESS", tracer);
     RetryingExecutorWithContext<String> executor =
         getExecutor(getAlgorithm(FAST_RETRY_SETTINGS, 0, null));
     RetryingFuture<String> future = executor.createFuture(callable, retryingContext);
@@ -142,7 +142,7 @@ public abstract class AbstractRetryingExecutorTest {
 
   @Test
   public void testMaxRetriesExceeded() throws Exception {
-    FailingCallable callable = new FailingCallable(tracer, 6, "FAILURE");
+    FailingCallable callable = new FailingCallable(6, "FAILURE", tracer);
     RetryingExecutorWithContext<String> executor =
         getExecutor(getAlgorithm(FAST_RETRY_SETTINGS, 0, null));
     RetryingFuture<String> future = executor.createFuture(callable, retryingContext);
@@ -169,7 +169,7 @@ public abstract class AbstractRetryingExecutorTest {
             .build();
     RetryingExecutorWithContext<String> executor =
         getExecutor(getAlgorithm(retrySettings, 0, null));
-    FailingCallable callable = new FailingCallable(tracer, 6, "FAILURE");
+    FailingCallable callable = new FailingCallable(6, "FAILURE", tracer);
     RetryingFuture<String> future = executor.createFuture(callable, retryingContext);
     future.setAttemptFuture(executor.submit(future));
 
@@ -184,7 +184,7 @@ public abstract class AbstractRetryingExecutorTest {
 
   @Test
   public void testCancelOuterFutureBeforeStart() throws Exception {
-    FailingCallable callable = new FailingCallable(tracer, 4, "SUCCESS");
+    FailingCallable callable = new FailingCallable(4, "SUCCESS", tracer);
 
     RetrySettings retrySettings =
         FAST_RETRY_SETTINGS
@@ -210,7 +210,7 @@ public abstract class AbstractRetryingExecutorTest {
 
   @Test
   public void testCancelByRetryingAlgorithm() throws Exception {
-    FailingCallable callable = new FailingCallable(tracer, 6, "FAILURE");
+    FailingCallable callable = new FailingCallable(6, "FAILURE", tracer);
     RetryingExecutorWithContext<String> executor =
         getExecutor(getAlgorithm(FAST_RETRY_SETTINGS, 5, new CancellationException()));
     RetryingFuture<String> future = executor.createFuture(callable, retryingContext);
@@ -231,7 +231,7 @@ public abstract class AbstractRetryingExecutorTest {
 
   @Test
   public void testUnexpectedExceptionFromRetryAlgorithm() throws Exception {
-    FailingCallable callable = new FailingCallable(tracer, 6, "FAILURE");
+    FailingCallable callable = new FailingCallable(6, "FAILURE", tracer);
     RetryingExecutorWithContext<String> executor =
         getExecutor(getAlgorithm(FAST_RETRY_SETTINGS, 5, new RuntimeException()));
     RetryingFuture<String> future = executor.createFuture(callable, retryingContext);
@@ -265,7 +265,7 @@ public abstract class AbstractRetryingExecutorTest {
             new ExponentialPollAlgorithm(retrySettings, NanoClock.getDefaultClock()));
 
     RetryingExecutorWithContext<String> executor = getExecutor(retryAlgorithm);
-    FailingCallable callable = new FailingCallable(tracer, 6, "FAILURE");
+    FailingCallable callable = new FailingCallable(6, "FAILURE", tracer);
     RetryingFuture<String> future = executor.createFuture(callable, retryingContext);
     future.setAttemptFuture(executor.submit(future));
 

--- a/gax/src/test/java/com/google/api/gax/retrying/AbstractRetryingExecutorTest.java
+++ b/gax/src/test/java/com/google/api/gax/retrying/AbstractRetryingExecutorTest.java
@@ -108,8 +108,7 @@ public abstract class AbstractRetryingExecutorTest {
     assertEquals(5, future.getAttemptSettings().getAttemptCount());
 
     verify(tracer, times(6)).attemptStarted(anyInt());
-    verify(tracer, times(5))
-        .attemptFailed(any(Throwable.class), any(Duration.class));
+    verify(tracer, times(5)).attemptFailed(any(Throwable.class), any(Duration.class));
     verify(tracer, times(1)).attemptSucceeded();
     verifyNoMoreInteractions(tracer);
   }
@@ -152,10 +151,8 @@ public abstract class AbstractRetryingExecutorTest {
     assertEquals(5, future.getAttemptSettings().getAttemptCount());
 
     verify(tracer, times(6)).attemptStarted(anyInt());
-    verify(tracer, times(5))
-        .attemptFailed(any(Throwable.class), any(Duration.class));
-    verify(tracer, times(1))
-        .attemptFailedRetriesExhausted(any(Throwable.class));
+    verify(tracer, times(5)).attemptFailed(any(Throwable.class), any(Duration.class));
+    verify(tracer, times(1)).attemptFailedRetriesExhausted(any(Throwable.class));
     verifyNoMoreInteractions(tracer);
   }
 
@@ -177,8 +174,7 @@ public abstract class AbstractRetryingExecutorTest {
     assertTrue(future.getAttemptSettings().getAttemptCount() < 4);
 
     verify(tracer, times(1)).attemptStarted(anyInt());
-    verify(tracer, times(1))
-        .attemptFailedRetriesExhausted(any(Throwable.class));
+    verify(tracer, times(1)).attemptFailedRetriesExhausted(any(Throwable.class));
     verifyNoMoreInteractions(tracer);
   }
 
@@ -221,11 +217,9 @@ public abstract class AbstractRetryingExecutorTest {
 
     verify(tracer, times(5)).attemptStarted(anyInt());
     // Pre-apocalypse failures
-    verify(tracer, times(4))
-        .attemptFailed(any(Throwable.class), any(Duration.class));
+    verify(tracer, times(4)).attemptFailed(any(Throwable.class), any(Duration.class));
     // Apocalypse failure
-    verify(tracer, times(1))
-        .attemptFailedRetriesExhausted(any(CancellationException.class));
+    verify(tracer, times(1)).attemptFailedRetriesExhausted(any(CancellationException.class));
     verifyNoMoreInteractions(tracer);
   }
 
@@ -242,11 +236,9 @@ public abstract class AbstractRetryingExecutorTest {
 
     verify(tracer, times(5)).attemptStarted(anyInt());
     // Pre-apocalypse failures
-    verify(tracer, times(4))
-        .attemptFailed(any(Throwable.class), any(Duration.class));
+    verify(tracer, times(4)).attemptFailed(any(Throwable.class), any(Duration.class));
     // Apocalypse failure
-    verify(tracer, times(1))
-        .attemptPermanentFailure(any(RuntimeException.class));
+    verify(tracer, times(1)).attemptPermanentFailure(any(RuntimeException.class));
     verifyNoMoreInteractions(tracer);
   }
 
@@ -273,8 +265,7 @@ public abstract class AbstractRetryingExecutorTest {
     assertTrue(future.getAttemptSettings().getAttemptCount() < 4);
 
     verify(tracer, times(1)).attemptStarted(anyInt());
-    verify(tracer, times(1))
-        .attemptPermanentFailure(any(PollException.class));
+    verify(tracer, times(1)).attemptPermanentFailure(any(PollException.class));
     verifyNoMoreInteractions(tracer);
   }
 

--- a/gax/src/test/java/com/google/api/gax/retrying/FailingCallable.java
+++ b/gax/src/test/java/com/google/api/gax/retrying/FailingCallable.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.retrying;
 
+import com.google.api.gax.tracing.ApiTracer;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.threeten.bp.Duration;
@@ -48,19 +49,26 @@ class FailingCallable implements Callable<String> {
           .build();
 
   private AtomicInteger attemptsCount = new AtomicInteger(0);
+  private final ApiTracer tracer;
   private final int expectedFailuresCount;
   private final String result;
 
-  FailingCallable(int expectedFailuresCount, String result) {
+  FailingCallable(ApiTracer tracer, int expectedFailuresCount, String result) {
+    this.tracer = tracer;
     this.expectedFailuresCount = expectedFailuresCount;
     this.result = result;
   }
 
   @Override
   public String call() throws Exception {
-    if (attemptsCount.getAndIncrement() < expectedFailuresCount) {
+    int attemptNumber = attemptsCount.getAndIncrement();
+
+    tracer.attemptStarted(attemptNumber);
+
+    if (attemptNumber < expectedFailuresCount) {
       throw new CustomException();
     }
+
     return result;
   }
 

--- a/gax/src/test/java/com/google/api/gax/retrying/FailingCallable.java
+++ b/gax/src/test/java/com/google/api/gax/retrying/FailingCallable.java
@@ -53,7 +53,7 @@ class FailingCallable implements Callable<String> {
   private final int expectedFailuresCount;
   private final String result;
 
-  FailingCallable(ApiTracer tracer, int expectedFailuresCount, String result) {
+  FailingCallable(int expectedFailuresCount, String result, ApiTracer tracer) {
     this.tracer = tracer;
     this.expectedFailuresCount = expectedFailuresCount;
     this.result = result;

--- a/gax/src/test/java/com/google/api/gax/retrying/ScheduledRetryingExecutorTest.java
+++ b/gax/src/test/java/com/google/api/gax/retrying/ScheduledRetryingExecutorTest.java
@@ -90,7 +90,7 @@ public class ScheduledRetryingExecutorTest extends AbstractRetryingExecutorTest 
       final int maxRetries = 100;
 
       ScheduledExecutorService localExecutor = Executors.newSingleThreadScheduledExecutor();
-      FailingCallable callable = new FailingCallable(tracer, 15, "SUCCESS");
+      FailingCallable callable = new FailingCallable(15, "SUCCESS", tracer);
 
       RetrySettings retrySettings =
           FAST_RETRY_SETTINGS
@@ -140,7 +140,7 @@ public class ScheduledRetryingExecutorTest extends AbstractRetryingExecutorTest 
       final int maxRetries = 100;
 
       ScheduledExecutorService localExecutor = Executors.newSingleThreadScheduledExecutor();
-      FailingCallable callable = new FailingCallable(tracer, 15, "SUCCESS");
+      FailingCallable callable = new FailingCallable(15, "SUCCESS", tracer);
       RetrySettings retrySettings =
           FAST_RETRY_SETTINGS
               .toBuilder()
@@ -192,7 +192,7 @@ public class ScheduledRetryingExecutorTest extends AbstractRetryingExecutorTest 
       ScheduledExecutorService localExecutor = Executors.newSingleThreadScheduledExecutor();
       final int maxRetries = 100;
 
-      FailingCallable callable = new FailingCallable(tracer, maxRetries - 1, "SUCCESS");
+      FailingCallable callable = new FailingCallable(maxRetries - 1, "SUCCESS", tracer);
       RetrySettings retrySettings =
           FAST_RETRY_SETTINGS
               .toBuilder()
@@ -248,7 +248,7 @@ public class ScheduledRetryingExecutorTest extends AbstractRetryingExecutorTest 
   public void testCancelOuterFutureAfterStart() throws Exception {
     for (int executionsCount = 0; executionsCount < EXECUTIONS_COUNT; executionsCount++) {
       ScheduledExecutorService localExecutor = Executors.newSingleThreadScheduledExecutor();
-      FailingCallable callable = new FailingCallable(tracer, 4, "SUCCESS");
+      FailingCallable callable = new FailingCallable(4, "SUCCESS", tracer);
       RetrySettings retrySettings =
           FAST_RETRY_SETTINGS
               .toBuilder()
@@ -274,7 +274,7 @@ public class ScheduledRetryingExecutorTest extends AbstractRetryingExecutorTest 
   @Test
   public void testCancelIsTraced() throws Exception {
     ScheduledExecutorService localExecutor = Executors.newSingleThreadScheduledExecutor();
-    FailingCallable callable = new FailingCallable(tracer, 4, "SUCCESS");
+    FailingCallable callable = new FailingCallable(4, "SUCCESS", tracer);
     RetrySettings retrySettings =
         FAST_RETRY_SETTINGS
             .toBuilder()
@@ -302,7 +302,7 @@ public class ScheduledRetryingExecutorTest extends AbstractRetryingExecutorTest 
     // this is a heavy test, which takes a lot of time, so only few executions.
     for (int executionsCount = 0; executionsCount < 2; executionsCount++) {
       ScheduledExecutorService localExecutor = Executors.newSingleThreadScheduledExecutor();
-      FailingCallable callable = new FailingCallable(tracer, 5, "SUCCESS");
+      FailingCallable callable = new FailingCallable(5, "SUCCESS", tracer);
       RetrySettings retrySettings =
           FAST_RETRY_SETTINGS
               .toBuilder()

--- a/gax/src/test/java/com/google/api/gax/retrying/ScheduledRetryingExecutorTest.java
+++ b/gax/src/test/java/com/google/api/gax/retrying/ScheduledRetryingExecutorTest.java
@@ -89,7 +89,7 @@ public class ScheduledRetryingExecutorTest extends AbstractRetryingExecutorTest 
       final int maxRetries = 100;
 
       ScheduledExecutorService localExecutor = Executors.newSingleThreadScheduledExecutor();
-      FailingCallable callable = new FailingCallable(15, "SUCCESS");
+      FailingCallable callable = new FailingCallable(tracer, 15, "SUCCESS");
 
       RetrySettings retrySettings =
           FAST_RETRY_SETTINGS
@@ -139,7 +139,7 @@ public class ScheduledRetryingExecutorTest extends AbstractRetryingExecutorTest 
       final int maxRetries = 100;
 
       ScheduledExecutorService localExecutor = Executors.newSingleThreadScheduledExecutor();
-      FailingCallable callable = new FailingCallable(15, "SUCCESS");
+      FailingCallable callable = new FailingCallable(tracer, 15, "SUCCESS");
       RetrySettings retrySettings =
           FAST_RETRY_SETTINGS
               .toBuilder()
@@ -191,7 +191,7 @@ public class ScheduledRetryingExecutorTest extends AbstractRetryingExecutorTest 
       ScheduledExecutorService localExecutor = Executors.newSingleThreadScheduledExecutor();
       final int maxRetries = 100;
 
-      FailingCallable callable = new FailingCallable(maxRetries - 1, "SUCCESS");
+      FailingCallable callable = new FailingCallable(tracer, maxRetries - 1, "SUCCESS");
       RetrySettings retrySettings =
           FAST_RETRY_SETTINGS
               .toBuilder()
@@ -247,7 +247,7 @@ public class ScheduledRetryingExecutorTest extends AbstractRetryingExecutorTest 
   public void testCancelOuterFutureAfterStart() throws Exception {
     for (int executionsCount = 0; executionsCount < EXECUTIONS_COUNT; executionsCount++) {
       ScheduledExecutorService localExecutor = Executors.newSingleThreadScheduledExecutor();
-      FailingCallable callable = new FailingCallable(4, "SUCCESS");
+      FailingCallable callable = new FailingCallable(tracer, 4, "SUCCESS");
       RetrySettings retrySettings =
           FAST_RETRY_SETTINGS
               .toBuilder()
@@ -275,7 +275,7 @@ public class ScheduledRetryingExecutorTest extends AbstractRetryingExecutorTest 
     // this is a heavy test, which takes a lot of time, so only few executions.
     for (int executionsCount = 0; executionsCount < 2; executionsCount++) {
       ScheduledExecutorService localExecutor = Executors.newSingleThreadScheduledExecutor();
-      FailingCallable callable = new FailingCallable(5, "SUCCESS");
+      FailingCallable callable = new FailingCallable(tracer, 5, "SUCCESS");
       RetrySettings retrySettings =
           FAST_RETRY_SETTINGS
               .toBuilder()

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
@@ -35,6 +35,7 @@ import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.api.gax.rpc.internal.Headers;
 import com.google.api.gax.tracing.ApiTracer;
+import com.google.api.gax.tracing.NoopApiTracer;
 import com.google.auth.Credentials;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -276,6 +277,9 @@ public class FakeCallContext implements ApiCallContext {
   @Override
   @Nonnull
   public ApiTracer getTracer() {
+    if (tracer == null) {
+      return NoopApiTracer.getInstance();
+    }
     return tracer;
   }
 


### PR DESCRIPTION
This instruments the retry logic to notify the tracer of the retry lifecycle. It also fixed a bug in the ApiTracer interface that prevented exhausted retries from passing the error.
