### PR TITLE
Opencensus Tracing: Start tracing BatchingCallables

### DIFF
--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
@@ -46,7 +46,7 @@ public interface ApiTracerFactory {
   ApiTracer newTracer(SpanName spanName);
 
   /**
-   * Create a new {@link ApiTracer } that will ignore the current context and start a new toplevel
+   * Create a new {@link ApiTracer} that will ignore the current context and start a new toplevel
    * trace.
    */
   ApiTracer newRootTracer(SpanName spanName);

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
@@ -41,5 +41,13 @@ import com.google.api.core.InternalExtensionOnly;
 @BetaApi("Surface for tracing is not yet stable")
 @InternalExtensionOnly
 public interface ApiTracerFactory {
+
+  /** Create a new {@link ApiTracer} that will be a child of the current context. */
   ApiTracer newTracer(SpanName spanName);
+
+  /**
+   * Create a new {@link ApiTracer } that will ignore the current context and start a new toplevel
+   * trace.
+   */
+  ApiTracer newRootTracer(SpanName spanName);
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
@@ -51,4 +51,9 @@ public final class NoopApiTracerFactory implements ApiTracerFactory {
   public ApiTracer newTracer(SpanName spanName) {
     return NoopApiTracer.getInstance();
   }
+
+  @Override
+  public ApiTracer newRootTracer(SpanName spanName) {
+    return NoopApiTracer.getInstance();
+  }
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracerFactory.java
@@ -32,6 +32,7 @@ package com.google.api.gax.tracing;
 import com.google.api.core.InternalApi;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import io.opencensus.trace.BlankSpan;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
@@ -93,6 +94,20 @@ public final class OpencensusTracerFactory implements ApiTracerFactory {
       spanName = spanName.withClientName(clientNameOverride);
     }
     Span span = internalTracer.spanBuilder(spanName.toString()).setRecordEvents(true).startSpan();
+
+    return new OpencensusTracer(internalTracer, span);
+  }
+
+  @Override
+  public ApiTracer newRootTracer(SpanName spanName) {
+    if (clientNameOverride != null) {
+      spanName = spanName.withClientName(clientNameOverride);
+    }
+    Span span =
+        internalTracer
+            .spanBuilderWithExplicitParent(spanName.toString(), BlankSpan.INSTANCE)
+            .setRecordEvents(true)
+            .startSpan();
 
     return new OpencensusTracer(internalTracer, span);
   }

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedBatchingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedBatchingCallable.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.BatchingDescriptor;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.util.concurrent.MoreExecutors;
+
+/**
+ * This callable wraps a batching callable chain in a {@link ApiTracer}.
+ *
+ * <p>For internal use only.
+ */
+@BetaApi("The surface for tracing is not stable and might change in the future")
+@InternalApi("For internal use by google-cloud-java clients only")
+public class TracedBatchingCallable<RequestT, ResponseT>
+    extends UnaryCallable<RequestT, ResponseT> {
+  private final ApiTracerFactory tracerFactory;
+  private final SpanName spanName;
+  private final BatchingDescriptor<RequestT, ResponseT> batchingDescriptor;
+  private final UnaryCallable<RequestT, ResponseT> innerCallable;
+
+  public TracedBatchingCallable(
+      UnaryCallable<RequestT, ResponseT> innerCallable,
+      ApiTracerFactory tracerFactory,
+      SpanName spanName,
+      BatchingDescriptor<RequestT, ResponseT> batchingDescriptor) {
+    this.tracerFactory = tracerFactory;
+    this.spanName = spanName;
+    this.batchingDescriptor = batchingDescriptor;
+    this.innerCallable = innerCallable;
+  }
+
+  @Override
+  public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext context) {
+    // NOTE: This will be invoked asynchronously outside of the original caller's thread.
+    // So this start a top level tracer.
+    ApiTracer tracer = tracerFactory.newRootTracer(spanName);
+    TraceFinisher<ResponseT> finisher = new TraceFinisher<>(tracer);
+
+    try {
+      long elementCount = batchingDescriptor.countElements(request);
+      long requestSize = batchingDescriptor.countBytes(request);
+
+      tracer.batchRequestSent(elementCount, requestSize);
+
+      context = context.withTracer(tracer);
+      ApiFuture<ResponseT> future = innerCallable.futureCall(request, context);
+      ApiFutures.addCallback(future, finisher, MoreExecutors.directExecutor());
+
+      return future;
+    } catch (RuntimeException e) {
+      finisher.onFailure(e);
+      throw e;
+    }
+  }
+}

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedBatchingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedBatchingCallableTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.api.gax.tracing;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.BatchingDescriptor;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.gax.rpc.testing.FakeCallContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+
+public class TracedBatchingCallableTest {
+  private static final SpanName SPAN_NAME = SpanName.of("FakeClient", "FakeRpc");
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  @Mock private ApiTracerFactory tracerFactory;
+  @Mock private ApiTracer tracer;
+  @Mock private BatchingDescriptor<String, String> batchingDescriptor;
+  @Mock private UnaryCallable<String, String> innerCallable;
+  private SettableApiFuture<String> innerResult;
+
+  private TracedBatchingCallable<String, String> tracedBatchingCallable;
+  private FakeCallContext callContext;
+
+  @Before
+  public void setUp() {
+    // Wire the mock tracer factory
+    when(tracerFactory.newRootTracer(any(SpanName.class))).thenReturn(tracer);
+
+    // Wire the mock inner callable
+    // This is a very hacky mock, the actual batching infrastructure is completely omitted here.
+    innerResult = SettableApiFuture.create();
+    when(innerCallable.futureCall(anyString(), any(ApiCallContext.class))).thenReturn(innerResult);
+
+    // Build the system under test
+    tracedBatchingCallable =
+        new TracedBatchingCallable<>(innerCallable, tracerFactory, SPAN_NAME, batchingDescriptor);
+    callContext = FakeCallContext.createDefault();
+  }
+
+  @Test
+  public void testRootTracerCreated() {
+    tracedBatchingCallable.futureCall("test", callContext);
+    verify(tracerFactory, times(1)).newRootTracer(SPAN_NAME);
+  }
+
+  @Test
+  public void testBatchAttributesStamped() {
+    when(batchingDescriptor.countElements(anyString())).thenReturn(10L);
+    when(batchingDescriptor.countBytes(anyString())).thenReturn(20L);
+
+    tracedBatchingCallable.futureCall("test", callContext);
+    verify(tracer).batchRequestSent(10, 20);
+  }
+
+  @Test
+  public void testOperationFinish() {
+    innerResult.set("successful result");
+    tracedBatchingCallable.futureCall("test", callContext);
+
+    verify(tracer, times(1)).operationSucceeded();
+  }
+
+  @Test
+  public void testOperationFailed() {
+    RuntimeException fakeError = new RuntimeException("fake error");
+    innerResult.setException(fakeError);
+    tracedBatchingCallable.futureCall("test", callContext);
+
+    verify(tracer, times(1)).operationFailed(fakeError);
+  }
+
+  @Test
+  public void testSyncError() {
+    RuntimeException fakeError = new RuntimeException("fake error");
+
+    // Reset the irrelevant expectations from setup. (only needed to silence the warnings).
+    @SuppressWarnings("unchecked")
+    UnaryCallable<String, String>[] innerCallableWrapper = new UnaryCallable[] {innerCallable};
+    reset(innerCallableWrapper);
+
+    when(innerCallable.futureCall(eq("failing test"), any(ApiCallContext.class)))
+        .thenThrow(fakeError);
+
+    try {
+      tracedBatchingCallable.futureCall("failing test", callContext);
+    } catch (RuntimeException e) {
+      // ignored
+    }
+
+    verify(tracer, times(1)).operationFailed(fakeError);
+  }
+}


### PR DESCRIPTION
This only traces the batched request. It doesn't take into account the traces of the individual element calls. The traces will be top level and ignore the caller's span. 

In the future, I'm hoping to add span links for the parent traces. 