### PR TITLE
oauth 0.16.2

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -34,8 +34,8 @@ version.io_grpc=1.21.0
 #   2) Replace all characters which are neither alphabetic nor digits with the underscore ('_') character
 maven.com_google_api_grpc_proto_google_common_protos=com.google.api.grpc:proto-google-common-protos:1.15.0
 maven.com_google_api_grpc_grpc_google_common_protos=com.google.api.grpc:grpc-google-common-protos:1.15.0
-maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:0.16.1
-maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:0.16.1
+maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:0.16.2
+maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:0.16.2
 maven.io_opencensus_opencensus_api=io.opencensus:opencensus-api:0.21.0
 maven.io_opencensus_opencensus_contrib_grpc_metrics=io.opencensus:opencensus-contrib-grpc-metrics:0.21.0
 maven.io_opencensus_opencensus_contrib_http_util=io.opencensus:opencensus-contrib-http-util:0.21.0


### PR DESCRIPTION
@chingor13 google-cloud-java 0.98.0 has gotten ahead of GAX, again. We should try to push another release of GAX and integrate it into google-cloud-java before we make any other dependency changes in google-cloud-java.

```
+-com.google.cloud.tools.opensource:upper-bounds-check:2.0.0-SNAPSHOT
  +-com.google.cloud:google-cloud-storage:1.80.0
    +-com.google.cloud:google-cloud-core-http:1.80.0
      +-com.google.auth:google-auth-library-oauth2-http:0.16.2
```
