### PR TITLE
Opencensus Tracing: Add ability to pass static attributes to OpencensusTracerFactory

### DIFF
--- a/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracerFactory.java
@@ -32,12 +32,15 @@ package com.google.api.gax.tracing;
 import com.google.api.core.InternalApi;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import io.opencensus.trace.AttributeValue;
 import io.opencensus.trace.BlankSpan;
 import io.opencensus.trace.Span;
+import io.opencensus.trace.SpanBuilder;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
+import java.util.Map;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * A {@link ApiTracerFactory} to build instances of {@link OpencensusTracer}.
@@ -50,14 +53,14 @@ import javax.annotation.Nullable;
 @InternalApi("For google-cloud-java client use only")
 public final class OpencensusTracerFactory implements ApiTracerFactory {
   @Nonnull private final Tracer internalTracer;
-  @Nullable private final String clientNameOverride;
+  @Nonnull private final Map<String, AttributeValue> spanAttributes;
 
   /**
    * Instantiates a new instance capturing the {@link io.opencensus.trace.Tracer} in {@code
    * Tracing.getTracer}.
    */
   public OpencensusTracerFactory() {
-    this(null);
+    this(ImmutableMap.<String, String>of());
   }
 
   /**
@@ -66,10 +69,11 @@ public final class OpencensusTracerFactory implements ApiTracerFactory {
    * client name. This is useful disambiguate spans created outer manual written wrappers and around
    * generated gapic spans.
    *
-   * @param clientNameOverride the client name that will override all of the spans' client name.
+   * @param spanAttributes the attributes to stamp on every span. Should include things like library
+   *     version.
    */
-  public OpencensusTracerFactory(@Nullable String clientNameOverride) {
-    this(Tracing.getTracer(), clientNameOverride);
+  public OpencensusTracerFactory(Map<String, String> spanAttributes) {
+    this(Tracing.getTracer(), spanAttributes);
   }
 
   /**
@@ -78,31 +82,33 @@ public final class OpencensusTracerFactory implements ApiTracerFactory {
    * disambiguate spans created outer manual written wrappers and around generated gapic spans.
    *
    * @param internalTracer the Opencensus tracer to wrap.
-   * @param clientNameOverride the client name that will override all of the spans' client name.
    */
   @InternalApi("Visible for testing")
-  OpencensusTracerFactory(Tracer internalTracer, @Nullable String clientNameOverride) {
+  OpencensusTracerFactory(Tracer internalTracer, @Nonnull Map<String, String> spanAttributes) {
     this.internalTracer =
         Preconditions.checkNotNull(internalTracer, "internalTracer can't be null");
-    this.clientNameOverride = clientNameOverride;
+    ImmutableMap.Builder<String, AttributeValue> formattedSpanAttributes = ImmutableMap.builder();
+    for (Map.Entry<String, String> entry : spanAttributes.entrySet()) {
+      formattedSpanAttributes.put(
+          entry.getKey(), AttributeValue.stringAttributeValue(entry.getValue()));
+    }
+    this.spanAttributes = formattedSpanAttributes.build();
   }
 
   /** {@inheritDoc } */
   @Override
   public ApiTracer newTracer(SpanName spanName) {
-    if (clientNameOverride != null) {
-      spanName = spanName.withClientName(clientNameOverride);
-    }
-    Span span = internalTracer.spanBuilder(spanName.toString()).setRecordEvents(true).startSpan();
+    SpanBuilder sb = internalTracer.spanBuilder(spanName.toString());
+    sb = sb.setRecordEvents(true);
+
+    Span span = sb.startSpan();
+    span.putAttributes(spanAttributes);
 
     return new OpencensusTracer(internalTracer, span);
   }
 
   @Override
   public ApiTracer newRootTracer(SpanName spanName) {
-    if (clientNameOverride != null) {
-      spanName = spanName.withClientName(clientNameOverride);
-    }
     Span span =
         internalTracer
             .spanBuilderWithExplicitParent(spanName.toString(), BlankSpan.INSTANCE)
@@ -122,11 +128,11 @@ public final class OpencensusTracerFactory implements ApiTracerFactory {
     }
     OpencensusTracerFactory that = (OpencensusTracerFactory) o;
     return Objects.equal(internalTracer, that.internalTracer)
-        && Objects.equal(clientNameOverride, that.clientNameOverride);
+        && Objects.equal(spanAttributes, that.spanAttributes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(internalTracer, clientNameOverride);
+    return Objects.hashCode(internalTracer, spanAttributes);
   }
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracerFactory.java
@@ -36,7 +36,6 @@ import com.google.common.collect.ImmutableMap;
 import io.opencensus.trace.AttributeValue;
 import io.opencensus.trace.BlankSpan;
 import io.opencensus.trace.Span;
-import io.opencensus.trace.SpanBuilder;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
 import java.util.Map;
@@ -98,10 +97,8 @@ public final class OpencensusTracerFactory implements ApiTracerFactory {
   /** {@inheritDoc } */
   @Override
   public ApiTracer newTracer(SpanName spanName) {
-    SpanBuilder sb = internalTracer.spanBuilder(spanName.toString());
-    sb = sb.setRecordEvents(true);
+    Span span = internalTracer.spanBuilder(spanName.toString()).setRecordEvents(true).startSpan();
 
-    Span span = sb.startSpan();
     span.putAttributes(spanAttributes);
 
     return new OpencensusTracer(internalTracer, span);

--- a/gax/src/main/java/com/google/api/gax/tracing/SpanName.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/SpanName.java
@@ -56,16 +56,6 @@ public abstract class SpanName {
   /** The name of the logical operation being traced. ie. ReadRows. */
   public abstract String getMethodName();
 
-  /** Creates a new instance with the clientName overriden. */
-  public SpanName withClientName(String clientName) {
-    return of(clientName, getMethodName());
-  }
-
-  /** Creates a new instance with the methodName overriden. */
-  public SpanName withMethodName(String methodName) {
-    return of(getClientName(), methodName);
-  }
-
   @Override
   public String toString() {
     return getClientName() + "." + getMethodName();


### PR DESCRIPTION
This will be used by the GAPIC generator to pass library versions to be
stamped on the created spans. Specifically the generated stub settings
will contain a new static method:

```java
public static TracerFactory defaultTracerFactory() {
  return new OpencensusTracerFactory(
    ImmutableMap.of(
      "gax version": GaxGrpcProperties.getGaxGrpcVersion(),
      "gapic version", GaxProperties.getLibraryVersion(__StubSettings.class),
      "grpc version", GaxProperties.getGrpcVersion()));
}
```
Also, this removes the ClientName override. I think there is are better
ways to handle manual wrappers that I want to experiment with before
committing nested spans and ClientName overrides.