### PR TITLE
Release gax-java v1.55.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,27 +31,27 @@ If you are using Maven, add this to your pom.xml file
 <dependency>
   <groupId>com.google.api</groupId>
   <artifactId>gax</artifactId>
-  <version>1.54.0</version>
+  <version>1.55.0</version>
 </dependency>
 <dependency>
   <groupId>com.google.api</groupId>
   <artifactId>gax-grpc</artifactId>
-  <version>1.54.0</version>
+  <version>1.55.0</version>
 </dependency>
 ```
 
 If you are using Gradle, add this to your dependencies
 
 ```Groovy
-compile 'com.google.api:gax:1.54.0',
-  'com.google.api:gax-grpc:1.54.0'
+compile 'com.google.api:gax:1.55.0',
+  'com.google.api:gax-grpc:1.55.0'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.api" % "gax" % "1.54.0"
-libraryDependencies += "com.google.api" % "gax-grpc" % "1.54.0"
+libraryDependencies += "com.google.api" % "gax" % "1.55.0"
+libraryDependencies += "com.google.api" % "gax-grpc" % "1.55.0"
 ```
 [//]: # ({x-version-update-end})
 

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -1,4 +1,4 @@
-project.version = "0.56.0" // {x-version-update:benchmark:current}
+project.version = "0.57.0" // {x-version-update:benchmark:current}
 
 buildscript {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'com.github.sherter.google-java-format'
 apply plugin: 'io.codearte.nexus-staging'
 
 // TODO: Populate this from dependencies.properties version property (for proper Gradle-Bazel sync)
-project.version = "1.54.0" // {x-version-update:gax:current}
+project.version = "1.55.0" // {x-version-update:gax:current}
 
 ext {
   // Project names not used for release

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -8,16 +8,16 @@
 
 # Versions of oneself
 # {x-version-update-start:gax:current}
-version.gax=1.54.0
+version.gax=1.55.0
 # {x-version-update-end}
 # {x-version-update-start:gax:current}
-version.gax_grpc=1.54.0
+version.gax_grpc=1.55.0
 # {x-version-update-end}
 # {x-version-update-start:gax:current}
-version.gax_bom=1.54.0
+version.gax_bom=1.55.0
 # {x-version-update-end}
 # {x-version-update-start:gax-httpjson:current}
-version.gax_httpjson=0.71.0
+version.gax_httpjson=0.72.0
 # {x-version-update-end}
 
 # Versions for dependencies which actual artifacts differ between Bazel and Gradle.

--- a/gax-bom/build.gradle
+++ b/gax-bom/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 archivesBaseName = "gax-bom"
 
-project.version = "1.54.0" // {x-version-update:gax-bom:current}
+project.version = "1.55.0" // {x-version-update:gax-bom:current}
 
 ext {
   mavenJavaDir = "$project.buildDir/publications/mavenJava"

--- a/gax-bom/pom.xml
+++ b/gax-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api</groupId>
   <artifactId>gax-bom</artifactId>
-  <version>1.54.0</version><!-- {x-version-update:gax-bom:current} -->
+  <version>1.55.0</version><!-- {x-version-update:gax-bom:current} -->
   <packaging>pom</packaging>
   <name>GAX (Google Api eXtensions) for Java</name>
   <description>Google Api eXtensions for Java</description>
@@ -33,34 +33,34 @@
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax</artifactId>
-        <version>1.54.0</version><!-- {x-version-update:gax:current} -->
+        <version>1.55.0</version><!-- {x-version-update:gax:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax</artifactId>
-        <version>1.54.0</version><!-- {x-version-update:gax:current} -->
+        <version>1.55.0</version><!-- {x-version-update:gax:current} -->
 	<classifier>testlib</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-grpc</artifactId>
-        <version>1.54.0</version><!-- {x-version-update:gax-grpc:current} -->
+        <version>1.55.0</version><!-- {x-version-update:gax-grpc:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-grpc</artifactId>
-        <version>1.54.0</version><!-- {x-version-update:gax-grpc:current} -->
+        <version>1.55.0</version><!-- {x-version-update:gax-grpc:current} -->
 	<classifier>testlib</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-httpjson</artifactId>
-        <version>0.71.0</version><!-- {x-version-update:gax-httpjson:current} -->
+        <version>0.72.0</version><!-- {x-version-update:gax-httpjson:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-httpjson</artifactId>
-        <version>0.71.0</version><!-- {x-version-update:gax-httpjson:current} -->
+        <version>0.72.0</version><!-- {x-version-update:gax-httpjson:current} -->
 	<classifier>testlib</classifier>
       </dependency>
     </dependencies>

--- a/gax-grpc/build.gradle
+++ b/gax-grpc/build.gradle
@@ -1,7 +1,7 @@
 archivesBaseName = "gax-grpc"
 
 // TODO: Populate this from dependencies.properties version property (for proper Gradle-Bazel sync)
-project.version = "1.54.0" // {x-version-update:gax-grpc:current}
+project.version = "1.55.0" // {x-version-update:gax-grpc:current}
 
 dependencies {
   compile project(':gax'),

--- a/gax-httpjson/build.gradle
+++ b/gax-httpjson/build.gradle
@@ -1,7 +1,7 @@
 archivesBaseName = "gax-httpjson"
 
 // TODO: Populate this from dependencies.properties version property (for proper Gradle-Bazel sync)
-project.version = "0.71.0" // {x-version-update:gax-httpjson:current}
+project.version = "0.72.0" // {x-version-update:gax-httpjson:current}
 
 dependencies {
   compile project(':gax'),

--- a/gax/build.gradle
+++ b/gax/build.gradle
@@ -1,7 +1,7 @@
 archivesBaseName = "gax"
 
 // TODO: Populate this from dependencies.properties version property (for proper Gradle-Bazel sync)
-project.version = "1.54.0" // {x-version-update:gax:current}
+project.version = "1.55.0" // {x-version-update:gax:current}
 
 dependencies {
   compile libraries['maven.com_google_guava_guava'],

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -14,13 +14,13 @@
       <groupId>com.google.api</groupId>
       <artifactId>gax</artifactId>
       <!-- WARNING this is automatically populated by a build script, don't update manually -->
-      <version>1.54.0</version><!-- {x-version-update:gax:current} -->
+      <version>1.55.0</version><!-- {x-version-update:gax:current} -->
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
       <!-- WARNING this is automatically populated by a build script, don't update manually -->
-      <version>1.54.0</version><!-- {x-version-update:gax-grpc:current} -->
+      <version>1.55.0</version><!-- {x-version-update:gax-grpc:current} -->
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>

--- a/versions.txt
+++ b/versions.txt
@@ -1,8 +1,8 @@
 # Format:
 # module:released-version:current-version
 
-gax:1.54.0:1.54.0
-gax-bom:1.54.0:1.54.0
-gax-grpc:1.54.0:1.54.0
-gax-httpjson:0.71.0:0.71.0
-benchmark:0.56.0:0.56.0
+gax:1.55.0:1.55.0
+gax-bom:1.55.0:1.55.0
+gax-grpc:1.55.0:1.55.0
+gax-httpjson:0.72.0:0.72.0
+benchmark:0.57.0:0.57.0


### PR DESCRIPTION
This pull request was generated using releasetool.

03-27-2020 08:33 PDT

### New Features
- Allow client authors to create their own callable chains ([#891](https://github.com/googleapis/gax-java/pull/891))

### Dependencies
- Update org.threeten:threetenbp to v1.4.1 ([#890](https://github.com/googleapis/gax-java/pull/890))

### Internal / Testing Changes
- chore(deps): update dependency com.google.api.grpc:grpc-google-cloud-bigtable-v2 to v1 ([#953](https://github.com/googleapis/gax-java/pull/953))
- chore(deps): update dependency com.google.api.grpc:grpc-google-cloud-pubsub-v1 to v1 ([#970](https://github.com/googleapis/gax-java/pull/970))
- remove unused property ([#887](https://github.com/googleapis/gax-java/pull/887))