### PR TITLE
Release gax-java v1.42.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,27 +31,27 @@ If you are using Maven, add this to your pom.xml file
 <dependency>
   <groupId>com.google.api</groupId>
   <artifactId>gax</artifactId>
-  <version>1.40.0</version>
+  <version>1.42.0</version>
 </dependency>
 <dependency>
   <groupId>com.google.api</groupId>
   <artifactId>gax-grpc</artifactId>
-  <version>1.40.0</version>
+  <version>1.42.0</version>
 </dependency>
 ```
 
 If you are using Gradle, add this to your dependencies
 
 ```Groovy
-compile 'com.google.api:gax:1.40.0',
-  'com.google.api:gax-grpc:1.40.0'
+compile 'com.google.api:gax:1.42.0',
+  'com.google.api:gax-grpc:1.42.0'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.api" % "gax" % "1.40.0"
-libraryDependencies += "com.google.api" % "gax-grpc" % "1.40.0"
+libraryDependencies += "com.google.api" % "gax" % "1.42.0"
+libraryDependencies += "com.google.api" % "gax-grpc" % "1.42.0"
 ```
 [//]: # ({x-version-update-end})
 

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -1,4 +1,4 @@
-project.version = "0.42.1-SNAPSHOT" // {x-version-update:benchmark:current}
+project.version = "0.44.0" // {x-version-update:benchmark:current}
 
 buildscript {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'java'
 apply plugin: 'com.github.sherter.google-java-format'
 apply plugin: 'io.codearte.nexus-staging'
 
-project.version = "1.40.1-SNAPSHOT" // {x-version-update:gax:current}
+project.version = "1.42.0" // {x-version-update:gax:current}
 
 ext {
   // When upgrading grpc, make sure to upgrade opencensusVersion to be consistent with grpc.

--- a/gax-bom/build.gradle
+++ b/gax-bom/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 archivesBaseName = "gax-bom"
 
-project.version = "1.40.1-SNAPSHOT" // {x-version-update:gax-bom:current}
+project.version = "1.42.0" // {x-version-update:gax-bom:current}
 
 ext {
   mavenJavaDir = "$project.buildDir/publications/mavenJava"

--- a/gax-bom/pom.xml
+++ b/gax-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api</groupId>
   <artifactId>gax-bom</artifactId>
-  <version>1.40.1-SNAPSHOT</version><!-- {x-version-update:gax-bom:current} -->
+  <version>1.42.0</version><!-- {x-version-update:gax-bom:current} -->
   <packaging>pom</packaging>
   <name>GAX (Google Api eXtensions) for Java</name>
   <description>Google Api eXtensions for Java</description>
@@ -33,34 +33,34 @@
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax</artifactId>
-        <version>1.40.1-SNAPSHOT</version><!-- {x-version-update:gax:current} -->
+        <version>1.42.0</version><!-- {x-version-update:gax:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax</artifactId>
-        <version>1.40.1-SNAPSHOT</version><!-- {x-version-update:gax:current} -->
+        <version>1.42.0</version><!-- {x-version-update:gax:current} -->
 	<classifier>testlib</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-grpc</artifactId>
-        <version>1.40.1-SNAPSHOT</version><!-- {x-version-update:gax-grpc:current} -->
+        <version>1.42.0</version><!-- {x-version-update:gax-grpc:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-grpc</artifactId>
-        <version>1.40.1-SNAPSHOT</version><!-- {x-version-update:gax-grpc:current} -->
+        <version>1.42.0</version><!-- {x-version-update:gax-grpc:current} -->
 	<classifier>testlib</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-httpjson</artifactId>
-        <version>0.57.1-SNAPSHOT</version><!-- {x-version-update:gax-httpjson:current} -->
+        <version>0.59.0</version><!-- {x-version-update:gax-httpjson:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-httpjson</artifactId>
-        <version>0.57.1-SNAPSHOT</version><!-- {x-version-update:gax-httpjson:current} -->
+        <version>0.59.0</version><!-- {x-version-update:gax-httpjson:current} -->
 	<classifier>testlib</classifier>
       </dependency>
     </dependencies>

--- a/gax-grpc/build.gradle
+++ b/gax-grpc/build.gradle
@@ -1,7 +1,7 @@
 
 archivesBaseName = "gax-grpc"
 
-project.version = "1.40.1-SNAPSHOT" // {x-version-update:gax-grpc:current}
+project.version = "1.42.0" // {x-version-update:gax-grpc:current}
 
 dependencies {
   compile project(':gax'),

--- a/gax-httpjson/build.gradle
+++ b/gax-httpjson/build.gradle
@@ -1,7 +1,7 @@
 
 archivesBaseName = "gax-httpjson"
 
-project.version = "0.57.1-SNAPSHOT" // {x-version-update:gax-httpjson:current}
+project.version = "0.59.0" // {x-version-update:gax-httpjson:current}
 
 dependencies {
   compile project(':gax'),

--- a/gax/build.gradle
+++ b/gax/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 archivesBaseName = "gax"
 
-project.version = "1.40.1-SNAPSHOT" // {x-version-update:gax:current}
+project.version = "1.42.0" // {x-version-update:gax:current}
 
 dependencies {
   compile libraries.guava,

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -14,13 +14,13 @@
       <groupId>com.google.api</groupId>
       <artifactId>gax</artifactId>
       <!-- WARNING this is automatically populated by a build script, don't update manually -->
-      <version>1.40.1-SNAPSHOT</version><!-- {x-version-update:gax:current} -->
+      <version>1.42.0</version><!-- {x-version-update:gax:current} -->
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
       <!-- WARNING this is automatically populated by a build script, don't update manually -->
-      <version>1.40.1-SNAPSHOT</version><!-- {x-version-update:gax-grpc:current} -->
+      <version>1.42.0</version><!-- {x-version-update:gax-grpc:current} -->
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>

--- a/versions.txt
+++ b/versions.txt
@@ -1,8 +1,8 @@
 # Format:
 # module:released-version:current-version
 
-gax:1.40.0:1.40.1-SNAPSHOT
-gax-bom:1.40.0:1.40.1-SNAPSHOT
-gax-grpc:1.40.0:1.40.1-SNAPSHOT
-gax-httpjson:0.57.0:0.57.1-SNAPSHOT
-benchmark:0.42.0:0.42.1-SNAPSHOT
+gax:1.42.0:1.42.0
+gax-bom:1.42.0:1.42.0
+gax-grpc:1.42.0:1.42.0
+gax-httpjson:0.59.0:0.59.0
+benchmark:0.44.0:0.44.0


### PR DESCRIPTION
This pull request was generated using releasetool.

03-04-2019 16:21 PST


### Implementation Changes
- Add 200 as a valid HTTP status code ([#679](https://github.com/googleapis/gax-java/pull/679))
- Add builder methods to EmptyMessage ([#685](https://github.com/googleapis/gax-java/pull/685))

### New Features
- Add an EmptyMessage class, analogous to protobuf's Empty ([#678](https://github.com/googleapis/gax-java/pull/678))
- Expose LRO callables for HttpJson ([#684](https://github.com/googleapis/gax-java/pull/684))
- [LRO] Add ApiMessageOperationTransformer ([#683](https://github.com/googleapis/gax-java/pull/683))

### Documentation
- 1.40.0 for all build tools ([#677](https://github.com/googleapis/gax-java/pull/677))
