### PR TITLE
update google-auth-library to 0.17.1

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -34,8 +34,8 @@ version.io_grpc=1.23.0
 #   2) Replace all characters which are neither alphabetic nor digits with the underscore ('_') character
 maven.com_google_api_grpc_proto_google_common_protos=com.google.api.grpc:proto-google-common-protos:1.15.0
 maven.com_google_api_grpc_grpc_google_common_protos=com.google.api.grpc:grpc-google-common-protos:1.15.0
-maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:0.17.0
-maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:0.17.0
+maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:0.17.1
+maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:0.17.1
 maven.io_opencensus_opencensus_api=io.opencensus:opencensus-api:0.23.0
 maven.io_opencensus_opencensus_contrib_grpc_metrics=io.opencensus:opencensus-contrib-grpc-metrics:0.23.0
 maven.io_opencensus_opencensus_contrib_http_util=io.opencensus:opencensus-contrib-http-util:0.23.0


### PR DESCRIPTION
0.17.1 fixed a regression that disallowed JWT credentials without privateKeyId