### PR TITLE
Fix Bazel build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,3 +12,6 @@ load("//:repositories.bzl", "com_google_api_gax_java_repositories")
 
 com_google_api_gax_java_repositories()
 
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -58,6 +58,18 @@ maven.org_apache_commons_commons_lang3=org.apache.commons:commons-lang3:3.6
 maven.javax_annotation_javax_annotation_api=javax.annotation:javax.annotation-api:1.2
 maven.com_google_guava_failureaccess=com.google.guava:failureaccess:1.0.1
 maven.com_google_android_annotations=com.google.android:annotations:4.1.1.4
+maven.io_perfmark_perfmark_api=io.perfmark:perfmark-api:0.17.0
+maven.io_netty_netty_handler=io.netty:netty-handler:4.1.38.Final
+maven.io_netty_netty_common=io.netty:netty-common:4.1.38.Final
+maven.io_netty_netty_transport=io.netty:netty-transport:4.1.38.Final
+maven.io_netty_netty_codec=io.netty:netty-codec:4.1.38.Final
+maven.io_netty_netty_buffer=io.netty:netty-buffer:4.1.38.Final
+maven.io_netty_netty_codec_http=io.netty:netty-codec-http:4.1.38.Final
+maven.io_netty_netty_codec_http2=io.netty:netty-codec-http2:4.1.38.Final
+maven.io_netty_netty_codec_socks=io.netty:netty-codec-socks:4.1.38.Final
+maven.io_netty_netty_handler_proxy=io.netty:netty-handler-proxy:4.1.38.Final
+maven.io_netty_netty_resolver=io.netty:netty-resolver:4.1.38.Final
+maven.io_netty_netty_tcnative_boringssl_static=io.netty:netty-tcnative-boringssl-static:2.0.25.Final
 
 # Testing maven artifacts
 maven.junit_junit=junit:junit:4.12

--- a/gax-grpc/BUILD.bazel
+++ b/gax-grpc/BUILD.bazel
@@ -24,6 +24,8 @@ _COMPILE_DEPS = [
     "@com_google_http_client_google_http_client//jar",
     "@io_grpc_grpc_java//context:context",
     "@io_grpc_grpc_netty_shaded//jar",
+    "@io_grpc_grpc_java//alts:alts",
+    "@io_netty_netty_tcnative_boringssl_static//jar",
     "//gax:gax",
 ]
 

--- a/gax/BUILD.bazel
+++ b/gax/BUILD.bazel
@@ -21,6 +21,7 @@ _COMPILE_DEPS = [
     "@com_google_http_client_google_http_client//jar",
     "@com_google_http_client_google_http_client_jackson2//jar",
     "@com_fasterxml_jackson_core_jackson_core//jar",
+    "@com_google_guava_failureaccess//jar",
 ]
 
 _TEST_COMPILE_DEPS = [

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamTest.java
@@ -148,7 +148,7 @@ public class ServerStreamTest {
 
     Throwable actualError = null;
     try {
-      Lists.newArrayList(stream);
+      Truth.assertThat(Lists.newArrayList(stream)).isNotNull();
     } catch (Throwable t) {
       actualError = t;
     }

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -70,14 +70,6 @@ def com_google_api_gax_java_repositories():
     )
 
     _maybe(
-        http_archive,
-        name = "net_zlib",
-        build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-        strip_prefix = "zlib-1.2.11",
-        urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
-    )
-
-    _maybe(
         native.maven_jar,
         name = "io_grpc_grpc_netty_shaded",
         artifact = "io.grpc:grpc-netty-shaded:%s" % PROPERTIES["version.io_grpc"],
@@ -99,12 +91,6 @@ def com_google_api_gax_java_repositories():
         native.bind,
         name = "gson",
         actual = "@com_google_code_gson_gson//jar",
-    )
-
-    _maybe(
-        native.bind,
-        name = "zlib",
-        actual = "@net_zlib//:zlib",
     )
 
     _maybe(


### PR DESCRIPTION
The issues were caused mostly by the upgrade to protobuf 3.9.1 and grpc 1.23.0.

The extended list of dependencies (`netty_*`) is caused by one of the recent changes (https://github.com/googleapis/gax-java/pull/707/files#diff-25ba434a47d99bcc0b998965a298661cR47).

Bazel does not support automatic transitive dependencies resolution, that is why it had to be added explicitly.

TODO: Add CircleCI bazel build job, to avoid this breakages in the future.