### PR TITLE
Opencensus Tracing: trace server streaming.{first,all} as unary rpcs

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
@@ -213,6 +213,16 @@ public abstract class ServerStreamingCallable<RequestT, ResponseT> {
       final ApiCallContext defaultCallContext) {
     return new ServerStreamingCallable<RequestT, ResponseT>() {
       @Override
+      public UnaryCallable<RequestT, ResponseT> first() {
+        return ServerStreamingCallable.this.first().withDefaultCallContext(defaultCallContext);
+      }
+
+      @Override
+      public UnaryCallable<RequestT, List<ResponseT>> all() {
+        return ServerStreamingCallable.this.all().withDefaultCallContext(defaultCallContext);
+      }
+
+      @Override
       public void call(
           RequestT request,
           ResponseObserver<ResponseT> responseObserver,

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
@@ -212,11 +212,18 @@ public abstract class ServerStreamingCallable<RequestT, ResponseT> {
   public ServerStreamingCallable<RequestT, ResponseT> withDefaultCallContext(
       final ApiCallContext defaultCallContext) {
     return new ServerStreamingCallable<RequestT, ResponseT>() {
+      // In case the next callable overrides the default behavior of first(), make sure to route
+      // the call directly to the next callable's first() implementation.
+      // The default implementation of first() instantiates a new FirstElementCallable which
+      // calls this instance's call method, bypassing the next callable's first implementation.
+      // Instead we will bypass the anonymous implementation of call() and invoke the next
+      // link's first() implementation.
       @Override
       public UnaryCallable<RequestT, ResponseT> first() {
         return ServerStreamingCallable.this.first().withDefaultCallContext(defaultCallContext);
       }
 
+      // Like, first(), make sure to respect the next callable's all() impl.
       @Override
       public UnaryCallable<RequestT, List<ResponseT>> all() {
         return ServerStreamingCallable.this.all().withDefaultCallContext(defaultCallContext);

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedServerStreamingCallable.java
@@ -68,12 +68,12 @@ public class TracedServerStreamingCallable<RequestT, ResponseT>
         new TracedUnaryCallable<>(
             innerCallable.first(),
             tracerFactory,
-            SpanName.of(spanName.getClientName(), spanName.getMethodName() + ".first"));
+            SpanName.of(spanName.getClientName(), spanName.getMethodName() + ".First"));
     this.tracedAllCallable =
         new TracedUnaryCallable<>(
             innerCallable.all(),
             tracerFactory,
-            SpanName.of(spanName.getClientName(), spanName.getMethodName() + ".all"));
+            SpanName.of(spanName.getClientName(), spanName.getMethodName() + ".All"));
   }
 
   @Override

--- a/gax/src/main/java/com/google/api/gax/tracing/TracedServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/TracedServerStreamingCallable.java
@@ -47,7 +47,9 @@ import javax.annotation.Nonnull;
  */
 @BetaApi("The surface for tracing is not stable and might change in the future")
 @InternalApi("For internal use by google-cloud-java clients only")
-public class TracedServerStreamingCallable<RequestT, ResponseT>
+// NOTE: the implementation for first() & all() bypass the main call() logic in this class
+// TO avoid unexpected behavior in subclasses, this class is marked as final.
+public final class TracedServerStreamingCallable<RequestT, ResponseT>
     extends ServerStreamingCallable<RequestT, ResponseT> {
 
   @Nonnull private final ApiTracerFactory tracerFactory;

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallableTest.java
@@ -32,6 +32,7 @@ package com.google.api.gax.rpc;
 import com.google.api.gax.rpc.testing.FakeCallContext;
 import com.google.api.gax.rpc.testing.FakeCallableFactory;
 import com.google.api.gax.rpc.testing.FakeChannel;
+import com.google.api.gax.rpc.testing.FakeSimpleApi.StashCallable;
 import com.google.api.gax.rpc.testing.FakeStreamingApi.ServerStreamingStashCallable;
 import com.google.api.gax.rpc.testing.FakeTransportChannel;
 import com.google.auth.Credentials;
@@ -179,15 +180,23 @@ public class ServerStreamingCallableTest {
   @Test
   public void testFirstElementCallWithDefaultContext() {
     ApiCallContext defaultCallContext = FakeCallContext.createDefault();
+
+    final StashCallable<Integer, Integer> stashFirstCallable = new StashCallable<>(11);
+
     ServerStreamingStashCallable<Integer, Integer> stashCallable =
-        new ServerStreamingStashCallable<>();
+        new ServerStreamingStashCallable<Integer, Integer>() {
+          @Override
+          public UnaryCallable<Integer, Integer> first() {
+            return stashFirstCallable;
+          }
+        };
 
     UnaryCallable<Integer, Integer> firstCallable =
-        stashCallable.first().withDefaultCallContext(defaultCallContext);
+        stashCallable.withDefaultCallContext(defaultCallContext).first();
     Integer request = 1;
     firstCallable.call(request);
-    Truth.assertThat(stashCallable.getActualRequest()).isSameAs(request);
-    Truth.assertThat(stashCallable.getContext()).isSameAs(defaultCallContext);
+    Truth.assertThat(stashFirstCallable.getRequest()).isSameAs(request);
+    Truth.assertThat(stashFirstCallable.getContext()).isSameAs(defaultCallContext);
   }
 
   @Test


### PR DESCRIPTION
Also fix #488