### PR TITLE
Update repository_rules.bzl

### DIFF
--- a/repository_rules.bzl
+++ b/repository_rules.bzl
@@ -31,7 +31,7 @@ def _com_google_api_gax_java_properties_impl(ctx):
     result = ctx.execute(["cat", props_path])
 
     if result.return_code != 0:
-        fail("Could not load dependencies from properties file, error_code %s" + result.return_code)
+        fail("Could not load dependencies from properties file, error_code %s" + str(result.return_code))
 
     props = result.stdout.splitlines()
     props_as_map = {}


### PR DESCRIPTION
Adding starlark string coercion to fix error: `unsupported operand type(s) for +: 'string' and 'int'`

## Discussion
This error hides the real error code when trying to read in the attributes file

I proced this error building the `//google/api:annotations_proto` rule in the `googleapis/googleapis`  repository. The api_annotations and swagger gen rules are used int the googleforgames/open-match project, whose protocol buffer rules I'm trying to run.