### PR TITLE
Always add Content-Length header

### DIFF
--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStatusCode.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStatusCode.java
@@ -80,6 +80,10 @@ public class HttpJsonStatusCode implements StatusCode {
         } else {
           return Code.ABORTED;
         }
+      case 411:
+        throw new IllegalStateException(
+            "411 status code received (Content-Length header not given.) Please file a bug against https://github.com/googleapis/gax-java/\n"
+                + httpStatus);
       case 429:
         return Code.RESOURCE_EXHAUSTED;
       case 499:

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ApiMessageHttpRequestTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ApiMessageHttpRequestTest.java
@@ -143,9 +143,6 @@ public class ApiMessageHttpRequestTest {
     HttpRequest httpRequest = httpRequestRunnable.createHttpRequest();
     String expectedUrl = ENDPOINT + "name/tree_frog" + "?requestId=request57";
     Truth.assertThat(httpRequest.getUrl().toString()).isEqualTo(expectedUrl);
-    Truth.assertThat(httpRequest.getHeaders().getContentLength())
-        .isEqualTo(httpRequest.getContent().getLength());
-    Truth.assertThat(httpRequest.getHeaders().getContentLength()).isGreaterThan((long) 0);
 
     OutputStream outputStream = new PrintableOutputStream();
     httpRequest.getContent().writeTo(outputStream);

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ApiMessageHttpRequestTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ApiMessageHttpRequestTest.java
@@ -143,6 +143,9 @@ public class ApiMessageHttpRequestTest {
     HttpRequest httpRequest = httpRequestRunnable.createHttpRequest();
     String expectedUrl = ENDPOINT + "name/tree_frog" + "?requestId=request57";
     Truth.assertThat(httpRequest.getUrl().toString()).isEqualTo(expectedUrl);
+    Truth.assertThat(httpRequest.getHeaders().getContentLength())
+        .isEqualTo(httpRequest.getContent().getLength());
+    Truth.assertThat(httpRequest.getHeaders().getContentLength()).isGreaterThan((long) 0);
 
     OutputStream outputStream = new PrintableOutputStream();
     httpRequest.getContent().writeTo(outputStream);

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpRequestRunnableTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpRequestRunnableTest.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.httpjson;
 
+import com.google.api.client.http.EmptyContent;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.testing.http.MockHttpTransport;
@@ -161,6 +162,7 @@ public class HttpRequestRunnableTest {
   @Test
   public void testRequestUrl() throws IOException {
     HttpRequest httpRequest = httpRequestRunnable.createHttpRequest();
+    Truth.assertThat(httpRequest.getContent()).isInstanceOf(EmptyContent.class);
     String expectedUrl = ENDPOINT + "name/feline" + "?food=bird&food=mouse&size=small";
     Truth.assertThat(httpRequest.getUrl().toString()).isEqualTo(expectedUrl);
   }


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-java/issues/3735 and prevents 411 HTTP error codes.