### PR TITLE
Fix Race condition when shutting down executor/transport channel

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -76,5 +76,6 @@ maven.junit_junit=junit:junit:4.12
 maven.org_mockito_mockito_core=org.mockito:mockito-core:2.21.0
 maven.org_hamcrest_hamcrest_core=org.hamcrest:hamcrest-core:1.3
 maven.com_google_truth_truth=com.google.truth:truth:0.44
+maven.com_googlecode_java_diff_utils_diffutils=com.googlecode.java-diff-utils:diffutils:1.3.0
 maven.net_bytebuddy_byte_buddy=net.bytebuddy:byte-buddy:1.8.15
 maven.org_objenesis_objenesis=org.objenesis:objenesis:2.6

--- a/gax-grpc/BUILD.bazel
+++ b/gax-grpc/BUILD.bazel
@@ -37,6 +37,7 @@ _TEST_COMPILE_DEPS = [
     "@com_google_api_grpc_grpc_google_common_protos//jar",
     "@org_apache_commons_commons_lang3//jar",
     "//gax:gax_testlib",
+    "@com_googlecode_java_diff_utils_diffutils//jar",
 ]
 
 java_library(

--- a/gax-httpjson/BUILD.bazel
+++ b/gax-httpjson/BUILD.bazel
@@ -26,6 +26,7 @@ _TEST_COMPILE_DEPS = [
     "@org_mockito_mockito_core//jar",
     "@com_google_truth_truth//jar",
     "//gax:gax_testlib",
+   "@com_googlecode_java_diff_utils_diffutils//jar",
 ]
 
 java_library(

--- a/gax/BUILD.bazel
+++ b/gax/BUILD.bazel
@@ -31,6 +31,7 @@ _TEST_COMPILE_DEPS = [
     "@org_hamcrest_hamcrest_core//jar",
     "@net_bytebuddy_byte_buddy//jar",
     "@org_objenesis_objenesis//jar",
+    "@com_googlecode_java_diff_utils_diffutils//jar",
 ]
 
 java_library(


### PR DESCRIPTION
This fixes the customer issue ("transitively"): https://github.com/googleapis/gax-java/issues/785

This PR only changes the order of shutdowns (first transportChannel and only then the Executor). This the most lightweight fix we can make, which should fix the issue. We would like to avoid enforcing `awaitTermination()` on `shutdown()` because that would convert non-blocking call (`shutdown()`) to a blocking one with great potential of having non-desirable side-effects. Also this may potentially require surface changes on gax (potentially requiring major version bump on gax), because currently `shutdown()` is widely used, it is declared in a public interface and is explicitly specified as non-blocking operation.