### PR TITLE
Expose LRO callables for HttpJson

### DIFF
--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
@@ -79,7 +79,7 @@ public class HttpJsonCallableFactory {
    * by generated code.
    *
    * @param httpJsonCallSettings the gRPC call settings
-   * @param callSettings the Unary call settings
+   * @param callSettings the unary call settings
    * @param clientContext {@link ClientContext} to use to connect to the service.
    */
   public static <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createBaseUnaryCallable(

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
@@ -31,9 +31,13 @@ package com.google.api.gax.httpjson;
 
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
+import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.Callables;
 import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.LongRunningClient;
+import com.google.api.gax.rpc.OperationCallSettings;
+import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.PagedCallSettings;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
@@ -68,6 +72,27 @@ public class HttpJsonCallableFactory {
         new HttpJsonExceptionCallable<>(innerCallable, callSettings.getRetryableCodes());
     callable = Callables.retrying(callable, callSettings, clientContext);
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
+  }
+
+  /**
+   * Create a Unary callable object with minimal http/json-specific functionality. Designed for use
+   * by generated code.
+   *
+   * @param httpJsonCallSettings the gRPC call settings
+   * @param callSettings the Unary call settings
+   * @param clientContext {@link ClientContext} to use to connect to the service.
+   */
+  public static <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createBaseUnaryCallable(
+      HttpJsonCallSettings<RequestT, ResponseT> httpJsonCallSettings,
+      UnaryCallSettings<?, ?> callSettings,
+      ClientContext clientContext) {
+    UnaryCallable<RequestT, ResponseT> callable =
+        new HttpJsonDirectCallable<>(httpJsonCallSettings.getMethodDescriptor());
+    callable = new HttpJsonExceptionCallable<>(callable, callSettings.getRetryableCodes());
+
+    callable = Callables.retrying(callable, callSettings, clientContext);
+
+    return callable;
   }
 
   /**
@@ -134,6 +159,20 @@ public class HttpJsonCallableFactory {
     callable = createUnaryCallable(callable, batchingCallSettings, clientContext);
     callable = Callables.batching(callable, batchingCallSettings, clientContext);
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
+  }
+
+  @BetaApi(
+      "The surface for long-running operations is not stable yet and may change in the future.")
+  public static <RequestT, ResponseT, MetadataT>
+      OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
+          OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings,
+          ClientContext clientContext,
+          LongRunningClient longRunningClient,
+          UnaryCallable<RequestT, OperationSnapshot> operationSnapshotCallable) {
+    OperationCallable<RequestT, ResponseT, MetadataT> operationCallable =
+        Callables.longRunningOperation(
+            operationSnapshotCallable, operationCallSettings, clientContext, longRunningClient);
+    return operationCallable.withDefaultCallContext(clientContext.getDefaultCallContext());
   }
 
   @InternalApi("Visible for testing")

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStubCallableFactory.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStubCallableFactory.java
@@ -30,14 +30,18 @@
 package com.google.api.gax.httpjson;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.OperationCallSettings;
+import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.PagedCallSettings;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 
 @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
-public interface HttpJsonStubCallableFactory {
+public interface HttpJsonStubCallableFactory<
+    OperationT extends ApiMessage, OperationsStub extends BackgroundResource> {
 
   /**
    * Create a callable object with http/json-specific functionality. Designed for use by generated
@@ -82,4 +86,11 @@ public interface HttpJsonStubCallableFactory {
       HttpJsonCallSettings<RequestT, ResponseT> httpJsonCallSettings,
       BatchingCallSettings<RequestT, ResponseT> batchingCallSettings,
       ClientContext clientContext);
+
+  public <RequestT, ResponseT, MetadataT>
+      OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
+          HttpJsonCallSettings<RequestT, OperationT> httpJsonCallSettings,
+          OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings,
+          ClientContext clientContext,
+          OperationsStub operationsStub);
 }


### PR DESCRIPTION
Just the HttpJson version of GrpcStubCallableFactory and GrpcCallableFactory.

These new methods will be implemented by future versions of [HttpJsonGlobalOperationStubCallableFactory](https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-clients/google-cloud-compute/src/main/java/com/google/cloud/compute/v1/stub/HttpJsonGlobalOperationCallableFactory.java), etc., in the same way that `com.google.longrunning.stub.GrpcOperationsCallableFactory` implements GrpcStubCallableFactory.