### PR TITLE
Add Kokoro release config

### DIFF
--- a/.kokoro/release/common.cfg
+++ b/.kokoro/release/common.cfg
@@ -1,0 +1,49 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# Use the trampoline script to run in docker.
+build_file: "gax-java/.kokoro/trampoline.sh"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 70247
+      keyname: "maven-gpg-keyring"
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 70247
+      keyname: "maven-gpg-passphrase"
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 70247
+      keyname: "maven-gpg-pubkeyring"
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 70247
+      keyname: "sonatype-credentials"
+    }
+  }
+}

--- a/.kokoro/release/common.sh
+++ b/.kokoro/release/common.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+# Get secrets from keystore and set and environment variables
+setup_environment_secrets() {
+  export GPG_PASSPHRASE=$(cat ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-passphrase)
+  export GPG_TTY=$(tty)
+  export GPG_HOMEDIR=/gpg
+  mkdir $GPG_HOMEDIR
+  mv ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-pubkeyring $GPG_HOMEDIR/pubring.gpg
+  mv ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-keyring $GPG_HOMEDIR/secring.gpg
+  export GPG_KEY_ID=$(echo -n $(gpg --with-colons ${GPG_HOMEDIR}/pubring.gpg | awk -F':' '/pub/{ print $5 }'))
+  export SONATYPE_USERNAME=$(cat ${KOKORO_KEYSTORE_DIR}/70247_sonatype-credentials | cut -f1 -d'|')
+  export SONATYPE_PASSWORD=$(cat ${KOKORO_KEYSTORE_DIR}/70247_sonatype-credentials | cut -f2 -d'|')
+}
+
+create_gradle_properties_file() {
+  echo "
+signing.gnupg.executable=gpg
+signing.gnupg.homeDir=${GPG_HOMEDIR}
+signing.gnupg.keyName=${GPG_KEY_ID}
+signing.gnupg.passphrase=${GPG_PASSPHRASE}
+
+ossrhUsername=${SONATYPE_USERNAME}
+ossrhPassword=${SONATYPE_PASSWORD}" > $1
+}

--- a/.kokoro/release/drop.cfg
+++ b/.kokoro/release/drop.cfg
@@ -1,0 +1,5 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+ env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/gax-java/.kokoro/release/drop.sh"
+}

--- a/.kokoro/release/drop.sh
+++ b/.kokoro/release/drop.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+echo "This dropping a staged repo does not appear supported by the gradle-nexus-staging-plugin"
+exit 1

--- a/.kokoro/release/promote.cfg
+++ b/.kokoro/release/promote.cfg
@@ -1,0 +1,5 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+ env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/gax-java/.kokoro/release/promote.sh"
+}

--- a/.kokoro/release/promote.sh
+++ b/.kokoro/release/promote.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+# STAGING_REPOSITORY_ID must be set
+#if [ -z "${STAGING_REPOSITORY_ID}" ]; then
+#  echo "Missing STAGING_REPOSITORY_ID environment variable"
+#  exit 1
+#fi
+
+source $(dirname "$0")/common.sh
+pushd $(dirname "$0")/../../
+
+setup_environment_secrets
+mkdir -p ${HOME}/.gradle
+create_gradle_properties_file "${HOME}/.gradle/gradle.properties"
+
+./gradlew closeAndReleaseRepository

--- a/.kokoro/release/publish_javadoc.cfg
+++ b/.kokoro/release/publish_javadoc.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+env_vars: {
+    key: "STAGING_BUCKET"
+    value: "docs-staging"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/gax-java/.kokoro/release/publish_javadoc.sh"
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "docuploader_service_account"
+    }
+  }
+}

--- a/.kokoro/release/publish_javadoc.sh
+++ b/.kokoro/release/publish_javadoc.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+if [[ -z "${CREDENTIALS}" ]]; then
+  CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
+fi
+
+if [[ -z "${STAGING_BUCKET}" ]]; then
+  echo "Need to set STAGING_BUCKET environment variable"
+  exit 1
+fi
+
+# work from the git root directory
+pushd $(dirname "$0")/../../
+
+# install docuploader package
+python3 -m pip install gcp-docuploader
+
+NAME=gax
+VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
+
+# build the docs
+./gradlew javadocCombined
+
+pushd tmp_docs
+
+# create metadata
+python3 -m docuploader create-metadata \
+  --name ${NAME} \
+  --version ${VERSION} \
+  --language java
+
+# upload docs
+python3 -m docuploader upload . \
+  --credentials ${CREDENTIALS} \
+  --staging-bucket ${STAGING_BUCKET}
+
+popd

--- a/.kokoro/release/stage.cfg
+++ b/.kokoro/release/stage.cfg
@@ -1,0 +1,35 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+ env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/gax-java/.kokoro/release/stage.sh"
+}
+
+# Fetch the token needed for reporting release status to GitHub
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "yoshi-automation-github-key"
+    }
+  }
+}
+
+# Fetch magictoken to use with Magic Github Proxy
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "releasetool-magictoken"
+    }
+  }
+}
+
+# Fetch api key to use with Magic Github Proxy
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "magic-github-proxy-api-key"
+    }
+  }
+}

--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+if [[ -n "${AUTORELEASE_PR}" ]]
+then
+  # Start the releasetool reporter
+  python3 -m pip install gcp-releasetool
+  python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
+fi
+
+source $(dirname "$0")/common.sh
+MAVEN_SETTINGS_FILE=$(realpath $(dirname "$0")/../../)/settings.xml
+pushd $(dirname "$0")/../../
+
+setup_environment_secrets
+mkdir -p ${HOME}/.gradle
+create_gradle_properties_file "${HOME}/.gradle/gradle.properties"
+
+./gradlew assemble publish
+
+if [[ -n "${AUTORELEASE_PR}" ]]
+then
+  ./gradlew closeAndReleaseRepository
+fi

--- a/build.gradle
+++ b/build.gradle
@@ -329,6 +329,9 @@ subprojects {
 
     signing {
       if (!project.hasProperty('skip.signing') && !noDefaultPublications.contains(project.name)) {
+        if (project.hasProperty('signing.gnupg.executable')) {
+          useGpgCmd()
+        }
         sign publishing.publications.mavenJava
       }
     }

--- a/gax-bom/build.gradle
+++ b/gax-bom/build.gradle
@@ -95,6 +95,9 @@ afterEvaluate {
 
   signing {
     if (!project.hasProperty('skip.signing')) {
+      if (project.hasProperty('signing.gnupg.executable')) {
+        useGpgCmd()
+      }
       sign publishing.publications.mavenJava
     }
   }


### PR DESCRIPTION
* Creates release scripts and configuration for Kokoro
* Enables artifact signing via the gpg-agent if you add `signing.gnupg.executable` and related gradle configs
* On stage, we skip the javadocs and allow the publish javadocs job to handle pushing to googleapis.dev

This will also allow us to use autorelease on this repository.