### PR TITLE
Fix default timeout for non-retryable operations

### DIFF
--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/TimeoutTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/TimeoutTest.java
@@ -69,8 +69,10 @@ import org.threeten.bp.Duration;
 public class TimeoutTest {
   private static final String CALL_OPTIONS_AUTHORITY = "RETRYING_TEST";
   private static final int DEADLINE_IN_DAYS = 7;
+  private static final int DEADLINE_IN_SECONDS = 20;
   private static final ImmutableSet<StatusCode.Code> emptyRetryCodes = ImmutableSet.of();
   private static final Duration totalTimeout = Duration.ofDays(DEADLINE_IN_DAYS);
+  private static final Duration singleRpcTimeout = Duration.ofSeconds(DEADLINE_IN_SECONDS);
 
   @Rule public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
   @Mock private Marshaller<String> stringMarshaller;
@@ -98,9 +100,9 @@ public class TimeoutTest {
             .setMaxRetryDelay(Duration.ZERO)
             .setMaxAttempts(1)
             .setJittered(true)
-            .setInitialRpcTimeout(totalTimeout)
+            .setInitialRpcTimeout(singleRpcTimeout)
             .setRpcTimeoutMultiplier(1.0)
-            .setMaxRpcTimeout(totalTimeout)
+            .setMaxRpcTimeout(singleRpcTimeout)
             .build();
   }
 

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/TimeoutTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/TimeoutTest.java
@@ -160,9 +160,9 @@ public class TimeoutTest {
 
     assertThat(callOptionsUsed.getDeadline()).isNotNull();
     assertThat(callOptionsUsed.getDeadline())
-        .isGreaterThan(Deadline.after(DEADLINE_IN_DAYS - 1, TimeUnit.DAYS));
+        .isGreaterThan(Deadline.after(DEADLINE_IN_SECONDS - 1, TimeUnit.SECONDS));
     assertThat(callOptionsUsed.getDeadline())
-        .isLessThan(Deadline.after(DEADLINE_IN_DAYS, TimeUnit.DAYS));
+        .isLessThan(Deadline.after(DEADLINE_IN_SECONDS, TimeUnit.SECONDS));
     assertThat(callOptionsUsed.getAuthority()).isEqualTo(CALL_OPTIONS_AUTHORITY);
   }
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -61,7 +61,7 @@ public class Callables {
           // When retries are disabled, the total timeout can be treated as the rpc timeout.
           clientContext
               .getDefaultCallContext()
-              .withTimeout(callSettings.getRetrySettings().getTotalTimeout()));
+              .withTimeout(callSettings.getRetrySettings().getMaxRpcTimeout()));
     }
 
     RetryAlgorithm<ResponseT> retryAlgorithm =
@@ -86,7 +86,7 @@ public class Callables {
       return innerCallable.withDefaultCallContext(
           clientContext
               .getDefaultCallContext()
-              .withTimeout(callSettings.getRetrySettings().getTotalTimeout()));
+              .withTimeout(callSettings.getRetrySettings().getMaxRpcTimeout()));
     }
 
     StreamingRetryAlgorithm<Void> retryAlgorithm =

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -110,7 +110,6 @@ public class Callables {
    * configuration most likely does not belong in retry settings and may change in the future.
    */
   static Duration singleRpcCallTimeout(RetrySettings retrySettings) {
-    System.out.println(retrySettings);
     // Prefer initialRpcTimeout, then maxRpcTimeout, then totalTimeout
     Duration duration = retrySettings.getInitialRpcTimeout();
     if (!duration.equals(Duration.ZERO)) {

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -39,6 +39,7 @@ import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.retrying.ScheduledRetryingExecutor;
 import com.google.api.gax.retrying.StreamingRetryAlgorithm;
 import java.util.Collection;
+import org.threeten.bp.Duration;
 
 /**
  * Class with utility methods to create callable objects using provided settings.
@@ -57,11 +58,12 @@ public class Callables {
       ClientContext clientContext) {
 
     if (areRetriesDisabled(callSettings.getRetryableCodes(), callSettings.getRetrySettings())) {
+      // When retries are disabled, the choose a timeout from the retrying settings to use as the
+      // timeout for the single rpc call.
       return innerCallable.withDefaultCallContext(
-          // When retries are disabled, the total timeout can be treated as the rpc timeout.
           clientContext
               .getDefaultCallContext()
-              .withTimeout(callSettings.getRetrySettings().getMaxRpcTimeout()));
+              .withTimeout(singleRpcCallTimeout(callSettings.getRetrySettings())));
     }
 
     RetryAlgorithm<ResponseT> retryAlgorithm =
@@ -82,11 +84,12 @@ public class Callables {
       ClientContext clientContext) {
 
     if (areRetriesDisabled(callSettings.getRetryableCodes(), callSettings.getRetrySettings())) {
-      // When retries are disabled, the total timeout can be treated as the rpc timeout.
+      // When retries are disabled, the choose a timeout from the retrying settings to use as the
+      // timeout for the single rpc call.
       return innerCallable.withDefaultCallContext(
           clientContext
               .getDefaultCallContext()
-              .withTimeout(callSettings.getRetrySettings().getMaxRpcTimeout()));
+              .withTimeout(singleRpcCallTimeout(callSettings.getRetrySettings())));
     }
 
     StreamingRetryAlgorithm<Void> retryAlgorithm =
@@ -100,6 +103,24 @@ public class Callables {
 
     return new RetryingServerStreamingCallable<>(
         innerCallable, retryingExecutor, callSettings.getResumptionStrategy());
+  }
+
+  /*
+   * Returns the default Duration for a single RPC call given a Callable's RetrySettings. This
+   * configuration most likely does not belong in retry settings and may change in the future.
+   */
+  static Duration singleRpcCallTimeout(RetrySettings retrySettings) {
+    System.out.println(retrySettings);
+    // Prefer initialRpcTimeout, then maxRpcTimeout, then totalTimeout
+    Duration duration = retrySettings.getInitialRpcTimeout();
+    if (!duration.equals(Duration.ZERO)) {
+      return duration;
+    }
+    duration = retrySettings.getMaxRpcTimeout();
+    if (!duration.equals(Duration.ZERO)) {
+      return duration;
+    }
+    return retrySettings.getTotalTimeout();
   }
 
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -112,11 +112,11 @@ public class Callables {
   static Duration singleRpcCallTimeout(RetrySettings retrySettings) {
     // Prefer initialRpcTimeout, then maxRpcTimeout, then totalTimeout
     Duration duration = retrySettings.getInitialRpcTimeout();
-    if (!duration.equals(Duration.ZERO)) {
+    if (!duration.isZero()) {
       return duration;
     }
     duration = retrySettings.getMaxRpcTimeout();
-    if (!duration.equals(Duration.ZERO)) {
+    if (!duration.isZero()) {
       return duration;
     }
     return retrySettings.getTotalTimeout();


### PR DESCRIPTION
We should prefer an individual timeout configured for the RPC call over the totalTimeout setting for non-retryable RPC calls.

Fixes https://github.com/googleapis/google-cloud-java/issues/5555