### PR TITLE
Add an EmptyMessage class, analogous to protobuf's Empty

### DIFF
--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/EmptyMessage.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/EmptyMessage.java
@@ -33,25 +33,28 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 /**
- * A generic empty message that you can re-use to avoid defining duplicated empty messages in your
+ * A generic empty message that can be re-used to avoid defining duplicated empty messages in your
  * APIs. A typical example is to use it as the response type of an API method.
  */
 public class EmptyMessage implements ApiMessage {
 
   @Nullable
   @Override
+  /* Overriden method. Will always return null, because there are no fields in this message type. */
   public Object getFieldValue(String fieldName) {
     return null;
   }
 
   @Nullable
   @Override
+  /* Overriden method. Will always return null, because there are no fields in this message type. */
   public List<String> getFieldMask() {
     return null;
   }
 
   @Nullable
   @Override
+  /* Overriden method. Will always return null, because there are no fields in this message type. */
   public ApiMessage getApiMessageRequestBody() {
     return null;
   }

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/EmptyMessage.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/EmptyMessage.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.httpjson;
+
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * A generic empty message that you can re-use to avoid defining duplicated empty messages in your
+ * APIs. A typical example is to use it as the response type of an API method.
+ */
+public class EmptyMessage implements ApiMessage {
+
+  @Nullable
+  @Override
+  public Object getFieldValue(String fieldName) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public List<String> getFieldMask() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public ApiMessage getApiMessageRequestBody() {
+    return null;
+  }
+}

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ApiMessageHttpRequestTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ApiMessageHttpRequestTest.java
@@ -137,22 +137,22 @@ public class ApiMessageHttpRequestTest {
             .setQueryParams(Sets.newHashSet("requestId"))
             .build();
 
-    ApiMethodDescriptor<InsertFrogRequest, Void> apiMethodDescriptor =
-        ApiMethodDescriptor.<InsertFrogRequest, Void>newBuilder()
+    ApiMethodDescriptor<InsertFrogRequest, EmptyMessage> apiMethodDescriptor =
+        ApiMethodDescriptor.<InsertFrogRequest, EmptyMessage>newBuilder()
             .setFullMethodName("house.details.get")
             .setHttpMethod(null)
             .setRequestFormatter(frogFormatter)
             .build();
 
     HttpRequestRunnable httpRequestRunnable =
-        HttpRequestRunnable.<InsertFrogRequest, Void>newBuilder()
+        HttpRequestRunnable.<InsertFrogRequest, EmptyMessage>newBuilder()
             .setHttpJsonCallOptions(fakeCallOptions)
             .setEndpoint(ENDPOINT)
             .setRequest(insertFrogRequest)
             .setApiMethodDescriptor(apiMethodDescriptor)
             .setHttpTransport(new MockHttpTransport())
             .setJsonFactory(new JacksonFactory())
-            .setResponseFuture(SettableApiFuture.<Void>create())
+            .setResponseFuture(SettableApiFuture.<EmptyMessage>create())
             .build();
 
     HttpRequest httpRequest = httpRequestRunnable.createHttpRequest();

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpRequestRunnableTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpRequestRunnableTest.java
@@ -58,8 +58,8 @@ public class HttpRequestRunnableTest {
   private static final String ENDPOINT = "https://www.googleapis.com/animals/v1/projects/";
   private static HttpRequestRunnable httpRequestRunnable;
   private static HttpRequestFormatter<CatMessage> catFormatter;
-  private static HttpResponseParser<Void> catParser;
-  private static ApiMethodDescriptor<CatMessage, Void> methodDescriptor;
+  private static HttpResponseParser<EmptyMessage> catParser;
+  private static ApiMethodDescriptor<CatMessage, EmptyMessage> methodDescriptor;
   private static PathTemplate nameTemplate = PathTemplate.create("name/{name}");
   private static Set<String> queryParams =
       Sets.newTreeSet(Lists.newArrayList("food", "size", "gibberish"));
@@ -127,20 +127,20 @@ public class HttpRequestRunnableTest {
         };
 
     catParser =
-        new HttpResponseParser<Void>() {
+        new HttpResponseParser<EmptyMessage>() {
           @Override
-          public Void parse(InputStream httpContent) {
+          public EmptyMessage parse(InputStream httpContent) {
             return null;
           }
 
           @Override
-          public String serialize(Void response) {
+          public String serialize(EmptyMessage response) {
             return null;
           }
         };
 
     methodDescriptor =
-        ApiMethodDescriptor.<CatMessage, Void>newBuilder()
+        ApiMethodDescriptor.<CatMessage, EmptyMessage>newBuilder()
             .setFullMethodName("house.cat.get")
             .setHttpMethod(null)
             .setRequestFormatter(catFormatter)
@@ -148,14 +148,14 @@ public class HttpRequestRunnableTest {
             .build();
 
     httpRequestRunnable =
-        HttpRequestRunnable.<CatMessage, Void>newBuilder()
+        HttpRequestRunnable.<CatMessage, EmptyMessage>newBuilder()
             .setHttpJsonCallOptions(fakeCallOptions)
             .setEndpoint(ENDPOINT)
             .setRequest(catMessage)
             .setApiMethodDescriptor(methodDescriptor)
             .setHttpTransport(new MockHttpTransport())
             .setJsonFactory(new JacksonFactory())
-            .setResponseFuture(SettableApiFuture.<Void>create())
+            .setResponseFuture(SettableApiFuture.<EmptyMessage>create())
             .build();
   }
 

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/MockHttpServiceTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/MockHttpServiceTest.java
@@ -90,6 +90,7 @@ public class MockHttpServiceTest {
     }
   }
 
+  @SuppressWarnings("unchecked")
   private static final HttpResponseParser<PetMessage> PET_RESPONSE_PARSER =
       new HttpResponseParser<PetMessage>() {
         @Override


### PR DESCRIPTION
This allows all interfaces that use `ApiMessage` to enforce that response objects have to be of type `ApiMessage`, which includes `EmptyMessage`. This replaces `java.lang.Void` as a response type.