### PR TITLE
build: google format plugin upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,10 +139,6 @@ subprojects {
     shadowNoGuava
   }
 
-  jacoco {
-    toolVersion = "0.8.2+" // For Java 11
-  }
-
   jacocoTestReport {
     reports {
       xml.enabled true

--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,10 @@ subprojects {
     shadowNoGuava
   }
 
+  jacoco {
+    toolVersion = "0.8.2+" // For Java 11
+  }
+
   jacocoTestReport {
     reports {
       xml.enabled true

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
       "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.8.0",
       "gradle.plugin.com.dorongold.plugins:task-tree:1.3.1"
 
-    classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.6"
+    classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.8"
   }
 }
 
@@ -53,6 +53,10 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 allprojects {
+  repositories {
+    mavenCentral() // for google-java-format's dependency
+  }
+
   // Formatting tasks
   // ================
   apply plugin: 'com.github.sherter.google-java-format'

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -249,7 +249,8 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
 
       // When channel pooling is enabled, force the pick_first grpclb strategy.
       // This is necessary to avoid the multiplicative effect of creating channel pool with
-      // `poolSize` number of `ManagedChannel`s, each with a `subSetting` number of number of subchannels.
+      // `poolSize` number of `ManagedChannel`s, each with a `subSetting` number of number of
+      // subchannels.
       // See the service config proto definition for more details:
       // https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto#L182
       ImmutableMap<String, Object> pickFirstStrategy =

--- a/gax-grpc/src/main/java/com/google/longrunning/OperationsClient.java
+++ b/gax-grpc/src/main/java/com/google/longrunning/OperationsClient.java
@@ -551,7 +551,10 @@ public class OperationsClient implements BackgroundResource {
 
   public static class ListOperationsPagedResponse
       extends AbstractPagedListResponse<
-          ListOperationsRequest, ListOperationsResponse, Operation, ListOperationsPage,
+          ListOperationsRequest,
+          ListOperationsResponse,
+          Operation,
+          ListOperationsPage,
           ListOperationsFixedSizeCollection> {
 
     public static ApiFuture<ListOperationsPagedResponse> createAsync(
@@ -606,7 +609,10 @@ public class OperationsClient implements BackgroundResource {
 
   public static class ListOperationsFixedSizeCollection
       extends AbstractFixedSizeCollection<
-          ListOperationsRequest, ListOperationsResponse, Operation, ListOperationsPage,
+          ListOperationsRequest,
+          ListOperationsResponse,
+          Operation,
+          ListOperationsPage,
           ListOperationsFixedSizeCollection> {
 
     private ListOperationsFixedSizeCollection(List<ListOperationsPage> pages, int collectionSize) {

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/RefreshingManagedChannelTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/RefreshingManagedChannelTest.java
@@ -166,7 +166,8 @@ public class RefreshingManagedChannelTest {
     final ManagedChannel refreshingManagedChannel =
         new RefreshingManagedChannel(channelFactory, scheduledExecutorService);
 
-    // send a bunch of request to RefreshingManagedChannel, executor needs more than 1 thread to test out concurrency
+    // send a bunch of request to RefreshingManagedChannel, executor needs more than 1 thread to
+    // test out concurrency
     ExecutorService executor = Executors.newFixedThreadPool(10);
 
     // channelCount - 1 because the last channel cannot be refreshed because the FakeChannelFactory

--- a/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracer.java
@@ -90,7 +90,6 @@ import org.threeten.bp.Duration;
  *         <dt>{@code connection}
  *         <dd>The UUID of the connection which the attempt was sent.
  *       </dl>
- *
  *   <li>{@code Attempt failed, scheduling next attempt} with the following attributes:
  *       <dl>
  *         <dt>{@code attempt}
@@ -108,7 +107,6 @@ import org.threeten.bp.Duration;
  *         <dt>{@code connection}
  *         <dd>The UUID of the connection which the attempt was sent.
  *       </dl>
- *
  *   <li>{@code Attempts exhausted} with the following attributes:
  *       <dl>
  *         <dt>{@code attempt}
@@ -124,7 +122,6 @@ import org.threeten.bp.Duration;
  *         <dt>{@code connection}
  *         <dd>The UUID of the connection which the attempt was sent.
  *       </dl>
- *
  *   <li>{@code Attempt failed, error not retryable} with the following attributes:
  *       <dl>
  *         <dt>{@code attempt}
@@ -140,7 +137,6 @@ import org.threeten.bp.Duration;
  *         <dt>{@code connection}
  *         <dd>The UUID of the connection which the attempt was sent.
  *       </dl>
- *
  *   <li>{@code Attempt succeeded} with the following attributes:
  *       <dl>
  *         <dt>{@code attempt}
@@ -154,7 +150,6 @@ import org.threeten.bp.Duration;
  *         <dt>{@code connection}
  *         <dd>The UUID of the connection which the attempt was sent.
  *       </dl>
- *
  * </ul>
  *
  * <p>Long running operations, which are composed of an initial RPC to start the operation and a
@@ -168,14 +163,12 @@ import org.threeten.bp.Duration;
  *         <dt>{@code status}
  *         <dd>The status code of why the operation failed to start
  *       </dl>
- *
  *   <li>{@code Polling was cancelled} with the following attributes:
  *       <dl>
  *         <dt>{@code attempt}
  *         <dd>Zero based sequential poll number.
  *         <dt>{@code attempt request count}
  *       </dl>
- *
  *   <li>{@code Scheduling next poll} with the following attributes:
  *       <dl>
  *         <dt>{@code attempt}
@@ -185,7 +178,6 @@ import org.threeten.bp.Duration;
  *         <dt>{@code delay}
  *         <dd>The number of milliseconds to wait before polling again
  *       </dl>
- *
  *   <li>{@code Polling attempts exhausted} with the following attributes:
  *       <dl>
  *         <dt>{@code attempt}
@@ -193,7 +185,6 @@ import org.threeten.bp.Duration;
  *         <dt>{@code status}
  *         <dd>OK if the poll succeeded, but the operation is still running.
  *       </dl>
- *
  *   <li>{@code Polling failed} with the following attributes:
  *       <dl>
  *         <dt>{@code attempt}
@@ -201,13 +192,11 @@ import org.threeten.bp.Duration;
  *         <dt>{@code status}
  *         <dd>OK if the poll succeeded, but the operation is still running.
  *       </dl>
- *
  *   <li>{@code Polling completed} with the following attributes:
  *       <dl>
  *         <dt>{@code attempt}
  *         <dd>Zero based sequential poll number
  *       </dl>
- *
  * </ul>
  *
  * <p>The toplevel long running operation span will also contain child spans to describe the retry


### PR DESCRIPTION
Torwards #867 . The old plugin version does not work with Gradle 6.

4 Java files are needed to be updated in new version of the formatter.[ `./gradlew googleJavaFormat`](https://github.com/sherter/google-java-format-gradle-plugin) made the change.