### PR TITLE
Disable gRPC ServiceConfig look up

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -229,6 +229,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     }
     builder =
         builder
+            .disableServiceConfigLookUp()
             .intercept(new GrpcChannelUUIDInterceptor())
             .intercept(headerInterceptor)
             .intercept(metadataHandlerInterceptor)

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -229,6 +229,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     }
     builder =
         builder
+            // See https://github.com/googleapis/gapic-generator/issues/2816
             .disableServiceConfigLookUp()
             .intercept(new GrpcChannelUUIDInterceptor())
             .intercept(headerInterceptor)


### PR DESCRIPTION
Disable resolution of the gRPC ServiceConfig from the DNS TXT records to prevent sudden duplication of retry logic should a service owner publish a RetryPolicy. More context in https://github.com/googleapis/gapic-generator/issues/2778.