### PR TITLE
Release gax-java v1.38.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ If you are using Maven, add this to your pom.xml file
 <dependency>
   <groupId>com.google.api</groupId>
   <artifactId>gax</artifactId>
-  <version>1.37.0</version>
+  <version>1.38.0</version>
 </dependency>
 <dependency>
   <groupId>com.google.api</groupId>
   <artifactId>gax-grpc</artifactId>
-  <version>1.37.0</version>
+  <version>1.38.0</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -1,4 +1,4 @@
-project.version = "0.39.1-SNAPSHOT" // {x-version-update:benchmark:current}
+project.version = "0.40.0" // {x-version-update:benchmark:current}
 
 buildscript {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'java'
 apply plugin: 'com.github.sherter.google-java-format'
 apply plugin: 'io.codearte.nexus-staging'
 
-project.version = "1.37.1-SNAPSHOT" // {x-version-update:gax:current}
+project.version = "1.38.0" // {x-version-update:gax:current}
 
 ext {
   // When upgrading grpc, make sure to upgrade opencensusVersion to be consistent with grpc.

--- a/gax-bom/build.gradle
+++ b/gax-bom/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 archivesBaseName = "gax-bom"
 
-project.version = "1.37.1-SNAPSHOT" // {x-version-update:gax-bom:current}
+project.version = "1.38.0" // {x-version-update:gax-bom:current}
 
 ext {
   mavenJavaDir = "$project.buildDir/publications/mavenJava"

--- a/gax-bom/pom.xml
+++ b/gax-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api</groupId>
   <artifactId>gax-bom</artifactId>
-  <version>1.37.1-SNAPSHOT</version><!-- {x-version-update:gax-bom:current} -->
+  <version>1.38.0</version><!-- {x-version-update:gax-bom:current} -->
   <packaging>pom</packaging>
   <name>GAX (Google Api eXtensions) for Java</name>
   <description>Google Api eXtensions for Java</description>
@@ -33,34 +33,34 @@
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax</artifactId>
-        <version>1.37.1-SNAPSHOT</version><!-- {x-version-update:gax:current} -->
+        <version>1.38.0</version><!-- {x-version-update:gax:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax</artifactId>
-        <version>1.37.1-SNAPSHOT</version><!-- {x-version-update:gax:current} -->
+        <version>1.38.0</version><!-- {x-version-update:gax:current} -->
 	<classifier>testlib</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-grpc</artifactId>
-        <version>1.37.1-SNAPSHOT</version><!-- {x-version-update:gax-grpc:current} -->
+        <version>1.38.0</version><!-- {x-version-update:gax-grpc:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-grpc</artifactId>
-        <version>1.37.1-SNAPSHOT</version><!-- {x-version-update:gax-grpc:current} -->
+        <version>1.38.0</version><!-- {x-version-update:gax-grpc:current} -->
 	<classifier>testlib</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-httpjson</artifactId>
-        <version>0.54.1-SNAPSHOT</version><!-- {x-version-update:gax-httpjson:current} -->
+        <version>0.55.0</version><!-- {x-version-update:gax-httpjson:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-httpjson</artifactId>
-        <version>0.54.1-SNAPSHOT</version><!-- {x-version-update:gax-httpjson:current} -->
+        <version>0.55.0</version><!-- {x-version-update:gax-httpjson:current} -->
 	<classifier>testlib</classifier>
       </dependency>
     </dependencies>

--- a/gax-grpc/build.gradle
+++ b/gax-grpc/build.gradle
@@ -1,7 +1,7 @@
 
 archivesBaseName = "gax-grpc"
 
-project.version = "1.37.1-SNAPSHOT" // {x-version-update:gax-grpc:current}
+project.version = "1.38.0" // {x-version-update:gax-grpc:current}
 
 dependencies {
   compile project(':gax'),

--- a/gax-httpjson/build.gradle
+++ b/gax-httpjson/build.gradle
@@ -1,7 +1,7 @@
 
 archivesBaseName = "gax-httpjson"
 
-project.version = "0.54.1-SNAPSHOT" // {x-version-update:gax-httpjson:current}
+project.version = "0.55.0" // {x-version-update:gax-httpjson:current}
 
 dependencies {
   compile project(':gax'),

--- a/gax/build.gradle
+++ b/gax/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 archivesBaseName = "gax"
 
-project.version = "1.37.1-SNAPSHOT" // {x-version-update:gax:current}
+project.version = "1.38.0" // {x-version-update:gax:current}
 
 dependencies {
   compile libraries.guava,

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -14,13 +14,13 @@
       <groupId>com.google.api</groupId>
       <artifactId>gax</artifactId>
       <!-- WARNING this is automatically populated by a build script, don't update manually -->
-      <version>1.37.1-SNAPSHOT</version><!-- {x-version-update:gax:current} -->
+      <version>1.38.0</version><!-- {x-version-update:gax:current} -->
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
       <!-- WARNING this is automatically populated by a build script, don't update manually -->
-      <version>1.37.1-SNAPSHOT</version><!-- {x-version-update:gax-grpc:current} -->
+      <version>1.38.0</version><!-- {x-version-update:gax-grpc:current} -->
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>

--- a/versions.txt
+++ b/versions.txt
@@ -1,8 +1,8 @@
 # Format:
 # module:released-version:current-version
 
-gax:1.37.0:1.37.1-SNAPSHOT
-gax-bom:1.37.0:1.37.1-SNAPSHOT
-gax-grpc:1.37.0:1.37.1-SNAPSHOT
-gax-httpjson:0.54.0:0.54.1-SNAPSHOT
-benchmark:0.39.0:0.39.1-SNAPSHOT
+gax:1.38.0:1.38.0
+gax-bom:1.38.0:1.38.0
+gax-grpc:1.38.0:1.38.0
+gax-httpjson:0.55.0:0.55.0
+benchmark:0.40.0:0.40.0


### PR DESCRIPTION
This pull request was generated using releasetool.

01-31-2019 11:23 PST

- Always add Content-Length header ([#648](https://github.com/googleapis/gax-java/pull/648))
- Opencensus Tracing: Implement ApiTracer using opencensus api ([#641](https://github.com/googleapis/gax-java/pull/641))
- Use GoogleDefaultChannelBuilder ([#627](https://github.com/googleapis/gax-java/pull/627))
- @AutoValue HttpRequestRunnable  ([#509](https://github.com/googleapis/gax-java/pull/509))
- Opencensus Tracing: Add annotations for retries ([#640](https://github.com/googleapis/gax-java/pull/640))
- Bump next snapshot ([#647](https://github.com/googleapis/gax-java/pull/647))

### Implementation Changes

### New Features

### Dependencies

### Documentation

### Internal / Testing Changes