### PR TITLE
Opencensus Tracing: minor tweaks

### DIFF
--- a/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracer.java
@@ -36,6 +36,7 @@ import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.api.gax.tracing.ApiTracerFactory.OperationType;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import io.opencensus.trace.AttributeValue;
 import io.opencensus.trace.EndSpanOptions;
 import io.opencensus.trace.Span;
@@ -464,6 +465,11 @@ public class OpencensusTracer implements ApiTracer {
 
     attributes.put(
         "status", AttributeValue.stringAttributeValue(status.getCanonicalCode().toString()));
+
+    if (!Strings.isNullOrEmpty(status.getDescription())) {
+      attributes.put(
+          "status message", AttributeValue.stringAttributeValue(status.getDescription()));
+    }
   }
 
   @InternalApi("Visible for testing")

--- a/gax/src/test/java/com/google/api/gax/tracing/OpencensusTracerTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/OpencensusTracerTest.java
@@ -100,6 +100,7 @@ public class OpencensusTracerTest {
                 "attempt", AttributeValue.longAttributeValue(0),
                 "delay ms", AttributeValue.longAttributeValue(5),
                 "status", AttributeValue.stringAttributeValue("DEADLINE_EXCEEDED"),
+                "status message", AttributeValue.stringAttributeValue("deadline exceeded"),
                 "connection", AttributeValue.stringAttributeValue("1")));
 
     // Attempt 1
@@ -184,6 +185,7 @@ public class OpencensusTracerTest {
             ImmutableMap.of(
                 "attempt", AttributeValue.longAttributeValue(0),
                 "status", AttributeValue.stringAttributeValue("DEADLINE_EXCEEDED"),
+                "status message", AttributeValue.stringAttributeValue("deadline exceeded"),
                 "connection", AttributeValue.stringAttributeValue("1")));
 
     verify(span)
@@ -238,6 +240,7 @@ public class OpencensusTracerTest {
             ImmutableMap.of(
                 "attempt", AttributeValue.longAttributeValue(0),
                 "status", AttributeValue.stringAttributeValue("NOT_FOUND"),
+                "status message", AttributeValue.stringAttributeValue("not found"),
                 "connection", AttributeValue.stringAttributeValue("1")));
 
     verify(span)


### PR DESCRIPTION
* Remove special handling for server streaming .all & .first. It doesn't add any value and creates confusion in bigtable's overlay
* Add status messages as attributes