### PR TITLE
Fix InstantiatingGrpcChannelProvider's channel pool to play nicely with DirectPath

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -42,6 +42,7 @@ import com.google.auth.Credentials;
 import com.google.auth.oauth2.ComputeEngineCredentials;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.alts.ComputeEngineChannelBuilder;
@@ -238,6 +239,21 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
       // Will be overridden by user defined values if any.
       builder.keepAliveTime(DIRECT_PATH_KEEP_ALIVE_TIME_SECONDS, TimeUnit.SECONDS);
       builder.keepAliveTimeout(DIRECT_PATH_KEEP_ALIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+      // When channel pooling is enabled, force the pick_first grpclb strategy.
+      // This is necessary to avoid the multiplicative effect of creating channel pool with
+      // `poolSize` number of  `ManagedChannel`s, each with a `subSetting` number of number of subchannels.
+      if (poolSize > 1) {
+        builder.defaultServiceConfig(
+            ImmutableMap.of(
+                "loadBalancingConfig",
+                ImmutableList.of(
+                    ImmutableMap.of(
+                        "grpclb",
+                        ImmutableMap.of(
+                            "childPolicy",
+                            ImmutableList.of(ImmutableMap.of("pick_first", ImmutableMap.of())))))));
+      }
     } else {
       builder = ManagedChannelBuilder.forAddress(serviceAddress, port);
     }


### PR DESCRIPTION
// cc @WeiranFang

By default grpclb strategy for DirectPath is to create a subchannel for
every address resolved by the grpclb and round robin over them.
Unfortunately this doesn't work well when Channel pooling is enable in
the InstantiatingGrpcChannelProvider, which will create multiple
ManagedChannels, each containing a bunch of subchannels.

Since channel pooling is needed to have good performance targeting CFEs,
the solution here is to force each ManagedChannel to pick a single
subchannel. Thus preserving the CFE behavior of a single ManagedChannel
only containing a single subchannel.