### PR TITLE
Annotating New Batcher interface with `@BetaApi`

### DIFF
--- a/gax/src/main/java/com/google/api/gax/batching/v2/Batcher.java
+++ b/gax/src/main/java/com/google/api/gax/batching/v2/Batcher.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.batching.v2;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.BetaApi;
 
 /**
  * Represents a batching context where individual elements will be accumulated and flushed in a
@@ -40,6 +41,7 @@ import com.google.api.core.ApiFuture;
  * @param <ElementT> The type of each individual element to be batched.
  * @param <ElementResultT> The type of the result for each individual element.
  */
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public interface Batcher<ElementT, ElementResultT> extends AutoCloseable {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/batching/v2/BatchingDescriptor.java
+++ b/gax/src/main/java/com/google/api/gax/batching/v2/BatchingDescriptor.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.batching.v2;
 
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.core.SettableApiFuture;
 import java.util.List;
 
@@ -81,6 +82,7 @@ import java.util.List;
  * @param <ResponseT> The type of the response that will be unpacked into individual element results
  */
 @BetaApi("The surface for batching is not stable yet and may change in the future.")
+@InternalExtensionOnly("For google-cloud-java client use only.")
 public interface BatchingDescriptor<ElementT, ElementResultT, RequestT, ResponseT> {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/batching/v2/BatchingDescriptor.java
+++ b/gax/src/main/java/com/google/api/gax/batching/v2/BatchingDescriptor.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.batching.v2;
 
+import com.google.api.core.BetaApi;
 import com.google.api.core.SettableApiFuture;
 import java.util.List;
 
@@ -79,6 +80,7 @@ import java.util.List;
  * @param <RequestT> The type of the request that will contain the accumulated elements
  * @param <ResponseT> The type of the response that will be unpacked into individual element results
  */
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public interface BatchingDescriptor<ElementT, ElementResultT, RequestT, ResponseT> {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/batching/v2/RequestBuilder.java
+++ b/gax/src/main/java/com/google/api/gax/batching/v2/RequestBuilder.java
@@ -29,6 +29,8 @@
  */
 package com.google.api.gax.batching.v2;
 
+import com.google.api.core.BetaApi;
+
 /**
  * Adapter to pack individual elements into a larger batch request.
  *
@@ -38,6 +40,7 @@ package com.google.api.gax.batching.v2;
  * @param <ElementT> The type of each individual element to be batched.
  * @param <RequestT> The type of the request that will contain the accumulated elements.
  */
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public interface RequestBuilder<ElementT, RequestT> {
 
   /** Adds element object into client specific batch request. */

--- a/gax/src/main/java/com/google/api/gax/batching/v2/RequestBuilder.java
+++ b/gax/src/main/java/com/google/api/gax/batching/v2/RequestBuilder.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.batching.v2;
 
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 
 /**
  * Adapter to pack individual elements into a larger batch request.
@@ -41,6 +42,7 @@ import com.google.api.core.BetaApi;
  * @param <RequestT> The type of the request that will contain the accumulated elements.
  */
 @BetaApi("The surface for batching is not stable yet and may change in the future.")
+@InternalExtensionOnly("For google-cloud-java client use only.")
 public interface RequestBuilder<ElementT, RequestT> {
 
   /** Adds element object into client specific batch request. */


### PR DESCRIPTION
This is a small followup of #692 for annotation in new Batcher API interfaces. 
