### PR TITLE
Release gax-java v1.46.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,27 +31,27 @@ If you are using Maven, add this to your pom.xml file
 <dependency>
   <groupId>com.google.api</groupId>
   <artifactId>gax</artifactId>
-  <version>1.45.0</version>
+  <version>1.46.0</version>
 </dependency>
 <dependency>
   <groupId>com.google.api</groupId>
   <artifactId>gax-grpc</artifactId>
-  <version>1.45.0</version>
+  <version>1.46.0</version>
 </dependency>
 ```
 
 If you are using Gradle, add this to your dependencies
 
 ```Groovy
-compile 'com.google.api:gax:1.45.0',
-  'com.google.api:gax-grpc:1.45.0'
+compile 'com.google.api:gax:1.46.0',
+  'com.google.api:gax-grpc:1.46.0'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.api" % "gax" % "1.45.0"
-libraryDependencies += "com.google.api" % "gax-grpc" % "1.45.0"
+libraryDependencies += "com.google.api" % "gax" % "1.46.0"
+libraryDependencies += "com.google.api" % "gax-grpc" % "1.46.0"
 ```
 [//]: # ({x-version-update-end})
 

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -1,4 +1,4 @@
-project.version = "0.47.1-SNAPSHOT" // {x-version-update:benchmark:current}
+project.version = "0.48.0" // {x-version-update:benchmark:current}
 
 buildscript {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'com.github.sherter.google-java-format'
 apply plugin: 'io.codearte.nexus-staging'
 
 // TODO: Populate this from dependencies.properties version property (for proper Gradle-Bazel sync)
-project.version = "1.45.1-SNAPSHOT" // {x-version-update:gax:current}
+project.version = "1.46.0" // {x-version-update:gax:current}
 
 ext {
   // Project names not used for release

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -8,16 +8,16 @@
 
 # Versions of oneself
 # {x-version-update-start:gax:current}
-version.gax=1.45.1-SNAPSHOT
+version.gax=1.46.0
 # {x-version-update-end}
 # {x-version-update-start:gax:current}
-version.gax_grpc=1.45.1-SNAPSHOT
+version.gax_grpc=1.46.0
 # {x-version-update-end}
 # {x-version-update-start:gax:current}
-version.gax_bom=1.45.1-SNAPSHOT
+version.gax_bom=1.46.0
 # {x-version-update-end}
 # {x-version-update-start:gax-httpjson:current}
-version.gax_httpjson=0.62.1-SNAPSHOT
+version.gax_httpjson=0.63.0
 # {x-version-update-end}
 
 # Versions for dependencies which actual artifacts differ between Bazel and Gradle.

--- a/gax-bom/build.gradle
+++ b/gax-bom/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 archivesBaseName = "gax-bom"
 
-project.version = "1.45.1-SNAPSHOT" // {x-version-update:gax-bom:current}
+project.version = "1.46.0" // {x-version-update:gax-bom:current}
 
 ext {
   mavenJavaDir = "$project.buildDir/publications/mavenJava"

--- a/gax-bom/pom.xml
+++ b/gax-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api</groupId>
   <artifactId>gax-bom</artifactId>
-  <version>1.45.1-SNAPSHOT</version><!-- {x-version-update:gax-bom:current} -->
+  <version>1.46.0</version><!-- {x-version-update:gax-bom:current} -->
   <packaging>pom</packaging>
   <name>GAX (Google Api eXtensions) for Java</name>
   <description>Google Api eXtensions for Java</description>
@@ -33,34 +33,34 @@
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax</artifactId>
-        <version>1.45.1-SNAPSHOT</version><!-- {x-version-update:gax:current} -->
+        <version>1.46.0</version><!-- {x-version-update:gax:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax</artifactId>
-        <version>1.45.1-SNAPSHOT</version><!-- {x-version-update:gax:current} -->
+        <version>1.46.0</version><!-- {x-version-update:gax:current} -->
 	<classifier>testlib</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-grpc</artifactId>
-        <version>1.45.1-SNAPSHOT</version><!-- {x-version-update:gax-grpc:current} -->
+        <version>1.46.0</version><!-- {x-version-update:gax-grpc:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-grpc</artifactId>
-        <version>1.45.1-SNAPSHOT</version><!-- {x-version-update:gax-grpc:current} -->
+        <version>1.46.0</version><!-- {x-version-update:gax-grpc:current} -->
 	<classifier>testlib</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-httpjson</artifactId>
-        <version>0.62.1-SNAPSHOT</version><!-- {x-version-update:gax-httpjson:current} -->
+        <version>0.63.0</version><!-- {x-version-update:gax-httpjson:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-httpjson</artifactId>
-        <version>0.62.1-SNAPSHOT</version><!-- {x-version-update:gax-httpjson:current} -->
+        <version>0.63.0</version><!-- {x-version-update:gax-httpjson:current} -->
 	<classifier>testlib</classifier>
       </dependency>
     </dependencies>

--- a/gax-grpc/build.gradle
+++ b/gax-grpc/build.gradle
@@ -1,7 +1,7 @@
 archivesBaseName = "gax-grpc"
 
 // TODO: Populate this from dependencies.properties version property (for proper Gradle-Bazel sync)
-project.version = "1.45.1-SNAPSHOT" // {x-version-update:gax-grpc:current}
+project.version = "1.46.0" // {x-version-update:gax-grpc:current}
 
 dependencies {
   compile project(':gax'),

--- a/gax-httpjson/build.gradle
+++ b/gax-httpjson/build.gradle
@@ -1,7 +1,7 @@
 archivesBaseName = "gax-httpjson"
 
 // TODO: Populate this from dependencies.properties version property (for proper Gradle-Bazel sync)
-project.version = "0.62.1-SNAPSHOT" // {x-version-update:gax-httpjson:current}
+project.version = "0.63.0" // {x-version-update:gax-httpjson:current}
 
 dependencies {
   compile project(':gax'),

--- a/gax/build.gradle
+++ b/gax/build.gradle
@@ -1,7 +1,7 @@
 archivesBaseName = "gax"
 
 // TODO: Populate this from dependencies.properties version property (for proper Gradle-Bazel sync)
-project.version = "1.45.1-SNAPSHOT" // {x-version-update:gax:current}
+project.version = "1.46.0" // {x-version-update:gax:current}
 
 dependencies {
   compile libraries['maven.com_google_guava_guava'],

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -14,13 +14,13 @@
       <groupId>com.google.api</groupId>
       <artifactId>gax</artifactId>
       <!-- WARNING this is automatically populated by a build script, don't update manually -->
-      <version>1.45.1-SNAPSHOT</version><!-- {x-version-update:gax:current} -->
+      <version>1.46.0</version><!-- {x-version-update:gax:current} -->
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
       <!-- WARNING this is automatically populated by a build script, don't update manually -->
-      <version>1.45.1-SNAPSHOT</version><!-- {x-version-update:gax-grpc:current} -->
+      <version>1.46.0</version><!-- {x-version-update:gax-grpc:current} -->
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>

--- a/versions.txt
+++ b/versions.txt
@@ -1,8 +1,8 @@
 # Format:
 # module:released-version:current-version
 
-gax:1.45.0:1.45.1-SNAPSHOT
-gax-bom:1.45.0:1.45.1-SNAPSHOT
-gax-grpc:1.45.0:1.45.1-SNAPSHOT
-gax-httpjson:0.62.0:0.62.1-SNAPSHOT
-benchmark:0.47.0:0.47.1-SNAPSHOT
+gax:1.46.0:1.46.0
+gax-bom:1.46.0:1.46.0
+gax-grpc:1.46.0:1.46.0
+gax-httpjson:0.63.0:0.63.0
+benchmark:0.48.0:0.48.0


### PR DESCRIPTION
This pull request was generated using releasetool.

06-18-2019 14:20 PDT

### Implementation Changes
- Minor performance improvement to Distribution ([#733](https://github.com/googleapis/gax-java/pull/733))
- Disable gRPC ServiceConfig look up ([#731](https://github.com/googleapis/gax-java/pull/731))

### New Features
- Enable Direct Path
  - Use ComputeEngineChannelBuilder when directpath is enabled and default service account is used ([#707](https://github.com/googleapis/gax-java/pull/707))
  - Set keepalive timeout for directpath ([#729](https://github.com/googleapis/gax-java/pull/729))

### Dependencies
- Update dependency org.codehaus.mojo:build-helper-maven-plugin to v3 ([#727](https://github.com/googleapis/gax-java/pull/727))
- Update dependency org.apache.maven.plugins:maven-javadoc-plugin to v3 ([#726](https://github.com/googleapis/gax-java/pull/726))
- Update dependency org.easymock:easymock to v4 ([#728](https://github.com/googleapis/gax-java/pull/728))
- Update dependency com.google.auto.value:auto-value to v1.6.5 ([#720](https://github.com/googleapis/gax-java/pull/720))
- Add renovate.json ([#719](https://github.com/googleapis/gax-java/pull/719))

### Internal / Testing Changes
- Add Kokoro CI config ([#580](https://github.com/googleapis/gax-java/pull/580))
- Bump next snapshot ([#718](https://github.com/googleapis/gax-java/pull/718))