### PR TITLE
Implementing ElementCount and ElementBytes Triggers

### DIFF
--- a/gax/src/main/java/com/google/api/gax/batching/v2/BatcherImpl.java
+++ b/gax/src/main/java/com/google/api/gax/batching/v2/BatcherImpl.java
@@ -70,6 +70,13 @@ public class BatcherImpl<ElementT, ElementResultT, RequestT, ResponseT>
   private final Object flushLock = new Object();
   private volatile boolean isClosed = false;
 
+  /**
+   * @param batchingDescriptor a {@link BatchingDescriptor} for transforming individual elements
+   *     into wrappers request and response.
+   * @param unaryCallable a {@link UnaryCallable} object.
+   * @param prototype a {@link RequestT} object.
+   * @param batchingSettings a {@link BatchingSettings} with configuration of thresholds.
+   */
   public BatcherImpl(
       BatchingDescriptor<ElementT, ElementResultT, RequestT, ResponseT> batchingDescriptor,
       UnaryCallable<RequestT, ResponseT> unaryCallable,

--- a/gax/src/main/java/com/google/api/gax/batching/v2/BatcherImpl.java
+++ b/gax/src/main/java/com/google/api/gax/batching/v2/BatcherImpl.java
@@ -55,7 +55,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @param <ResponseT> The type of the response that will unpack into individual element results.
  */
 @BetaApi("The surface for batching is not stable yet and may change in the future.")
-@InternalApi
+@InternalApi("For google-cloud-java client use only")
 public class BatcherImpl<ElementT, ElementResultT, RequestT, ResponseT>
     implements Batcher<ElementT, ElementResultT> {
 
@@ -225,7 +225,8 @@ public class BatcherImpl<ElementT, ElementResultT, RequestT, ResponseT>
     }
 
     boolean hasAnyThresholdReached() {
-      return elementCounter >= elementThreshold || byteCounter >= bytesThreshold;
+      return (elementThreshold != 0 && elementThreshold <= elementCounter)
+          || (bytesThreshold != 0 && bytesThreshold <= byteCounter);
     }
   }
 }

--- a/gax/src/main/java/com/google/api/gax/batching/v2/BatcherImpl.java
+++ b/gax/src/main/java/com/google/api/gax/batching/v2/BatcherImpl.java
@@ -225,8 +225,7 @@ public class BatcherImpl<ElementT, ElementResultT, RequestT, ResponseT>
     }
 
     boolean hasAnyThresholdReached() {
-      return (elementThreshold != 0 && elementThreshold <= elementCounter)
-          || (bytesThreshold != 0 && bytesThreshold <= byteCounter);
+      return elementCounter >= elementThreshold || byteCounter >= bytesThreshold;
     }
   }
 }

--- a/gax/src/main/java/com/google/api/gax/batching/v2/BatchingSettings.java
+++ b/gax/src/main/java/com/google/api/gax/batching/v2/BatchingSettings.java
@@ -40,9 +40,9 @@ import com.google.common.base.Preconditions;
  * would be the safest behavior for their jobs.
  *
  * <p>The default instance of this settings are configured to accept elements until either of the
- * threshold reaches {@link Long#MAX_VALUE}) or an explicit call to {@link Batcher#flush()} is made
- * or the {@link Batcher#close()} is called. Users are expected to configure actual batching
- * thresholds explicitly: the element count or the request bytes count.
+ * threshold reaches their defined value or an explicit call to {@link Batcher#flush()} is made or
+ * the {@link Batcher#close()} is called. Users are expected to configure actual batching thresholds
+ * explicitly: the element count or the request bytes count.
  *
  * <p>Warning: With the incorrect settings, it is possible to cause long periods of dead waiting
  * time.
@@ -58,7 +58,7 @@ import com.google.common.base.Preconditions;
  * <ul>
  *   <li><b>Message Count Threshold</b>: Once this many messages are queued, send all of the
  *       messages in a single call, even if the request byte threshold has not been exceed yet. The
- *       default value is {@link Long#MAX_VALUE} messages.
+ *       default value is {@link Integer#MAX_VALUE} messages.
  *   <li><b>Request Byte Threshold</b>: Once the number of bytes in the batched request reaches this
  *       threshold, send all of the messages in a single call, even if message count threshold has
  *       not been exceeded yet. The default value is {@link Long#MAX_VALUE} bytes.
@@ -72,7 +72,7 @@ import com.google.common.base.Preconditions;
 public abstract class BatchingSettings {
 
   /** Get the element count threshold to use for batching. */
-  public abstract long getElementCountThreshold();
+  public abstract int getElementCountThreshold();
 
   /** Get the request byte threshold to use for batching. */
   public abstract long getRequestByteThreshold();
@@ -80,7 +80,7 @@ public abstract class BatchingSettings {
   /** Get a new builder. */
   public static Builder newBuilder() {
     return new AutoValue_BatchingSettings.Builder()
-        .setElementCountThreshold(Long.MAX_VALUE)
+        .setElementCountThreshold(Integer.MAX_VALUE)
         .setRequestByteThreshold(Long.MAX_VALUE);
   }
 
@@ -97,7 +97,7 @@ public abstract class BatchingSettings {
      * Set the element count threshold to use for batching. After this many elements are
      * accumulated, they will be wrapped up in a batch and sent.
      */
-    public abstract Builder setElementCountThreshold(long elementCountThreshold);
+    public abstract Builder setElementCountThreshold(int elementCountThreshold);
 
     /**
      * Set the request byte threshold to use for batching. After this many bytes are accumulated,

--- a/gax/src/main/java/com/google/api/gax/batching/v2/BatchingSettings.java
+++ b/gax/src/main/java/com/google/api/gax/batching/v2/BatchingSettings.java
@@ -44,6 +44,8 @@ import com.google.common.base.Preconditions;
  * the {@link Batcher#close()} is called. Users are expected to configure actual batching thresholds
  * explicitly: the element count or the request bytes count.
  *
+ * <p>Element count and Request byte threshold can be disabled by setting it to 0.
+ *
  * <p>Warning: With the incorrect settings, it is possible to cause long periods of dead waiting
  * time.
  *
@@ -56,11 +58,11 @@ import com.google.common.base.Preconditions;
  * <p>There are several supported thresholds:
  *
  * <ul>
- *   <li><b>Message Count Threshold</b>: Once this many messages are queued, send all of the
- *       messages in a single call, even if the request byte threshold has not been exceed yet. The
- *       default value is {@link Integer#MAX_VALUE} messages.
+ *   <li><b>Element Count Threshold</b>: Once this many elements are queued, send all of the
+ *       elements in a single call, even if the request byte threshold has not been exceed yet. The
+ *       default value is {@link Integer#MAX_VALUE} elements.
  *   <li><b>Request Byte Threshold</b>: Once the number of bytes in the batched request reaches this
- *       threshold, send all of the messages in a single call, even if message count threshold has
+ *       threshold, send all of the elements in a single call, even if element count threshold has
  *       not been exceeded yet. The default value is {@link Long#MAX_VALUE} bytes.
  * </ul>
  *

--- a/gax/src/main/java/com/google/api/gax/batching/v2/BatchingSettings.java
+++ b/gax/src/main/java/com/google/api/gax/batching/v2/BatchingSettings.java
@@ -39,12 +39,9 @@ import com.google.common.base.Preconditions;
  * <p>Each batching client must define their own set of default values for these thresholds, which
  * would be the safest behavior for their jobs.
  *
- * <p>The default instance of this settings are configured to accept elements until either of the
- * threshold reaches their defined value or an explicit call to {@link Batcher#flush()} is made or
- * the {@link Batcher#close()} is called. Users are expected to configure actual batching thresholds
- * explicitly: the element count or the request bytes count.
- *
- * <p>Element count and Request byte threshold can be disabled by setting it to 0.
+ * <p>The default instance of this settings does not have any default values. Users are expected to
+ * configure batching thresholds explicitly: the element count or the request bytes count.
+ * Thresholds can be disabled(meaning immediate result of input elements) by setting its value to 0.
  *
  * <p>Warning: With the incorrect settings, it is possible to cause long periods of dead waiting
  * time.
@@ -59,11 +56,10 @@ import com.google.common.base.Preconditions;
  *
  * <ul>
  *   <li><b>Element Count Threshold</b>: Once this many elements are queued, send all of the
- *       elements in a single call, even if the request byte threshold has not been exceed yet. The
- *       default value is {@link Integer#MAX_VALUE} elements.
+ *       elements in a single call, even if the request byte threshold has not been exceed yet.
  *   <li><b>Request Byte Threshold</b>: Once the number of bytes in the batched request reaches this
  *       threshold, send all of the elements in a single call, even if element count threshold has
- *       not been exceeded yet. The default value is {@link Long#MAX_VALUE} bytes.
+ *       not been exceeded yet.
  * </ul>
  *
  * <p>These thresholds are treated as triggers, not as limits. Each threshold is an independent
@@ -81,9 +77,7 @@ public abstract class BatchingSettings {
 
   /** Get a new builder. */
   public static Builder newBuilder() {
-    return new AutoValue_BatchingSettings.Builder()
-        .setElementCountThreshold(Integer.MAX_VALUE)
-        .setRequestByteThreshold(Long.MAX_VALUE);
+    return new AutoValue_BatchingSettings.Builder();
   }
 
   /** Get a builder with the same values as this object. */

--- a/gax/src/main/java/com/google/api/gax/batching/v2/BatchingSettings.java
+++ b/gax/src/main/java/com/google/api/gax/batching/v2/BatchingSettings.java
@@ -111,9 +111,9 @@ public abstract class BatchingSettings {
     public BatchingSettings build() {
       BatchingSettings settings = autoBuild();
       Preconditions.checkState(
-          settings.getElementCountThreshold() > 0, "elementCountThreshold must be positive");
+          settings.getElementCountThreshold() >= 0, "elementCountThreshold cannot be negative");
       Preconditions.checkState(
-          settings.getRequestByteThreshold() > 0, "requestByteThreshold must be positive");
+          settings.getRequestByteThreshold() >= 0, "requestByteThreshold cannot be negative");
       return settings;
     }
   }

--- a/gax/src/main/java/com/google/api/gax/batching/v2/BatchingSettings.java
+++ b/gax/src/main/java/com/google/api/gax/batching/v2/BatchingSettings.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.batching.v2;
+
+import com.google.api.core.BetaApi;
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+
+/**
+ * Represents the batching settings to use for an API method that is capable of batching.
+ *
+ * <p>Each batching client must define their own set of default values for these thresholds, which
+ * would be the safest behavior for their jobs.
+ *
+ * <p>The default instance of this settings are configured to accept elements until either of the
+ * threshold reaches {@link Long#MAX_VALUE}) or an explicit call to {@link Batcher#flush()} is made
+ * or the {@link Batcher#close()} is called. Users are expected to configure actual batching
+ * thresholds explicitly: the element count or the request bytes count.
+ *
+ * <p>Warning: With the incorrect settings, it is possible to cause long periods of dead waiting
+ * time.
+ *
+ * <p>When batching is configured for an API method, a call to that method will result in the
+ * request being queued up with other requests. When any of the set thresholds are reached, the
+ * queued up requests are packaged together in a batch and set to the service as a single RPC. When
+ * the response comes back, it is split apart into individual responses according to the individual
+ * input requests.
+ *
+ * <p>There are several supported thresholds:
+ *
+ * <ul>
+ *   <li><b>Message Count Threshold</b>: Once this many messages are queued, send all of the
+ *       messages in a single call, even if the request byte threshold has not been exceed yet. The
+ *       default value is {@link Long#MAX_VALUE} messages.
+ *   <li><b>Request Byte Threshold</b>: Once the number of bytes in the batched request reaches this
+ *       threshold, send all of the messages in a single call, even if message count threshold has
+ *       not been exceeded yet. The default value is {@link Long#MAX_VALUE} bytes.
+ * </ul>
+ *
+ * <p>These thresholds are treated as triggers, not as limits. Each threshold is an independent
+ * trigger and doesn't have any knowledge of the other thresholds.
+ */
+@BetaApi("The surface for batching is not stable yet and may change in the future.")
+@AutoValue
+public abstract class BatchingSettings {
+
+  /** Get the element count threshold to use for batching. */
+  public abstract long getElementCountThreshold();
+
+  /** Get the request byte threshold to use for batching. */
+  public abstract long getRequestByteThreshold();
+
+  /** Get a new builder. */
+  public static Builder newBuilder() {
+    return new AutoValue_BatchingSettings.Builder()
+        .setElementCountThreshold(Long.MAX_VALUE)
+        .setRequestByteThreshold(Long.MAX_VALUE);
+  }
+
+  /** Get a builder with the same values as this object. */
+  public abstract Builder toBuilder();
+
+  /**
+   * See the class documentation of {@link BatchingSettings} for a description of the different
+   * values that can be set.
+   */
+  @AutoValue.Builder
+  public abstract static class Builder {
+    /**
+     * Set the element count threshold to use for batching. After this many elements are
+     * accumulated, they will be wrapped up in a batch and sent.
+     */
+    public abstract Builder setElementCountThreshold(long elementCountThreshold);
+
+    /**
+     * Set the request byte threshold to use for batching. After this many bytes are accumulated,
+     * the elements will be wrapped up in a batch and sent.
+     */
+    public abstract Builder setRequestByteThreshold(long requestByteThreshold);
+
+    abstract BatchingSettings autoBuild();
+
+    /** Build the BatchingSettings object. */
+    public BatchingSettings build() {
+      BatchingSettings settings = autoBuild();
+      Preconditions.checkState(
+          settings.getElementCountThreshold() > 0, "elementCountThreshold must be positive");
+      Preconditions.checkState(
+          settings.getRequestByteThreshold() > 0, "requestByteThreshold must be positive");
+      return settings;
+    }
+  }
+}

--- a/gax/src/test/java/com/google/api/gax/batching/v2/BatcherImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/v2/BatcherImplTest.java
@@ -81,9 +81,14 @@ public class BatcherImplTest {
   /** The accumulated results in the test are resolved when {@link Batcher#flush()} is called. */
   @Test
   public void testResultsAreResolvedAfterFlush() throws Exception {
+    BatchingSettings settings =
+        BatchingSettings.newBuilder()
+            .setElementCountThreshold(0)
+            .setRequestByteThreshold(0)
+            .build();
     underTest =
         new BatcherImpl<>(
-            SQUARER_BATCHING_DESC_V2, callLabeledIntSquarer, labeledIntList, batchingSettings);
+            SQUARER_BATCHING_DESC_V2, callLabeledIntSquarer, labeledIntList, settings);
     Future<Integer> result = underTest.add(4);
     assertThat(result.isDone()).isFalse();
     underTest.flush();
@@ -244,10 +249,10 @@ public class BatcherImplTest {
     underTest =
         new BatcherImpl<>(
             SQUARER_BATCHING_DESC_V2, callLabeledIntSquarer, labeledIntList, settings);
-    Future result = underTest.add(4);
+    Future<Integer> result = underTest.add(4);
     assertThat(result.isDone()).isFalse();
     // After this element is added, the batch triggers sendBatch().
-    Future anotherResult = underTest.add(5);
+    Future<Integer> anotherResult = underTest.add(5);
     // Both the elements should be resolved now.
     assertThat(result.isDone()).isTrue();
     assertThat(result.get()).isEqualTo(16);

--- a/gax/src/test/java/com/google/api/gax/batching/v2/BatcherImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/v2/BatcherImplTest.java
@@ -68,7 +68,7 @@ public class BatcherImplTest {
   private BatchingSettings batchingSettings =
       BatchingSettings.newBuilder()
           .setRequestByteThreshold(1000L)
-          .setElementCountThreshold(1000L)
+          .setElementCountThreshold(1000)
           .build();
 
   @After
@@ -230,7 +230,7 @@ public class BatcherImplTest {
 
   @Test
   public void testWhenElementCountExceeds() throws Exception {
-    BatchingSettings settings = batchingSettings.toBuilder().setElementCountThreshold(2L).build();
+    BatchingSettings settings = batchingSettings.toBuilder().setElementCountThreshold(2).build();
     testElementTriggers(settings);
   }
 

--- a/gax/src/test/java/com/google/api/gax/batching/v2/BatcherImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/v2/BatcherImplTest.java
@@ -46,6 +46,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,11 +65,25 @@ public class BatcherImplTest {
 
   private Batcher<Integer, Integer> underTest;
   private LabeledIntList labeledIntList = new LabeledIntList("Default");
+  private BatchingSettings batchingSettings =
+      BatchingSettings.newBuilder()
+          .setRequestByteThreshold(1000L)
+          .setElementCountThreshold(1000L)
+          .build();
+
+  @After
+  public void tearDown() throws InterruptedException {
+    if (underTest != null) {
+      underTest.close();
+    }
+  }
 
   /** The accumulated results in the test are resolved when {@link Batcher#flush()} is called. */
   @Test
   public void testResultsAreResolvedAfterFlush() throws Exception {
-    underTest = new BatcherImpl<>(SQUARER_BATCHING_DESC_V2, callLabeledIntSquarer, labeledIntList);
+    underTest =
+        new BatcherImpl<>(
+            SQUARER_BATCHING_DESC_V2, callLabeledIntSquarer, labeledIntList, batchingSettings);
     Future<Integer> result = underTest.add(4);
     assertThat(result.isDone()).isFalse();
     underTest.flush();
@@ -84,7 +99,8 @@ public class BatcherImplTest {
   public void testWhenBatcherIsClose() throws Exception {
     Future<Integer> result;
     try (Batcher<Integer, Integer> batcher =
-        new BatcherImpl<>(SQUARER_BATCHING_DESC_V2, callLabeledIntSquarer, labeledIntList)) {
+        new BatcherImpl<>(
+            SQUARER_BATCHING_DESC_V2, callLabeledIntSquarer, labeledIntList, batchingSettings)) {
       result = batcher.add(5);
     }
     assertThat(result.isDone()).isTrue();
@@ -94,7 +110,9 @@ public class BatcherImplTest {
   /** Validates exception when batch is called after {@link Batcher#close()}. */
   @Test
   public void testNoElementAdditionAfterClose() throws Exception {
-    underTest = new BatcherImpl<>(SQUARER_BATCHING_DESC_V2, callLabeledIntSquarer, labeledIntList);
+    underTest =
+        new BatcherImpl<>(
+            SQUARER_BATCHING_DESC_V2, callLabeledIntSquarer, labeledIntList, batchingSettings);
     underTest.close();
     Throwable actualError = null;
     try {
@@ -109,7 +127,9 @@ public class BatcherImplTest {
   /** Verifies unaryCallable is being called with a batch. */
   @Test
   public void testResultsAfterRPCSucceed() throws Exception {
-    underTest = new BatcherImpl<>(SQUARER_BATCHING_DESC_V2, mockUnaryCallable, labeledIntList);
+    underTest =
+        new BatcherImpl<>(
+            SQUARER_BATCHING_DESC_V2, mockUnaryCallable, labeledIntList, batchingSettings);
     when(mockUnaryCallable.futureCall(any(LabeledIntList.class)))
         .thenReturn(ApiFutures.immediateFuture(Arrays.asList(16, 25)));
 
@@ -126,7 +146,9 @@ public class BatcherImplTest {
   /** Verifies exception occurred at RPC is propagated to element results */
   @Test
   public void testResultFailureAfterRPCFailure() throws Exception {
-    underTest = new BatcherImpl<>(SQUARER_BATCHING_DESC_V2, mockUnaryCallable, labeledIntList);
+    underTest =
+        new BatcherImpl<>(
+            SQUARER_BATCHING_DESC_V2, mockUnaryCallable, labeledIntList, batchingSettings);
     final Exception fakeError = new RuntimeException();
 
     when(mockUnaryCallable.futureCall(any(LabeledIntList.class)))
@@ -149,7 +171,8 @@ public class BatcherImplTest {
   /** Resolves future results when {@link BatchingDescriptor#splitResponse} throws exception. */
   @Test
   public void testExceptionInDescriptor() throws InterruptedException {
-    underTest = new BatcherImpl<>(mockDescriptor, callLabeledIntSquarer, labeledIntList);
+    underTest =
+        new BatcherImpl<>(mockDescriptor, callLabeledIntSquarer, labeledIntList, batchingSettings);
 
     final RuntimeException fakeError = new RuntimeException("internal exception");
     when(mockDescriptor.newRequestBuilder(any(LabeledIntList.class)))
@@ -178,7 +201,8 @@ public class BatcherImplTest {
   /** Resolves future results when {@link BatchingDescriptor#splitException} throws exception */
   @Test
   public void testExceptionInDescriptorErrorHandling() throws InterruptedException {
-    underTest = new BatcherImpl<>(mockDescriptor, mockUnaryCallable, labeledIntList);
+    underTest =
+        new BatcherImpl<>(mockDescriptor, mockUnaryCallable, labeledIntList, batchingSettings);
 
     final RuntimeException fakeRpcError = new RuntimeException("RPC error");
     final RuntimeException fakeError = new RuntimeException("internal exception");
@@ -202,5 +226,31 @@ public class BatcherImplTest {
     assertThat(actualError.getCause()).isSameAs(fakeError);
     verify(mockDescriptor)
         .splitException(any(Throwable.class), Mockito.<SettableApiFuture<Integer>>anyList());
+  }
+
+  @Test
+  public void testWhenElementCountExceeds() throws Exception {
+    BatchingSettings settings = batchingSettings.toBuilder().setElementCountThreshold(2L).build();
+    testElementTriggers(settings);
+  }
+
+  @Test
+  public void testWhenElementBytesExceeds() throws Exception {
+    BatchingSettings settings = batchingSettings.toBuilder().setRequestByteThreshold(2L).build();
+    testElementTriggers(settings);
+  }
+
+  private void testElementTriggers(BatchingSettings settings) throws Exception {
+    underTest =
+        new BatcherImpl<>(
+            SQUARER_BATCHING_DESC_V2, callLabeledIntSquarer, labeledIntList, settings);
+    Future result = underTest.add(4);
+    assertThat(result.isDone()).isFalse();
+    // After this element is added, the batch triggers sendBatch().
+    Future anotherResult = underTest.add(5);
+    // Both the elements should be resolved now.
+    assertThat(result.isDone()).isTrue();
+    assertThat(result.get()).isEqualTo(16);
+    assertThat(anotherResult.isDone()).isTrue();
   }
 }


### PR DESCRIPTION
This is in continuation of follow up PR for new Batching API(#716)

***
### What This PR contains
Added two new thresholds in the `BatcherImpl.java` which will trigger automatic batch processing upon breach of any one of this threshold.
 - ElementCount: Number of elements queued up till now.
 - ElementBytes: Size in bytes of the accumulated elements.

A threshold would be added in BatcherImpl via `v2.BatchingSettings.java` and It will be calculated with the help of `BatchingThreshold.java`, `v2.ElementCounter.java` & `v2.NumericThreshold.java`.

_Note: Once this PR is merged, I would raise another followup PR with DelayThreshold/maxDelay._