### PR TITLE
gax-grpc: allow custom direct path service config

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -89,6 +89,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
   @Nullable private final Integer poolSize;
   @Nullable private final Credentials credentials;
   @Nullable private final ChannelPrimer channelPrimer;
+  private final ImmutableMap<String, ?> directPathServiceConfig;
 
   @Nullable
   private final ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> channelConfigurator;
@@ -109,6 +110,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     this.channelConfigurator = builder.channelConfigurator;
     this.credentials = builder.credentials;
     this.channelPrimer = builder.channelPrimer;
+    this.directPathServiceConfig = builder.directPathServiceConfig;
   }
 
   @Override
@@ -246,37 +248,18 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
       // Will be overridden by user defined values if any.
       builder.keepAliveTime(DIRECT_PATH_KEEP_ALIVE_TIME_SECONDS, TimeUnit.SECONDS);
       builder.keepAliveTimeout(DIRECT_PATH_KEEP_ALIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-
-      // When channel pooling is enabled, force the pick_first grpclb strategy.
-      // This is necessary to avoid the multiplicative effect of creating channel pool with
-      // `poolSize` number of `ManagedChannel`s, each with a `subSetting` number of number of subchannels.
-      // See the service config proto definition for more details:
-      // https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto#L182
-      ImmutableMap<String, Object> pickFirstStrategy =
-          ImmutableMap.<String, Object>of("pick_first", ImmutableMap.of());
-
-      ImmutableMap<String, Object> childPolicy =
-          ImmutableMap.<String, Object>of("childPolicy", ImmutableList.of(pickFirstStrategy));
-
-      ImmutableMap<String, Object> grpcLbPolicy =
-          ImmutableMap.<String, Object>of("grpclb", childPolicy);
-
-      ImmutableMap<String, Object> loadBalancingConfig =
-          ImmutableMap.<String, Object>of("loadBalancingConfig", ImmutableList.of(grpcLbPolicy));
-
-      builder.defaultServiceConfig(loadBalancingConfig);
+      builder.defaultServiceConfig(directPathServiceConfig);
     } else {
       builder = ManagedChannelBuilder.forAddress(serviceAddress, port);
     }
-    builder =
-        builder
-            // See https://github.com/googleapis/gapic-generator/issues/2816
-            .disableServiceConfigLookUp()
-            .intercept(new GrpcChannelUUIDInterceptor())
-            .intercept(headerInterceptor)
-            .intercept(metadataHandlerInterceptor)
-            .userAgent(headerInterceptor.getUserAgentHeader())
-            .executor(executor);
+    builder
+        // See https://github.com/googleapis/gapic-generator/issues/2816
+        .disableServiceConfigLookUp()
+        .intercept(new GrpcChannelUUIDInterceptor())
+        .intercept(headerInterceptor)
+        .intercept(metadataHandlerInterceptor)
+        .userAgent(headerInterceptor.getUserAgentHeader())
+        .executor(executor);
 
     if (maxInboundMetadataSize != null) {
       builder.maxInboundMetadataSize(maxInboundMetadataSize);
@@ -362,6 +345,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     @Nullable private ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> channelConfigurator;
     @Nullable private Credentials credentials;
     @Nullable private ChannelPrimer channelPrimer;
+    private ImmutableMap<String, ?> directPathServiceConfig = getDefaultDirectPathServiceConfig();
 
     private Builder() {
       processorCount = Runtime.getRuntime().availableProcessors();
@@ -564,6 +548,23 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
       return this;
     }
 
+    /**
+     * Sets a service config for direct path. If direct path is not enabled, the provided service
+     * config will be ignored.
+     *
+     * <p>See <a href=
+     * "https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto">
+     * the service config proto definition</a> for more details.
+     *
+     * <p>This is public only for technical reasons, for advanced usage.
+     */
+    @InternalApi("For internal use by google-cloud-java clients only")
+    public Builder setDirectPathServiceConfig(Map<String, ?> serviceConfig) {
+      Preconditions.checkNotNull(serviceConfig, "serviceConfig");
+      this.directPathServiceConfig = ImmutableMap.copyOf(serviceConfig);
+      return this;
+    }
+
     public InstantiatingGrpcChannelProvider build() {
       return new InstantiatingGrpcChannelProvider(this);
     }
@@ -586,6 +587,25 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     public ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> getChannelConfigurator() {
       return channelConfigurator;
     }
+  }
+
+  private static ImmutableMap<String, ?> getDefaultDirectPathServiceConfig() {
+    // When channel pooling is enabled, force the pick_first grpclb strategy.
+    // This is necessary to avoid the multiplicative effect of creating channel pool with
+    // `poolSize` number of `ManagedChannel`s, each with a `subSetting` number of number of
+    // subchannels.
+    // See the service config proto definition for more details:
+    // https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto
+    ImmutableMap<String, Object> pickFirstStrategy =
+        ImmutableMap.<String, Object>of("pick_first", ImmutableMap.of());
+
+    ImmutableMap<String, Object> childPolicy =
+        ImmutableMap.<String, Object>of("childPolicy", ImmutableList.of(pickFirstStrategy));
+
+    ImmutableMap<String, Object> grpcLbPolicy =
+        ImmutableMap.<String, Object>of("grpclb", childPolicy);
+
+    return ImmutableMap.<String, Object>of("loadBalancingConfig", ImmutableList.of(grpcLbPolicy));
   }
 
   private static void validateEndpoint(String endpoint) {

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -41,6 +41,7 @@ import com.google.api.gax.rpc.TransportChannel;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.ComputeEngineCredentials;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -89,7 +90,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
   @Nullable private final Integer poolSize;
   @Nullable private final Credentials credentials;
   @Nullable private final ChannelPrimer channelPrimer;
-  private final ImmutableMap<String, ?> directPathServiceConfig;
+  @VisibleForTesting final ImmutableMap<String, ?> directPathServiceConfig;
 
   @Nullable
   private final ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> channelConfigurator;

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.grpc;
 
 import static com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.DIRECT_PATH_ENV_VAR;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -42,13 +43,20 @@ import com.google.api.gax.rpc.HeaderProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.auth.oauth2.CloudShellCredentials;
 import com.google.auth.oauth2.ComputeEngineCredentials;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.alts.ComputeEngineChannelBuilder;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import javax.annotation.Nullable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -384,5 +392,79 @@ public class InstantiatingGrpcChannelProviderTest {
       Mockito.verify(mockChannelPrimer, Mockito.times(poolSize))
           .primeChannel(Mockito.any(ManagedChannel.class));
     }
+  }
+
+  @Test
+  public void testWithDefaultDirectPathServiceConfig() {
+    InstantiatingGrpcChannelProvider provider =
+        InstantiatingGrpcChannelProvider.newBuilder().build();
+
+    ImmutableMap<String, ?> defaultServiceConfig = provider.directPathServiceConfig;
+
+    List<Map<String, ?>> lbConfigs = getAsObjectList(defaultServiceConfig, "loadBalancingConfig");
+    assertThat(lbConfigs).hasSize(1);
+    Map<String, ?> lbConfig = lbConfigs.get(0);
+    Map<String, ?> grpclb = getAsObject(lbConfig, "grpclb");
+    List<Map<String, ?>> childPolicies = getAsObjectList(grpclb, "childPolicy");
+    assertThat(childPolicies).hasSize(1);
+    Map<String, ?> childPolicy = childPolicies.get(0);
+    assertThat(childPolicy.keySet()).containsExactly("pick_first");
+  }
+
+  @Nullable
+  private static Map<String, ?> getAsObject(Map<String, ?> json, String key) {
+    Object mapObject = json.get(key);
+    if (mapObject == null) {
+      return null;
+    }
+    return checkObject(mapObject);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, ?> checkObject(Object json) {
+    checkArgument(json instanceof Map, "Invalid json object representation: %s", json);
+    for (Map.Entry<Object, Object> entry : ((Map<Object, Object>) json).entrySet()) {
+      checkArgument(entry.getKey() instanceof String, "Key is not string");
+    }
+    return (Map<String, ?>) json;
+  }
+
+  private static List<Map<String, ?>> getAsObjectList(Map<String, ?> json, String key) {
+    Object listObject = json.get(key);
+    if (listObject == null) {
+      return null;
+    }
+    return checkAndJsonListOfObjects(listObject);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Map<String, ?>> checkAndJsonListOfObjects(Object listObject) {
+    checkArgument(listObject instanceof List, "Passed object is not a list");
+    List<Map<String, ?>> list = new ArrayList<>();
+    for (Object object : ((List<Object>) listObject)) {
+      list.add(checkObject(object));
+    }
+    return list;
+  }
+
+  @Test
+  public void testWithCustomDirectPathServiceConfig() {
+    ImmutableMap<String, Object> pickFirstStrategy =
+        ImmutableMap.<String, Object>of("round_robin", ImmutableMap.of());
+    ImmutableMap<String, Object> childPolicy =
+        ImmutableMap.<String, Object>of(
+            "childPolicy", ImmutableList.of(pickFirstStrategy), "foo", "bar");
+    ImmutableMap<String, Object> grpcLbPolicy =
+        ImmutableMap.<String, Object>of("grpclb", childPolicy);
+    Map<String, Object> passedServiceConfig = new HashMap<>();
+    passedServiceConfig.put("loadBalancingConfig", ImmutableList.of(grpcLbPolicy));
+
+    InstantiatingGrpcChannelProvider provider =
+        InstantiatingGrpcChannelProvider.newBuilder()
+            .setDirectPathServiceConfig(passedServiceConfig)
+            .build();
+
+    ImmutableMap<String, ?> defaultServiceConfig = provider.directPathServiceConfig;
+    assertThat(defaultServiceConfig).isEqualTo(passedServiceConfig);
   }
 }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
@@ -434,11 +434,11 @@ public class InstantiatingGrpcChannelProviderTest {
     if (listObject == null) {
       return null;
     }
-    return checkAndJsonListOfObjects(listObject);
+    return checkListOfObjects(listObject);
   }
 
   @SuppressWarnings("unchecked")
-  private static List<Map<String, ?>> checkAndJsonListOfObjects(Object listObject) {
+  private static List<Map<String, ?>> checkListOfObjects(Object listObject) {
     checkArgument(listObject instanceof List, "Passed object is not a list");
     List<Map<String, ?>> list = new ArrayList<>();
     for (Object object : ((List<Object>) listObject)) {


### PR DESCRIPTION
this change allows `gax-grpc` users to specify service config for (mostly) more advanced direct path configuration. e.g. using different load balancing policy. by default, behavior remains same as today.