### PR TITLE
Revert PR#690

### DIFF
--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -21,7 +21,7 @@ repositories {
 dependencies {
     compile project(':gax')
     compile project(':gax-grpc')
-    compile "io.grpc:grpc-netty"
+    compile "io.grpc:grpc-netty:${libraries['version.io_grpc']}"
 
     compile 'com.google.api.grpc:grpc-google-cloud-bigtable-v2:0.1.28'
     compile 'com.google.api.grpc:grpc-google-cloud-pubsub-v1:0.1.28'

--- a/build.gradle
+++ b/build.gradle
@@ -112,14 +112,14 @@ subprojects {
 
     // Gradle-specific build script dependencies
     libraries.putAll([
-      'maven.io_grpc_grpc_bom': 'io.grpc:grpc-bom:' + libraries['version.io_grpc'],
-      'maven.io_grpc_grpc_core': 'io.grpc:grpc-core:' + libraries['version.io_grpc'],
-      'maven.io_grpc_grpc_context': 'io.grpc:grpc-context:' + libraries['version.io_grpc'],
-      'maven.io_grpc_grpc_stub': 'io.grpc:grpc-stub:' + libraries['version.io_grpc'],
-      'maven.io_grpc_grpc_auth': 'io.grpc:grpc-auth:' + libraries['version.io_grpc'],
-      'maven.io_grpc_grpc_protobuf': 'io.grpc:grpc-protobuf:' + libraries['version.io_grpc'],
-      'maven.io_grpc_grpc_netty_shaded': 'io.grpc:grpc-netty-shaded:' + libraries['version.io_grpc'],
-      'maven.io_grpc_grpc_alts': 'io.grpc:grpc-alts:' + libraries['version.io_grpc'],
+      'maven.io_grpc_grpc_bom': "io.grpc:grpc-bom:${libraries['version.io_grpc']}",
+      'maven.io_grpc_grpc_core': "io.grpc:grpc-core:${libraries['version.io_grpc']}",
+      'maven.io_grpc_grpc_context': "io.grpc:grpc-context:${libraries['version.io_grpc']}",
+      'maven.io_grpc_grpc_stub': "io.grpc:grpc-stub:${libraries['version.io_grpc']}",
+      'maven.io_grpc_grpc_auth': "io.grpc:grpc-auth:${libraries['version.io_grpc']}",
+      'maven.io_grpc_grpc_protobuf': "io.grpc:grpc-protobuf:${libraries['version.io_grpc']}",
+      'maven.io_grpc_grpc_netty_shaded': "io.grpc:grpc-netty-shaded:${libraries['version.io_grpc']}",
+      'maven.io_grpc_grpc_alts': "io.grpc:grpc-alts:${libraries['version.io_grpc']}",
     ])
   }
 

--- a/gax-grpc/build.gradle
+++ b/gax-grpc/build.gradle
@@ -5,7 +5,6 @@ project.version = "1.42.1-SNAPSHOT" // {x-version-update:gax-grpc:current}
 
 dependencies {
   compile project(':gax'),
-    libraries['maven.io_grpc_grpc_bom'],
     libraries['maven.io_grpc_grpc_stub'],
     libraries['maven.io_grpc_grpc_auth'],
     libraries['maven.io_grpc_grpc_protobuf'],

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,5 +3,3 @@ include "gax-bom"
 include "gax-grpc"
 include "gax-httpjson"
 include "benchmark"
-// The following can be removed once gax-java migrates to Gradle 5.x
-enableFeaturePreview('IMPROVED_POM_SUPPORT')


### PR DESCRIPTION
The [reverted PR](https://github.com/googleapis/gax-java/pull/690) breaks "maven installable" artifacts (generated by `./gradlew publishToMavenLocal`), as it puts `bom` artifact (grpc-bom) into `<dependencies>` section (but must be put in `<dependenciesManagement>`). 

As result any library, which depends on `gax-grpc` cannot be compiled (maven would fail trying to download `jar` artifact for the specified `bom` dependency, because `bom` dependency does not provide `jar` artifact (it is just an .xml))