### PR TITLE
fix: do not shut down executor when WatchDog is shut down

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
@@ -124,7 +124,6 @@ public class Watchdog implements Runnable, BackgroundResource {
   @Override
   public void shutdown() {
     future.cancel(false);
-    executor.shutdown();
   }
 
   @Override

--- a/gax/src/test/java/com/google/api/gax/rpc/WatchdogTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/WatchdogTest.java
@@ -188,7 +188,6 @@ public class WatchdogTest {
         .scheduleAtFixedRate(
             underTest, checkInterval.toMillis(), checkInterval.toMillis(), TimeUnit.MILLISECONDS);
     Mockito.verify(future, Mockito.times(2)).cancel(false);
-    Mockito.verify(mockExecutor, Mockito.times(2)).shutdown();
 
     underTest.shutdownNow();
     Mockito.verify(future).cancel(true);


### PR DESCRIPTION
Fixes #870