### PR TITLE
Opencensus Tracing: fix nested traces + ApiTracer types

### DIFF
--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
@@ -29,8 +29,7 @@
  */
 package com.google.api.gax.tracing;
 
-import com.google.api.core.BetaApi;
-import com.google.api.core.InternalExtensionOnly;
+import com.google.api.core.InternalApi;
 import org.threeten.bp.Duration;
 
 /**
@@ -39,10 +38,21 @@ import org.threeten.bp.Duration;
  * <p>A single instance of a tracer represents a logical operation that can be annotated throughout
  * its lifecycle. Constructing an instance of a subclass will implicitly signal the start of a new
  * operation.
+ *
+ * <p>For internal use only.
  */
-@BetaApi("Surface for tracing is not yet stable")
-@InternalExtensionOnly
+@InternalApi("For internal use by google-cloud-java clients only")
 public interface ApiTracer {
+  /** The type of operation the {@link ApiTracer} is tracing. */
+  enum Type {
+    Unary,
+    Batching,
+    LongRunning,
+    ServerStreaming,
+    ClientStreaming,
+    BidiStreaming
+  }
+
   /**
    * Asks the underlying implementation to install itself as a thread local. This allows for interop
    * between clients using gax and external resources to share the same implementation of the

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
@@ -43,15 +43,6 @@ import org.threeten.bp.Duration;
  */
 @InternalApi("For internal use by google-cloud-java clients only")
 public interface ApiTracer {
-  /** The type of operation the {@link ApiTracer} is tracing. */
-  enum Type {
-    Unary,
-    Batching,
-    LongRunning,
-    ServerStreaming,
-    ClientStreaming,
-    BidiStreaming
-  }
 
   /**
    * Asks the underlying implementation to install itself as a thread local. This allows for interop

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
@@ -43,7 +43,7 @@ import com.google.api.core.InternalExtensionOnly;
 public interface ApiTracerFactory {
 
   /** Create a new {@link ApiTracer} that will be a child of the current context. */
-  ApiTracer newTracer(SpanName spanName);
+  ApiTracer newTracer(ApiTracer parent, SpanName spanName);
 
   /**
    * Create a new {@link ApiTracer} that will ignore the current context and start a new toplevel

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
@@ -29,7 +29,7 @@
  */
 package com.google.api.gax.tracing;
 
-import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
 import com.google.api.core.InternalExtensionOnly;
 
 /**
@@ -37,16 +37,28 @@ import com.google.api.core.InternalExtensionOnly;
  *
  * <p>In general a single instance of an {@link ApiTracer} will correspond to a single logical
  * operation.
+ *
+ * <p>For internal use only.
  */
-@BetaApi("Surface for tracing is not yet stable")
+@InternalApi("For internal use by google-cloud-java clients only")
 @InternalExtensionOnly
 public interface ApiTracerFactory {
+  /** The type of operation the {@link ApiTracer} is tracing. */
+  enum OperationType {
+    Unary,
+    Batching,
+    LongRunning,
+    ServerStreaming,
+    ClientStreaming,
+    BidiStreaming
+  }
+
   /**
    * Create a new {@link ApiTracer} that will be a child of the current context.
    *
-   * @param parent The parent of this tracer.
-   * @param spanName THe name of the new span.
-   * @param type The type of operation that the tracer will trace.
+   * @param parent the parent of this tracer
+   * @param spanName the name of the new span
+   * @param operationType the type of operation that the tracer will trace
    */
-  ApiTracer newTracer(ApiTracer parent, SpanName spanName, ApiTracer.Type type);
+  ApiTracer newTracer(ApiTracer parent, SpanName spanName, OperationType operationType);
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
@@ -41,13 +41,12 @@ import com.google.api.core.InternalExtensionOnly;
 @BetaApi("Surface for tracing is not yet stable")
 @InternalExtensionOnly
 public interface ApiTracerFactory {
-
-  /** Create a new {@link ApiTracer} that will be a child of the current context. */
-  ApiTracer newTracer(ApiTracer parent, SpanName spanName);
-
   /**
-   * Create a new {@link ApiTracer} that will ignore the current context and start a new toplevel
-   * trace.
+   * Create a new {@link ApiTracer} that will be a child of the current context.
+   *
+   * @param parent The parent of this tracer.
+   * @param spanName THe name of the new span.
+   * @param type The type of operation that the tracer will trace.
    */
-  ApiTracer newRootTracer(SpanName spanName);
+  ApiTracer newTracer(ApiTracer parent, SpanName spanName, ApiTracer.Type type);
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
@@ -48,12 +48,13 @@ public final class NoopApiTracerFactory implements ApiTracerFactory {
 
   /** {@inheritDoc} */
   @Override
-  public ApiTracer newTracer(SpanName spanName) {
+  public ApiTracer newRootTracer(SpanName spanName) {
     return NoopApiTracer.getInstance();
   }
 
+  /** {@inheritDoc} */
   @Override
-  public ApiTracer newRootTracer(SpanName spanName) {
+  public ApiTracer newTracer(ApiTracer parent, SpanName spanName) {
     return NoopApiTracer.getInstance();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
@@ -48,7 +48,7 @@ public final class NoopApiTracerFactory implements ApiTracerFactory {
 
   /** {@inheritDoc} */
   @Override
-  public ApiTracer newTracer(ApiTracer parent, SpanName spanName, ApiTracer.Type type) {
+  public ApiTracer newTracer(ApiTracer parent, SpanName spanName, OperationType operationType) {
     return NoopApiTracer.getInstance();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
@@ -48,13 +48,7 @@ public final class NoopApiTracerFactory implements ApiTracerFactory {
 
   /** {@inheritDoc} */
   @Override
-  public ApiTracer newRootTracer(SpanName spanName) {
-    return NoopApiTracer.getInstance();
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public ApiTracer newTracer(ApiTracer parent, SpanName spanName) {
+  public ApiTracer newTracer(ApiTracer parent, SpanName spanName, ApiTracer.Type type) {
     return NoopApiTracer.getInstance();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracer.java
@@ -32,6 +32,7 @@ package com.google.api.gax.tracing;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.tracing.ApiTracerFactory.OperationType;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import io.opencensus.trace.AttributeValue;
@@ -164,7 +165,7 @@ import org.threeten.bp.Duration;
 public class OpencensusTracer implements ApiTracer {
   private final Tracer tracer;
   private final Span span;
-  private final ApiTracer.Type type;
+  private final OperationType operationType;
 
   private volatile long currentAttemptId;
   private AtomicLong attemptSentMessages = new AtomicLong(0);
@@ -172,10 +173,11 @@ public class OpencensusTracer implements ApiTracer {
   private AtomicLong totalSentMessages = new AtomicLong(0);
   private long totalReceivedMessages = 0;
 
-  OpencensusTracer(@Nonnull Tracer tracer, @Nonnull Span span, @Nonnull ApiTracer.Type type) {
+  OpencensusTracer(
+      @Nonnull Tracer tracer, @Nonnull Span span, @Nonnull OperationType operationType) {
     this.tracer = Preconditions.checkNotNull(tracer, "tracer can't be null");
     this.span = Preconditions.checkNotNull(span, "span can't be null");
-    this.type = Preconditions.checkNotNull(type, "type can't be null");
+    this.operationType = Preconditions.checkNotNull(operationType, "operationType can't be null");
   }
 
   Span getSpan() {

--- a/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracer.java
@@ -164,6 +164,7 @@ import org.threeten.bp.Duration;
 public class OpencensusTracer implements ApiTracer {
   private final Tracer tracer;
   private final Span span;
+  private final ApiTracer.Type type;
 
   private volatile long currentAttemptId;
   private AtomicLong attemptSentMessages = new AtomicLong(0);
@@ -171,9 +172,10 @@ public class OpencensusTracer implements ApiTracer {
   private AtomicLong totalSentMessages = new AtomicLong(0);
   private long totalReceivedMessages = 0;
 
-  OpencensusTracer(@Nonnull Tracer tracer, @Nonnull Span span) {
+  OpencensusTracer(@Nonnull Tracer tracer, @Nonnull Span span, @Nonnull ApiTracer.Type type) {
     this.tracer = Preconditions.checkNotNull(tracer, "tracer can't be null");
     this.span = Preconditions.checkNotNull(span, "span can't be null");
+    this.type = Preconditions.checkNotNull(type, "type can't be null");
   }
 
   Span getSpan() {

--- a/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracer.java
@@ -176,6 +176,10 @@ public class OpencensusTracer implements ApiTracer {
     this.span = Preconditions.checkNotNull(span, "span can't be null");
   }
 
+  Span getSpan() {
+    return span;
+  }
+
   /** {@inheritDoc} */
   @Override
   public Scope inScope() {

--- a/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracerFactory.java
@@ -95,7 +95,7 @@ public final class OpencensusTracerFactory implements ApiTracerFactory {
 
   /** {@inheritDoc } */
   @Override
-  public ApiTracer newTracer(ApiTracer parent, SpanName spanName, ApiTracer.Type type) {
+  public ApiTracer newTracer(ApiTracer parent, SpanName spanName, OperationType operationType) {
     // Default to the current in context span. This is used for outermost tracers that inherit
     // the caller's parent span.
     Span parentSpan = internalTracer.getCurrentSpan();
@@ -112,7 +112,7 @@ public final class OpencensusTracerFactory implements ApiTracerFactory {
             .startSpan();
     span.putAttributes(spanAttributes);
 
-    return new OpencensusTracer(internalTracer, span, type);
+    return new OpencensusTracer(internalTracer, span, operationType);
   }
 
   @Override

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedBatchingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedBatchingCallable.java
@@ -36,6 +36,7 @@ import com.google.api.core.InternalApi;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.BatchingDescriptor;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.gax.tracing.ApiTracerFactory.OperationType;
 import com.google.common.util.concurrent.MoreExecutors;
 
 /**
@@ -68,7 +69,7 @@ public class TracedBatchingCallable<RequestT, ResponseT>
     // NOTE: This will be invoked asynchronously outside of the original caller's thread.
     // So this start a top level tracer.
     ApiTracer tracer =
-        tracerFactory.newTracer(context.getTracer(), spanName, ApiTracer.Type.Batching);
+        tracerFactory.newTracer(context.getTracer(), spanName, OperationType.Batching);
     TraceFinisher<ResponseT> finisher = new TraceFinisher<>(tracer);
 
     try {

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedBatchingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedBatchingCallable.java
@@ -67,7 +67,8 @@ public class TracedBatchingCallable<RequestT, ResponseT>
   public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext context) {
     // NOTE: This will be invoked asynchronously outside of the original caller's thread.
     // So this start a top level tracer.
-    ApiTracer tracer = tracerFactory.newRootTracer(spanName);
+    ApiTracer tracer =
+        tracerFactory.newTracer(context.getTracer(), spanName, ApiTracer.Type.Batching);
     TraceFinisher<ResponseT> finisher = new TraceFinisher<>(tracer);
 
     try {

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedBidiCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedBidiCallable.java
@@ -70,7 +70,8 @@ public class TracedBidiCallable<RequestT, ResponseT>
       ClientStreamReadyObserver<RequestT> onReady,
       ApiCallContext context) {
 
-    ApiTracer tracer = tracerFactory.newTracer(context.getTracer(), spanName);
+    ApiTracer tracer =
+        tracerFactory.newTracer(context.getTracer(), spanName, ApiTracer.Type.BidiStreaming);
     context = context.withTracer(tracer);
 
     AtomicBoolean wasCancelled = new AtomicBoolean();

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedBidiCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedBidiCallable.java
@@ -36,6 +36,7 @@ import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.ClientStream;
 import com.google.api.gax.rpc.ClientStreamReadyObserver;
 import com.google.api.gax.rpc.ResponseObserver;
+import com.google.api.gax.tracing.ApiTracerFactory.OperationType;
 import com.google.common.base.Preconditions;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -71,7 +72,7 @@ public class TracedBidiCallable<RequestT, ResponseT>
       ApiCallContext context) {
 
     ApiTracer tracer =
-        tracerFactory.newTracer(context.getTracer(), spanName, ApiTracer.Type.BidiStreaming);
+        tracerFactory.newTracer(context.getTracer(), spanName, OperationType.BidiStreaming);
     context = context.withTracer(tracer);
 
     AtomicBoolean wasCancelled = new AtomicBoolean();

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedBidiCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedBidiCallable.java
@@ -70,7 +70,7 @@ public class TracedBidiCallable<RequestT, ResponseT>
       ClientStreamReadyObserver<RequestT> onReady,
       ApiCallContext context) {
 
-    ApiTracer tracer = tracerFactory.newTracer(spanName);
+    ApiTracer tracer = tracerFactory.newTracer(context.getTracer(), spanName);
     context = context.withTracer(tracer);
 
     AtomicBoolean wasCancelled = new AtomicBoolean();

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedServerStreamingCallable.java
@@ -64,7 +64,7 @@ public class TracedServerStreamingCallable<RequestT, ResponseT>
   public void call(
       RequestT request, ResponseObserver<ResponseT> responseObserver, ApiCallContext context) {
 
-    ApiTracer tracer = tracerFactory.newTracer(spanName);
+    ApiTracer tracer = tracerFactory.newTracer(context.getTracer(), spanName);
     TracedResponseObserver<ResponseT> tracedObserver =
         new TracedResponseObserver<>(tracer, responseObserver);
 

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedServerStreamingCallable.java
@@ -64,7 +64,8 @@ public class TracedServerStreamingCallable<RequestT, ResponseT>
   public void call(
       RequestT request, ResponseObserver<ResponseT> responseObserver, ApiCallContext context) {
 
-    ApiTracer tracer = tracerFactory.newTracer(context.getTracer(), spanName);
+    ApiTracer tracer =
+        tracerFactory.newTracer(context.getTracer(), spanName, ApiTracer.Type.ServerStreaming);
     TracedResponseObserver<ResponseT> tracedObserver =
         new TracedResponseObserver<>(tracer, responseObserver);
 

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedServerStreamingCallable.java
@@ -34,6 +34,7 @@ import com.google.api.core.InternalApi;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.tracing.ApiTracerFactory.OperationType;
 import com.google.common.base.Preconditions;
 import javax.annotation.Nonnull;
 
@@ -65,7 +66,7 @@ public class TracedServerStreamingCallable<RequestT, ResponseT>
       RequestT request, ResponseObserver<ResponseT> responseObserver, ApiCallContext context) {
 
     ApiTracer tracer =
-        tracerFactory.newTracer(context.getTracer(), spanName, ApiTracer.Type.ServerStreaming);
+        tracerFactory.newTracer(context.getTracer(), spanName, OperationType.ServerStreaming);
     TracedResponseObserver<ResponseT> tracedObserver =
         new TracedResponseObserver<>(tracer, responseObserver);
 

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedUnaryCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedUnaryCallable.java
@@ -67,7 +67,7 @@ public final class TracedUnaryCallable<RequestT, ResponseT>
    */
   @Override
   public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext context) {
-    ApiTracer tracer = tracerFactory.newTracer(spanName);
+    ApiTracer tracer = tracerFactory.newTracer(context.getTracer(), spanName);
     TraceFinisher<ResponseT> finisher = new TraceFinisher<>(tracer);
 
     try {

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedUnaryCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedUnaryCallable.java
@@ -35,6 +35,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.gax.tracing.ApiTracerFactory.OperationType;
 import com.google.common.util.concurrent.MoreExecutors;
 
 /**
@@ -67,7 +68,7 @@ public final class TracedUnaryCallable<RequestT, ResponseT>
    */
   @Override
   public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext context) {
-    ApiTracer tracer = tracerFactory.newTracer(context.getTracer(), spanName, ApiTracer.Type.Unary);
+    ApiTracer tracer = tracerFactory.newTracer(context.getTracer(), spanName, OperationType.Unary);
     TraceFinisher<ResponseT> finisher = new TraceFinisher<>(tracer);
 
     try {

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedUnaryCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedUnaryCallable.java
@@ -67,7 +67,7 @@ public final class TracedUnaryCallable<RequestT, ResponseT>
    */
   @Override
   public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext context) {
-    ApiTracer tracer = tracerFactory.newTracer(context.getTracer(), spanName);
+    ApiTracer tracer = tracerFactory.newTracer(context.getTracer(), spanName, ApiTracer.Type.Unary);
     TraceFinisher<ResponseT> finisher = new TraceFinisher<>(tracer);
 
     try {

--- a/gax/src/test/java/com/google/api/gax/tracing/OpencensusTracerFactoryTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/OpencensusTracerFactoryTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.api.gax.tracing.ApiTracerFactory.OperationType;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.Context;
 import io.opencensus.trace.AttributeValue;
@@ -79,7 +80,7 @@ public class OpencensusTracerFactoryTest {
         new OpencensusTracerFactory(internalTracer, ImmutableMap.<String, String>of());
 
     factory.newTracer(
-        NoopApiTracer.getInstance(), SpanName.of("FakeClient", "FakeMethod"), ApiTracer.Type.Unary);
+        NoopApiTracer.getInstance(), SpanName.of("FakeClient", "FakeMethod"), OperationType.Unary);
 
     verify(internalTracer)
         .spanBuilderWithExplicitParent(eq("FakeClient.FakeMethod"), nullable(Span.class));
@@ -98,7 +99,7 @@ public class OpencensusTracerFactoryTest {
       factory.newTracer(
           NoopApiTracer.getInstance(),
           SpanName.of("FakeClient", "FakeMethod"),
-          ApiTracer.Type.Unary);
+          OperationType.Unary);
     } finally {
       Context.current().detach(origContext);
     }
@@ -113,9 +114,9 @@ public class OpencensusTracerFactoryTest {
 
     Span parentSpan = mock(Span.class);
     OpencensusTracer parentTracer =
-        new OpencensusTracer(internalTracer, parentSpan, ApiTracer.Type.Unary);
+        new OpencensusTracer(internalTracer, parentSpan, OperationType.Unary);
 
-    factory.newTracer(parentTracer, SpanName.of("FakeClient", "FakeMethod"), ApiTracer.Type.Unary);
+    factory.newTracer(parentTracer, SpanName.of("FakeClient", "FakeMethod"), OperationType.Unary);
 
     verify(internalTracer).spanBuilderWithExplicitParent(anyString(), same(parentSpan));
   }
@@ -127,14 +128,13 @@ public class OpencensusTracerFactoryTest {
 
     Span parentSpan = mock(Span.class);
     OpencensusTracer parentTracer =
-        new OpencensusTracer(internalTracer, parentSpan, ApiTracer.Type.Unary);
+        new OpencensusTracer(internalTracer, parentSpan, OperationType.Unary);
 
     Context origContext =
         Context.current().withValue(ContextUtils.CONTEXT_SPAN_KEY, parentSpan).attach();
 
     try {
-      factory.newTracer(
-          parentTracer, SpanName.of("FakeClient", "FakeMethod"), ApiTracer.Type.Unary);
+      factory.newTracer(parentTracer, SpanName.of("FakeClient", "FakeMethod"), OperationType.Unary);
     } finally {
       Context.current().detach(origContext);
     }
@@ -148,7 +148,7 @@ public class OpencensusTracerFactoryTest {
         new OpencensusTracerFactory(internalTracer, ImmutableMap.of("gax.version", "1.2.3"));
 
     factory.newTracer(
-        NoopApiTracer.getInstance(), SpanName.of("FakeClient", "FakeMethod"), ApiTracer.Type.Unary);
+        NoopApiTracer.getInstance(), SpanName.of("FakeClient", "FakeMethod"), OperationType.Unary);
 
     verify(span, times(1))
         .putAttributes(

--- a/gax/src/test/java/com/google/api/gax/tracing/OpencensusTracerFactoryTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/OpencensusTracerFactoryTest.java
@@ -64,14 +64,14 @@ public class OpencensusTracerFactoryTest {
   @Before
   public void setUp() {
     internalTracer = new FakeTracer();
-    parentTracer = new OpencensusTracer(internalTracer, parentSpan);
+    parentTracer = new OpencensusTracer(internalTracer, parentSpan, ApiTracer.Type.Unary);
   }
 
   @Test
   public void testSpanNamePassthrough() {
     OpencensusTracerFactory factory = new OpencensusTracerFactory(internalTracer, null);
 
-    factory.newTracer(parentTracer, SpanName.of("FakeClient", "FakeMethod"));
+    factory.newTracer(parentTracer, SpanName.of("FakeClient", "FakeMethod"), ApiTracer.Type.Unary);
 
     assertThat(internalTracer.lastSpanName).isEqualTo("FakeClient.FakeMethod");
   }
@@ -85,7 +85,8 @@ public class OpencensusTracerFactoryTest {
         Context.current().withValue(ContextUtils.CONTEXT_SPAN_KEY, parentSpan).attach();
 
     try {
-      factory.newRootTracer(SpanName.of("FakeClient", "FakeMethod"));
+      factory.newTracer(
+          parentTracer, SpanName.of("FakeClient", "FakeMethod"), ApiTracer.Type.Batching);
     } finally {
       Context.current().detach(origContext);
     }
@@ -102,7 +103,10 @@ public class OpencensusTracerFactoryTest {
         Context.current().withValue(ContextUtils.CONTEXT_SPAN_KEY, parentSpan).attach();
 
     try {
-      factory.newTracer(NoopApiTracer.getInstance(), SpanName.of("FakeClient", "FakeMethod"));
+      factory.newTracer(
+          NoopApiTracer.getInstance(),
+          SpanName.of("FakeClient", "FakeMethod"),
+          ApiTracer.Type.Unary);
     } finally {
       Context.current().detach(origContext);
     }
@@ -114,7 +118,7 @@ public class OpencensusTracerFactoryTest {
   public void testExplicitChild() {
     OpencensusTracerFactory factory = new OpencensusTracerFactory(internalTracer, null);
 
-    factory.newTracer(parentTracer, SpanName.of("FakeClient", "FakeMethod"));
+    factory.newTracer(parentTracer, SpanName.of("FakeClient", "FakeMethod"), ApiTracer.Type.Unary);
 
     assertThat(internalTracer.lastParentSpan).isSameAs(parentSpan);
   }
@@ -124,7 +128,7 @@ public class OpencensusTracerFactoryTest {
     OpencensusTracerFactory factory =
         new OpencensusTracerFactory(internalTracer, "OverridenClient");
 
-    factory.newTracer(parentTracer, SpanName.of("FakeClient", "FakeMethod"));
+    factory.newTracer(parentTracer, SpanName.of("FakeClient", "FakeMethod"), ApiTracer.Type.Unary);
 
     assertThat(internalTracer.lastSpanName).isEqualTo("OverridenClient.FakeMethod");
   }

--- a/gax/src/test/java/com/google/api/gax/tracing/OpencensusTracerTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/OpencensusTracerTest.java
@@ -39,6 +39,7 @@ import com.google.api.gax.rpc.DeadlineExceededException;
 import com.google.api.gax.rpc.NotFoundException;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.api.gax.rpc.testing.FakeStatusCode;
+import com.google.api.gax.tracing.ApiTracerFactory.OperationType;
 import com.google.common.collect.ImmutableMap;
 import io.opencensus.trace.AttributeValue;
 import io.opencensus.trace.EndSpanOptions;
@@ -72,7 +73,7 @@ public class OpencensusTracerTest {
 
   @Before
   public void setUp() {
-    tracer = new OpencensusTracer(internalTracer, span, ApiTracer.Type.Unary);
+    tracer = new OpencensusTracer(internalTracer, span, OperationType.Unary);
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/tracing/OpencensusTracerTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/OpencensusTracerTest.java
@@ -72,7 +72,7 @@ public class OpencensusTracerTest {
 
   @Before
   public void setUp() {
-    tracer = new OpencensusTracer(internalTracer, span);
+    tracer = new OpencensusTracer(internalTracer, span, ApiTracer.Type.Unary);
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedBatchingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedBatchingCallableTest.java
@@ -69,7 +69,9 @@ public class TracedBatchingCallableTest {
   @Before
   public void setUp() {
     // Wire the mock tracer factory
-    when(tracerFactory.newRootTracer(any(SpanName.class))).thenReturn(tracer);
+    when(tracerFactory.newTracer(
+            any(ApiTracer.class), any(SpanName.class), eq(ApiTracer.Type.Batching)))
+        .thenReturn(tracer);
 
     // Wire the mock inner callable
     // This is a very hacky mock, the actual batching infrastructure is completely omitted here.
@@ -85,7 +87,8 @@ public class TracedBatchingCallableTest {
   @Test
   public void testRootTracerCreated() {
     tracedBatchingCallable.futureCall("test", callContext);
-    verify(tracerFactory, times(1)).newRootTracer(SPAN_NAME);
+    verify(tracerFactory, times(1))
+        .newTracer(callContext.getTracer(), SPAN_NAME, ApiTracer.Type.Batching);
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedBatchingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedBatchingCallableTest.java
@@ -43,6 +43,7 @@ import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.BatchingDescriptor;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.gax.rpc.testing.FakeCallContext;
+import com.google.api.gax.tracing.ApiTracerFactory.OperationType;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -70,7 +71,7 @@ public class TracedBatchingCallableTest {
   public void setUp() {
     // Wire the mock tracer factory
     when(tracerFactory.newTracer(
-            any(ApiTracer.class), any(SpanName.class), eq(ApiTracer.Type.Batching)))
+            any(ApiTracer.class), any(SpanName.class), eq(OperationType.Batching)))
         .thenReturn(tracer);
 
     // Wire the mock inner callable
@@ -88,7 +89,7 @@ public class TracedBatchingCallableTest {
   public void testRootTracerCreated() {
     tracedBatchingCallable.futureCall("test", callContext);
     verify(tracerFactory, times(1))
-        .newTracer(callContext.getTracer(), SPAN_NAME, ApiTracer.Type.Batching);
+        .newTracer(callContext.getTracer(), SPAN_NAME, OperationType.Batching);
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedBidiCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedBidiCallableTest.java
@@ -77,7 +77,8 @@ public class TracedBidiCallableTest {
     outerObserver = new FakeBidiObserver();
     outerCallContext = FakeCallContext.createDefault();
 
-    when(tracerFactory.newTracer(parentTracer, SPAN_NAME)).thenReturn(tracer);
+    when(tracerFactory.newTracer(parentTracer, SPAN_NAME, ApiTracer.Type.BidiStreaming))
+        .thenReturn(tracer);
 
     innerCallable = new FakeBidiCallable();
     innerController = new FakeStreamController();
@@ -88,7 +89,8 @@ public class TracedBidiCallableTest {
   public void testTracerCreated() {
     tracedCallable.call(outerObserver, outerCallContext);
 
-    verify(tracerFactory, times(1)).newTracer(parentTracer, SPAN_NAME);
+    verify(tracerFactory, times(1))
+        .newTracer(parentTracer, SPAN_NAME, ApiTracer.Type.BidiStreaming);
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedBidiCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedBidiCallableTest.java
@@ -43,6 +43,7 @@ import com.google.api.gax.rpc.ClientStreamReadyObserver;
 import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.StreamController;
 import com.google.api.gax.rpc.testing.FakeCallContext;
+import com.google.api.gax.tracing.ApiTracerFactory.OperationType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
@@ -77,7 +78,7 @@ public class TracedBidiCallableTest {
     outerObserver = new FakeBidiObserver();
     outerCallContext = FakeCallContext.createDefault();
 
-    when(tracerFactory.newTracer(parentTracer, SPAN_NAME, ApiTracer.Type.BidiStreaming))
+    when(tracerFactory.newTracer(parentTracer, SPAN_NAME, OperationType.BidiStreaming))
         .thenReturn(tracer);
 
     innerCallable = new FakeBidiCallable();
@@ -89,8 +90,7 @@ public class TracedBidiCallableTest {
   public void testTracerCreated() {
     tracedCallable.call(outerObserver, outerCallContext);
 
-    verify(tracerFactory, times(1))
-        .newTracer(parentTracer, SPAN_NAME, ApiTracer.Type.BidiStreaming);
+    verify(tracerFactory, times(1)).newTracer(parentTracer, SPAN_NAME, OperationType.BidiStreaming);
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedBidiCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedBidiCallableTest.java
@@ -64,6 +64,7 @@ public class TracedBidiCallableTest {
   private FakeCallContext outerCallContext;
 
   @Mock private ApiTracerFactory tracerFactory;
+  private ApiTracer parentTracer = NoopApiTracer.getInstance();
   @Mock private ApiTracer tracer;
 
   private TracedBidiCallable<String, String> tracedCallable;
@@ -76,7 +77,7 @@ public class TracedBidiCallableTest {
     outerObserver = new FakeBidiObserver();
     outerCallContext = FakeCallContext.createDefault();
 
-    when(tracerFactory.newTracer(SPAN_NAME)).thenReturn(tracer);
+    when(tracerFactory.newTracer(parentTracer, SPAN_NAME)).thenReturn(tracer);
 
     innerCallable = new FakeBidiCallable();
     innerController = new FakeStreamController();
@@ -87,7 +88,7 @@ public class TracedBidiCallableTest {
   public void testTracerCreated() {
     tracedCallable.call(outerObserver, outerCallContext);
 
-    verify(tracerFactory, times(1)).newTracer(SPAN_NAME);
+    verify(tracerFactory, times(1)).newTracer(parentTracer, SPAN_NAME);
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedServerStreamingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedServerStreamingCallableTest.java
@@ -77,7 +77,9 @@ public class TracedServerStreamingCallableTest {
   @Before
   public void setUp() {
     // Wire the mock tracer factory
-    when(tracerFactory.newTracer(any(ApiTracer.class), any(SpanName.class))).thenReturn(tracer);
+    when(tracerFactory.newTracer(
+            any(ApiTracer.class), any(SpanName.class), eq(ApiTracer.Type.ServerStreaming)))
+        .thenReturn(tracer);
     innerCallable = new MockServerStreamingCallable<>();
 
     responseObserver = new MockResponseObserver<>(true);
@@ -90,7 +92,8 @@ public class TracedServerStreamingCallableTest {
   @Test
   public void testTracerCreated() {
     tracedCallable.call("test", responseObserver, callContext);
-    verify(tracerFactory, times(1)).newTracer(parentTracer, SPAN_NAME);
+    verify(tracerFactory, times(1))
+        .newTracer(parentTracer, SPAN_NAME, ApiTracer.Type.ServerStreaming);
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedServerStreamingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedServerStreamingCallableTest.java
@@ -48,6 +48,7 @@ import com.google.api.gax.rpc.testing.FakeStatusCode;
 import com.google.api.gax.rpc.testing.MockStreamingApi.MockResponseObserver;
 import com.google.api.gax.rpc.testing.MockStreamingApi.MockServerStreamingCall;
 import com.google.api.gax.rpc.testing.MockStreamingApi.MockServerStreamingCallable;
+import com.google.api.gax.tracing.ApiTracerFactory.OperationType;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -78,7 +79,7 @@ public class TracedServerStreamingCallableTest {
   public void setUp() {
     // Wire the mock tracer factory
     when(tracerFactory.newTracer(
-            any(ApiTracer.class), any(SpanName.class), eq(ApiTracer.Type.ServerStreaming)))
+            any(ApiTracer.class), any(SpanName.class), eq(OperationType.ServerStreaming)))
         .thenReturn(tracer);
     innerCallable = new MockServerStreamingCallable<>();
 
@@ -93,7 +94,7 @@ public class TracedServerStreamingCallableTest {
   public void testTracerCreated() {
     tracedCallable.call("test", responseObserver, callContext);
     verify(tracerFactory, times(1))
-        .newTracer(parentTracer, SPAN_NAME, ApiTracer.Type.ServerStreaming);
+        .newTracer(parentTracer, SPAN_NAME, OperationType.ServerStreaming);
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedServerStreamingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedServerStreamingCallableTest.java
@@ -71,16 +71,17 @@ public class TracedServerStreamingCallableTest {
   private MockServerStreamingCallable<String, String> innerCallable;
   private TracedServerStreamingCallable<String, String> tracedCallable;
   private MockResponseObserver<String> responseObserver;
-  private FakeCallContext callContext;
+  private ApiCallContext callContext;
+  @Mock private ApiTracer parentTracer;
 
   @Before
   public void setUp() {
     // Wire the mock tracer factory
-    when(tracerFactory.newTracer(any(SpanName.class))).thenReturn(tracer);
+    when(tracerFactory.newTracer(any(ApiTracer.class), any(SpanName.class))).thenReturn(tracer);
     innerCallable = new MockServerStreamingCallable<>();
 
     responseObserver = new MockResponseObserver<>(true);
-    callContext = FakeCallContext.createDefault();
+    callContext = FakeCallContext.createDefault().withTracer(parentTracer);
 
     // Build the system under test
     tracedCallable = new TracedServerStreamingCallable<>(innerCallable, tracerFactory, SPAN_NAME);
@@ -89,7 +90,7 @@ public class TracedServerStreamingCallableTest {
   @Test
   public void testTracerCreated() {
     tracedCallable.call("test", responseObserver, callContext);
-    verify(tracerFactory, times(1)).newTracer(SPAN_NAME);
+    verify(tracerFactory, times(1)).newTracer(parentTracer, SPAN_NAME);
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedUnaryCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedUnaryCallableTest.java
@@ -59,6 +59,7 @@ public class TracedUnaryCallableTest {
   public final MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
 
   @Mock private ApiTracerFactory tracerFactory;
+  private ApiTracer parentTracer;
   @Mock private ApiTracer tracer;
   @Mock private UnaryCallable<String, String> innerCallable;
   private SettableApiFuture<String> innerResult;
@@ -68,8 +69,10 @@ public class TracedUnaryCallableTest {
 
   @Before
   public void setUp() {
+    parentTracer = NoopApiTracer.getInstance();
+
     // Wire the mock tracer factory
-    when(tracerFactory.newTracer(any(SpanName.class))).thenReturn(tracer);
+    when(tracerFactory.newTracer(any(ApiTracer.class), any(SpanName.class))).thenReturn(tracer);
 
     // Wire the mock inner callable
     innerResult = SettableApiFuture.create();
@@ -83,7 +86,7 @@ public class TracedUnaryCallableTest {
   @Test
   public void testTracerCreated() {
     tracedUnaryCallable.futureCall("test", callContext);
-    verify(tracerFactory, times(1)).newTracer(SPAN_NAME);
+    verify(tracerFactory, times(1)).newTracer(parentTracer, SPAN_NAME);
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedUnaryCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedUnaryCallableTest.java
@@ -41,6 +41,7 @@ import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.gax.rpc.testing.FakeCallContext;
+import com.google.api.gax.tracing.ApiTracerFactory.OperationType;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -73,7 +74,7 @@ public class TracedUnaryCallableTest {
 
     // Wire the mock tracer factory
     when(tracerFactory.newTracer(
-            any(ApiTracer.class), any(SpanName.class), eq(ApiTracer.Type.Unary)))
+            any(ApiTracer.class), any(SpanName.class), eq(OperationType.Unary)))
         .thenReturn(tracer);
 
     // Wire the mock inner callable
@@ -88,7 +89,7 @@ public class TracedUnaryCallableTest {
   @Test
   public void testTracerCreated() {
     tracedUnaryCallable.futureCall("test", callContext);
-    verify(tracerFactory, times(1)).newTracer(parentTracer, SPAN_NAME, ApiTracer.Type.Unary);
+    verify(tracerFactory, times(1)).newTracer(parentTracer, SPAN_NAME, OperationType.Unary);
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedUnaryCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedUnaryCallableTest.java
@@ -72,7 +72,9 @@ public class TracedUnaryCallableTest {
     parentTracer = NoopApiTracer.getInstance();
 
     // Wire the mock tracer factory
-    when(tracerFactory.newTracer(any(ApiTracer.class), any(SpanName.class))).thenReturn(tracer);
+    when(tracerFactory.newTracer(
+            any(ApiTracer.class), any(SpanName.class), eq(ApiTracer.Type.Unary)))
+        .thenReturn(tracer);
 
     // Wire the mock inner callable
     innerResult = SettableApiFuture.create();
@@ -86,7 +88,7 @@ public class TracedUnaryCallableTest {
   @Test
   public void testTracerCreated() {
     tracedUnaryCallable.futureCall("test", callContext);
-    verify(tracerFactory, times(1)).newTracer(parentTracer, SPAN_NAME);
+    verify(tracerFactory, times(1)).newTracer(parentTracer, SPAN_NAME, ApiTracer.Type.Unary);
   }
 
   @Test


### PR DESCRIPTION
Complex callable chains like LRO callables need to be able to create a hierarchy of spans.

For example LROs will need to create the following heirarchy:
- one span for the entire logical operation
- a child for the initial rpc to start the operation
- a child for each poll attempt

This PR enables the behavior by extracting the parent span from the ApiCallContext. If the ApiCallContext doesn't have a parent span, it will fallback to the ambient parent span that the caller might've set in the GRPC context.

It also introduces ApiTracer types to modify the behavior of tracing for different operation types. Currently this only affects Batching by forcing it be a root span. In a follow up PR it also be used for LRO tracing to change the annotations for polling.

The two changes (nesting & tracer types) are unrelated, but they both modify the same factory methods, so I figured I would bundle them together. If it makes it easier to review, I can split the PR.