### PR TITLE
Update gRPC (and related opencensus dependencies) to v1.21.0

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -25,7 +25,7 @@ version.gax_httpjson=0.61.1-SNAPSHOT
 # with the sources.
 version.com_google_protobuf=3.7.1
 version.google_java_format=1.1
-version.io_grpc=1.20.0
+version.io_grpc=1.21.0
 
 # Maven artifacts.
 # Note, the actual name of each property matters (bazel build scripts depend on it).
@@ -36,9 +36,9 @@ maven.com_google_api_grpc_proto_google_common_protos=com.google.api.grpc:proto-g
 maven.com_google_api_grpc_grpc_google_common_protos=com.google.api.grpc:grpc-google-common-protos:1.14.0
 maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:0.15.0
 maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:0.15.0
-maven.io_opencensus_opencensus_api=io.opencensus:opencensus-api:0.19.2
-maven.io_opencensus_opencensus_contrib_grpc_metrics=io.opencensus:opencensus-contrib-grpc-metrics:0.19.2
-maven.io_opencensus_opencensus_contrib_http_util=io.opencensus:opencensus-contrib-http-util:0.19.2
+maven.io_opencensus_opencensus_api=io.opencensus:opencensus-api:0.21.0
+maven.io_opencensus_opencensus_contrib_grpc_metrics=io.opencensus:opencensus-contrib-grpc-metrics:0.21.0
+maven.io_opencensus_opencensus_contrib_http_util=io.opencensus:opencensus-contrib-http-util:0.21.0
 maven.com_google_code_gson_gson=com.google.code.gson:gson:2.7
 maven.com_google_guava_guava=com.google.guava:guava:26.0-android
 maven.com_google_code_findbugs_jsr305=com.google.code.findbugs:jsr305:3.0.2


### PR DESCRIPTION
This is needed to support bazel v0.25.0+