### PR TITLE
Create a executorService with a separate pool of threads for channelpool

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelPool.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelPool.java
@@ -50,6 +50,7 @@ import javax.annotation.Nullable;
  * <p>Package-private for internal use.
  */
 class ChannelPool extends ManagedChannel {
+  private static final int EXECUTOR_THREAD_POOL_SIZE = 2;
   private final ImmutableList<ManagedChannel> channels;
   private final AtomicInteger indexTicker = new AtomicInteger();
   private final String authority;
@@ -100,7 +101,7 @@ class ChannelPool extends ManagedChannel {
    */
   static ChannelPool createRefreshing(int poolSize, final ChannelFactory channelFactory)
       throws IOException {
-    return createRefreshing(poolSize, channelFactory, Executors.newScheduledThreadPool(2));
+    return createRefreshing(poolSize, channelFactory, Executors.newScheduledThreadPool(EXECUTOR_THREAD_POOL_SIZE));
   }
 
   /**
@@ -118,7 +119,7 @@ class ChannelPool extends ManagedChannel {
    * @param channels a List of channels to pool.
    * @param executorService periodically refreshes the channels
    */
-  private ChannelPool(List<ManagedChannel> channels, ScheduledExecutorService executorService) {
+  private ChannelPool(List<ManagedChannel> channels, @Nullable ScheduledExecutorService executorService) {
     this.channels = ImmutableList.copyOf(channels);
     authority = channels.get(0).authority();
     this.executorService = executorService;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelPool.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelPool.java
@@ -101,7 +101,8 @@ class ChannelPool extends ManagedChannel {
    */
   static ChannelPool createRefreshing(int poolSize, final ChannelFactory channelFactory)
       throws IOException {
-    return createRefreshing(poolSize, channelFactory, Executors.newScheduledThreadPool(EXECUTOR_THREAD_POOL_SIZE));
+    return createRefreshing(
+        poolSize, channelFactory, Executors.newScheduledThreadPool(EXECUTOR_THREAD_POOL_SIZE));
   }
 
   /**
@@ -119,7 +120,8 @@ class ChannelPool extends ManagedChannel {
    * @param channels a List of channels to pool.
    * @param executorService periodically refreshes the channels
    */
-  private ChannelPool(List<ManagedChannel> channels, @Nullable ScheduledExecutorService executorService) {
+  private ChannelPool(
+      List<ManagedChannel> channels, @Nullable ScheduledExecutorService executorService) {
     this.channels = ImmutableList.copyOf(channels);
     authority = channels.get(0).authority();
     this.executorService = executorService;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelPool.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelPool.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.grpc;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
@@ -37,6 +38,7 @@ import io.grpc.MethodDescriptor;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -71,11 +73,14 @@ class ChannelPool extends ManagedChannel {
   /**
    * Factory method to create a refreshing channel pool
    *
+   * <p>Package-private for testing purposes only
+   *
    * @param poolSize number of channels in the pool
    * @param channelFactory method to create the channels
    * @param executorService periodically refreshes the channels
    * @return ChannelPool of refreshing channels
    */
+  @VisibleForTesting
   static ChannelPool createRefreshing(
       int poolSize, final ChannelFactory channelFactory, ScheduledExecutorService executorService)
       throws IOException {
@@ -84,6 +89,18 @@ class ChannelPool extends ManagedChannel {
       channels.add(new RefreshingManagedChannel(channelFactory, executorService));
     }
     return new ChannelPool(channels, executorService);
+  }
+
+  /**
+   * Factory method to create a refreshing channel pool
+   *
+   * @param poolSize number of channels in the pool
+   * @param channelFactory method to create the channels
+   * @return ChannelPool of refreshing channels
+   */
+  static ChannelPool createRefreshing(int poolSize, final ChannelFactory channelFactory)
+      throws IOException {
+    return createRefreshing(poolSize, channelFactory, Executors.newScheduledThreadPool(2));
   }
 
   /**

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -50,6 +50,7 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.alts.ComputeEngineChannelBuilder;
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -206,7 +207,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     if (channelPrimer != null) {
       outerChannel =
           ChannelPool.createRefreshing(
-              realPoolSize, channelFactory, executorProvider.getExecutor());
+              realPoolSize, channelFactory, Executors.newScheduledThreadPool(2));
     } else {
       outerChannel = ChannelPool.create(realPoolSize, channelFactory);
     }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -50,7 +50,6 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.alts.ComputeEngineChannelBuilder;
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -205,9 +204,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
         };
     ManagedChannel outerChannel;
     if (channelPrimer != null) {
-      outerChannel =
-          ChannelPool.createRefreshing(
-              realPoolSize, channelFactory, Executors.newScheduledThreadPool(2));
+      outerChannel = ChannelPool.createRefreshing(realPoolSize, channelFactory);
     } else {
       outerChannel = ChannelPool.create(realPoolSize, channelFactory);
     }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
@@ -364,6 +364,8 @@ public class InstantiatingGrpcChannelProviderTest {
   // Test that if ChannelPrimer is provided, it is called during creation
   @Test
   public void testWithPrimeChannel() throws IOException {
+    // create channelProvider with different pool sizes to verify ChannelPrimer is called the
+    // correct number of times
     for (int poolSize = 1; poolSize < 5; poolSize++) {
       final ChannelPrimer mockChannelPrimer = Mockito.mock(ChannelPrimer.class);
 

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
@@ -36,7 +36,6 @@ import static org.junit.Assert.fail;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.gax.core.ExecutorProvider;
-import com.google.api.gax.core.FixedExecutorProvider;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.Builder;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.EnvironmentProvider;
 import com.google.api.gax.rpc.HeaderProvider;
@@ -47,20 +46,14 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.alts.ComputeEngineChannelBuilder;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
@@ -368,52 +361,26 @@ public class InstantiatingGrpcChannelProviderTest {
     provider.getTransportChannel().shutdownNow();
   }
 
-  // Test that if ChannelPrimer is provided, it is called during creation and periodically
+  // Test that if ChannelPrimer is provided, it is called during creation
   @Test
   public void testWithPrimeChannel() throws IOException {
+    for (int poolSize = 1; poolSize < 5; poolSize++) {
+      final ChannelPrimer mockChannelPrimer = Mockito.mock(ChannelPrimer.class);
 
-    final ChannelPrimer mockChannelPrimer = Mockito.mock(ChannelPrimer.class);
-    final List<Runnable> channelRefreshers = new ArrayList<>();
+      InstantiatingGrpcChannelProvider provider =
+          InstantiatingGrpcChannelProvider.newBuilder()
+              .setEndpoint("localhost:8080")
+              .setPoolSize(poolSize)
+              .setHeaderProvider(Mockito.mock(HeaderProvider.class))
+              .setExecutorProvider(Mockito.mock(ExecutorProvider.class))
+              .setChannelPrimer(mockChannelPrimer)
+              .build();
 
-    ScheduledExecutorService scheduledExecutorService =
-        Mockito.mock(ScheduledExecutorService.class);
+      provider.getTransportChannel().shutdownNow();
 
-    Answer extractChannelRefresher =
-        new Answer() {
-          public Object answer(InvocationOnMock invocation) {
-            channelRefreshers.add((Runnable) invocation.getArgument(0));
-            return Mockito.mock(ScheduledFuture.class);
-          }
-        };
-
-    Mockito.doAnswer(extractChannelRefresher)
-        .when(scheduledExecutorService)
-        .schedule(
-            Mockito.any(Runnable.class), Mockito.anyLong(), Mockito.eq(TimeUnit.MILLISECONDS));
-
-    InstantiatingGrpcChannelProvider provider =
-        InstantiatingGrpcChannelProvider.newBuilder()
-            .setEndpoint("localhost:8080")
-            .setPoolSize(2)
-            .setHeaderProvider(Mockito.mock(HeaderProvider.class))
-            .setExecutorProvider(FixedExecutorProvider.create(scheduledExecutorService))
-            .setChannelPrimer(mockChannelPrimer)
-            .build();
-
-    provider.getTransportChannel().shutdownNow();
-
-    // 2 calls during the creation, 2 more calls when they get scheduled
-    Mockito.verify(mockChannelPrimer, Mockito.times(2))
-        .primeChannel(Mockito.any(ManagedChannel.class));
-    assertThat(channelRefreshers).hasSize(2);
-    Mockito.verify(scheduledExecutorService, Mockito.times(2))
-        .schedule(
-            Mockito.any(Runnable.class), Mockito.anyLong(), Mockito.eq(TimeUnit.MILLISECONDS));
-    channelRefreshers.get(0).run();
-    Mockito.verify(mockChannelPrimer, Mockito.times(3))
-        .primeChannel(Mockito.any(ManagedChannel.class));
-    channelRefreshers.get(1).run();
-    Mockito.verify(mockChannelPrimer, Mockito.times(4))
-        .primeChannel(Mockito.any(ManagedChannel.class));
+      // every channel in the pool should call primeChannel during creation.
+      Mockito.verify(mockChannelPrimer, Mockito.times(poolSize))
+          .primeChannel(Mockito.any(ManagedChannel.class));
+    }
   }
 }


### PR DESCRIPTION
Refreshing ChannelPool shares the executorService with gRPC. This could lead to undesirable behaviour. If it takes a while (a few seconds) to refresh a channel and many channels are being refreshed at the same time, it could occupy all the threads in the executorService and starve gRPC from using them.

Proposed is to create a separate executorService with its own pools of threads. It shouldn't need many threads to refresh the channels.