### PR TITLE
Add builder methods to EmptyMessage

### DIFF
--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/EmptyMessage.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/EmptyMessage.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.httpjson;
 
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -57,5 +58,63 @@ public class EmptyMessage implements ApiMessage {
   /* Overriden method. Will always return null, because there are no fields in this message type. */
   public ApiMessage getApiMessageRequestBody() {
     return null;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return other instanceof EmptyMessage;
+  }
+
+  private static final EmptyMessage DEFAULT_INSTANCE;
+
+  public static EmptyMessage getDefaultInstance() {
+    return DEFAULT_INSTANCE;
+  }
+
+  private EmptyMessage() {}
+
+  public static Builder newBuilder() {
+    return DEFAULT_INSTANCE.toBuilder();
+  }
+
+  public static Builder newBuilder(EmptyMessage prototype) {
+    return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+  }
+
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  static {
+    DEFAULT_INSTANCE = new EmptyMessage();
+  }
+
+  public static class Builder {
+    Builder() {}
+
+    public Builder mergeFrom(EmptyMessage other) {
+      return this;
+    }
+
+    public Builder(EmptyMessage other) {}
+
+    public EmptyMessage build() {
+      return new EmptyMessage();
+    }
+
+    public Builder clone() {
+      Builder newBuilder = new Builder();
+      return newBuilder;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "EmptyMessage{}";
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(DEFAULT_INSTANCE);
   }
 }

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/EmptyMessage.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/EmptyMessage.java
@@ -65,7 +65,8 @@ public class EmptyMessage implements ApiMessage {
     return other instanceof EmptyMessage;
   }
 
-  private static final EmptyMessage DEFAULT_INSTANCE;
+  // This is a singleton class.
+  private static final EmptyMessage DEFAULT_INSTANCE = new EmptyMessage();
 
   public static EmptyMessage getDefaultInstance() {
     return DEFAULT_INSTANCE;
@@ -85,10 +86,6 @@ public class EmptyMessage implements ApiMessage {
     return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
-  static {
-    DEFAULT_INSTANCE = new EmptyMessage();
-  }
-
   public static class Builder {
     Builder() {}
 
@@ -99,12 +96,11 @@ public class EmptyMessage implements ApiMessage {
     public Builder(EmptyMessage other) {}
 
     public EmptyMessage build() {
-      return new EmptyMessage();
+      return DEFAULT_INSTANCE;
     }
 
     public Builder clone() {
-      Builder newBuilder = new Builder();
-      return newBuilder;
+      return new Builder();
     }
   }
 


### PR DESCRIPTION
So that EmptyMessage has the same calling structures as other ApiMessage implementations, e.g. the [Address resource class](https://github.com/googleapis/google-cloud-java/blob/ed3a0c85339ea6b73560b9a570abfbb76b93a263/google-cloud-clients/google-cloud-compute/src/main/java/com/google/cloud/compute/v1/Address.java#L307).