### PR TITLE
fix: scale number of threads to scale with number of cpus

### DIFF
--- a/gax/src/main/java/com/google/api/gax/core/InstantiatingExecutorProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/InstantiatingExecutorProvider.java
@@ -78,7 +78,7 @@ public abstract class InstantiatingExecutorProvider implements ExecutorProvider 
 
   public static Builder newBuilder() {
     int numCpus = Runtime.getRuntime().availableProcessors();
-    int numThreads = Math.max(4, (int) Math.ceil(numCpus * 1.5));
+    int numThreads = Math.max(4, numCpus);
 
     return new AutoValue_InstantiatingExecutorProvider.Builder()
         .setExecutorThreadCount(numThreads)

--- a/gax/src/main/java/com/google/api/gax/core/InstantiatingExecutorProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/InstantiatingExecutorProvider.java
@@ -41,8 +41,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @AutoValue
 public abstract class InstantiatingExecutorProvider implements ExecutorProvider {
-  // The number of threads to use with the default executor.
-  private static final int DEFAULT_EXECUTOR_THREADS = 4;
   // Thread factory to use to create our worker threads
   private static final ThreadFactory DEFAULT_THREAD_FACTORY =
       new ThreadFactory() {
@@ -79,8 +77,11 @@ public abstract class InstantiatingExecutorProvider implements ExecutorProvider 
   public abstract Builder toBuilder();
 
   public static Builder newBuilder() {
+    int numCpus = Runtime.getRuntime().availableProcessors();
+    int numThreads = Math.max(4, (int) Math.ceil(numCpus * 1.5));
+
     return new AutoValue_InstantiatingExecutorProvider.Builder()
-        .setExecutorThreadCount(DEFAULT_EXECUTOR_THREADS)
+        .setExecutorThreadCount(numThreads)
         .setThreadFactory(DEFAULT_THREAD_FACTORY);
   }
 


### PR DESCRIPTION
This is temporary solution until something better can be worked out.
Ideally we would separate the executor for gax and the transport provider. But there are some backwards compatibility concerns to workout first.