### PR TITLE
feat: add ability to partially update retry settings

### DIFF
--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/SettingsTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/SettingsTest.java
@@ -634,7 +634,7 @@ public class SettingsTest {
       UnaryCallSettings.Builder<?, ?> builderB) {
     assertIsReflectionEqual(path, builderA, builderB, new String[] {"retrySettingsBuilder"});
     assertIsReflectionEqual(
-        path + ".getRetrySettings", builderA.getRetrySettings(), builderB.getRetrySettings());
+        path + ".retrySettingsBuilder", builderA.getRetrySettings(), builderB.getRetrySettings());
   }
 
   private static <RequestT, ResponseT> void assertIsReflectionEqual(
@@ -664,10 +664,12 @@ public class SettingsTest {
         path,
         builderA,
         builderB,
-        new String[] {"retrySettings", "batchingDescriptor", "batchingSettings", "flowController"});
+        new String[] {
+          "retrySettingsBuilder", "batchingDescriptor", "batchingSettings", "flowController"
+        });
 
     assertIsReflectionEqual(
-        path + ".getRetrySettings", builderA.getRetrySettings(), builderB.getRetrySettings());
+        path + ".retrySettingsBuilder", builderA.getRetrySettings(), builderB.getRetrySettings());
     assertIsReflectionEqual(
         path + ".getBatchingSettings",
         builderA.getBatchingSettings(),

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -37,6 +37,7 @@ import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.threeten.bp.Duration;
@@ -142,7 +143,7 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
 
     /** Initialize the builder with default settings */
     private Builder() {
-      this.retryableCodes = ImmutableSet.of();
+      this.retryableCodes = new HashSet<>();
       this.retrySettingsBuilder = RetrySettings.newBuilder();
       this.resumptionStrategy = new SimpleStreamResumptionStrategy<>();
 
@@ -151,7 +152,7 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
 
     private Builder(ServerStreamingCallSettings<RequestT, ResponseT> settings) {
       super(settings);
-      this.retryableCodes = settings.retryableCodes;
+      this.retryableCodes = Sets.newHashSet(settings.retryableCodes);
       this.retrySettingsBuilder = settings.retrySettings.toBuilder();
       this.resumptionStrategy = settings.resumptionStrategy;
 

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -37,7 +37,6 @@ import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.threeten.bp.Duration;
@@ -143,7 +142,7 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
 
     /** Initialize the builder with default settings */
     private Builder() {
-      this.retryableCodes = new HashSet<>();
+      this.retryableCodes = ImmutableSet.of();
       this.retrySettingsBuilder = RetrySettings.newBuilder();
       this.resumptionStrategy = new SimpleStreamResumptionStrategy<>();
 
@@ -152,7 +151,7 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
 
     private Builder(ServerStreamingCallSettings<RequestT, ResponseT> settings) {
       super(settings);
-      this.retryableCodes = Sets.newHashSet(settings.retryableCodes);
+      this.retryableCodes = settings.retryableCodes;
       this.retrySettingsBuilder = settings.retrySettings.toBuilder();
       this.resumptionStrategy = settings.resumptionStrategy;
 
@@ -160,32 +159,8 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
     }
 
     /**
-     * Adds a status code to enable retries for.
-     *
-     * <p>See the class documentation of {@link ServerStreamingCallSettings} for a description of
-     * what retryableCodes do.
-     */
-    public Builder<RequestT, ResponseT> addRetryableCode(StatusCode.Code code) {
-      this.retryableCodes.add(code);
-      return this;
-    }
-
-    /**
-     * Removes a status code to enable retries for.
-     *
-     * <p>See the class documentation of {@link ServerStreamingCallSettings} for a description of
-     * what retryableCodes do.
-     */
-    public Builder<RequestT, ResponseT> removeRetryableCode(StatusCode.Code code) {
-      this.retryableCodes.remove(code);
-      return this;
-    }
-
-    /**
-     * Replaces all of the retryable code.
-     *
-     * <p>See the class documentation of {@link ServerStreamingCallSettings} for a description of
-     * what retryableCodes do.
+     * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
+     * retryableCodes do.
      */
     public Builder<RequestT, ResponseT> setRetryableCodes(StatusCode.Code... codes) {
       this.setRetryableCodes(Sets.newHashSet(codes));
@@ -217,9 +192,6 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
 
     /**
      * Replaces the {@link RetrySettings} for the associated {@link ServerStreamingCallable}.
-     *
-     * <p>Prefer to use {@link #retrySettings()}, which will allow you to partially update the
-     * settings, keeping unset properties as default.
      *
      * <p>When using the method, make sure that the {@link RetrySettings} are complete. For example,
      * the following code will disable retries because the retry delay is not set:

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -83,7 +83,7 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
 
   private ServerStreamingCallSettings(Builder<RequestT, ResponseT> builder) {
     this.retryableCodes = ImmutableSet.copyOf(builder.retryableCodes);
-    this.retrySettings = builder.retrySettings;
+    this.retrySettings = builder.retrySettingsBuilder.build();
     this.resumptionStrategy = builder.resumptionStrategy;
     this.idleTimeout = builder.idleTimeout;
   }
@@ -135,7 +135,7 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
   public static class Builder<RequestT, ResponseT>
       extends StreamingCallSettings.Builder<RequestT, ResponseT> {
     @Nonnull private Set<StatusCode.Code> retryableCodes;
-    @Nonnull private RetrySettings retrySettings;
+    @Nonnull private RetrySettings.Builder retrySettingsBuilder;
     @Nonnull private StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategy;
 
     @Nonnull private Duration idleTimeout;
@@ -143,7 +143,7 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
     /** Initialize the builder with default settings */
     private Builder() {
       this.retryableCodes = ImmutableSet.of();
-      this.retrySettings = RetrySettings.newBuilder().build();
+      this.retrySettingsBuilder = RetrySettings.newBuilder();
       this.resumptionStrategy = new SimpleStreamResumptionStrategy<>();
 
       this.idleTimeout = Duration.ZERO;
@@ -152,15 +152,39 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
     private Builder(ServerStreamingCallSettings<RequestT, ResponseT> settings) {
       super(settings);
       this.retryableCodes = settings.retryableCodes;
-      this.retrySettings = settings.retrySettings;
+      this.retrySettingsBuilder = settings.retrySettings.toBuilder();
       this.resumptionStrategy = settings.resumptionStrategy;
 
       this.idleTimeout = settings.idleTimeout;
     }
 
     /**
-     * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
-     * retryableCodes do.
+     * Adds a status code to enable retries for.
+     *
+     * <p>See the class documentation of {@link ServerStreamingCallSettings} for a description of
+     * what retryableCodes do.
+     */
+    public Builder<RequestT, ResponseT> addRetryableCode(StatusCode.Code code) {
+      this.retryableCodes.add(code);
+      return this;
+    }
+
+    /**
+     * Removes a status code to enable retries for.
+     *
+     * <p>See the class documentation of {@link ServerStreamingCallSettings} for a description of
+     * what retryableCodes do.
+     */
+    public Builder<RequestT, ResponseT> removeRetryableCode(StatusCode.Code code) {
+      this.retryableCodes.remove(code);
+      return this;
+    }
+
+    /**
+     * Replaces all of the retryable code.
+     *
+     * <p>See the class documentation of {@link ServerStreamingCallSettings} for a description of
+     * what retryableCodes do.
      */
     public Builder<RequestT, ResponseT> setRetryableCodes(StatusCode.Code... codes) {
       this.setRetryableCodes(Sets.newHashSet(codes));
@@ -183,18 +207,40 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
     }
 
     /**
-     * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
-     * retrySettings do.
+     * Returns the underlying {@link RetrySettings.Builder}, which allows callers to augment the
+     * existing {@link RetrySettings}.
+     */
+    public RetrySettings.Builder retrySettings() {
+      return this.retrySettingsBuilder;
+    }
+
+    /**
+     * Replaces the {@link RetrySettings} for the associated {@link ServerStreamingCallable}.
+     *
+     * <p>Prefer to use {@link #retrySettings()}, which will allow you to partially update the
+     * settings, keeping unset properties as default.
+     *
+     * <p>When using the method, make sure that the {@link RetrySettings} are complete. For example,
+     * the following code will disable retries because the retry delay is not set:
+     *
+     * <pre>{@code
+     * stubSettings.setRetrySettings(
+     *   RetrySettings.newBuilder()
+     *     .setTotalTimeout(Duration.ofSeconds(10)
+     * );
+     * }</pre>
+     *
+     * @see #retrySettings()
      */
     public Builder<RequestT, ResponseT> setRetrySettings(@Nonnull RetrySettings retrySettings) {
       Preconditions.checkNotNull(retrySettings);
-      this.retrySettings = retrySettings;
+      this.retrySettingsBuilder = retrySettings.toBuilder();
       return this;
     }
 
     @Nonnull
     public RetrySettings getRetrySettings() {
-      return retrySettings;
+      return retrySettingsBuilder.build();
     }
 
     /** Disables retries and sets the overall timeout. */

--- a/gax/src/main/java/com/google/api/gax/rpc/UnaryCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/UnaryCallSettings.java
@@ -110,32 +110,8 @@ public class UnaryCallSettings<RequestT, ResponseT> {
     }
 
     /**
-     * Adds a status code to enable retries for.
-     *
-     * <p>See the class documentation of {@link UnaryCallSettings} for a description of what
-     * retryableCodes do.
-     */
-    public UnaryCallSettings.Builder<RequestT, ResponseT> addRetryableCode(StatusCode.Code code) {
-      this.retryableCodes.add(code);
-      return this;
-    }
-
-    /**
-     * Removes a status code to enable retries for.
-     *
-     * <p>See the class documentation of {@link UnaryCallSettings} for a description of what
-     * retryableCodes do.
-     */
-    public UnaryCallSettings.Builder<RequestT, ResponseT> removeRetryableCode(
-        StatusCode.Code code) {
-      this.retryableCodes.remove(code);
-      return this;
-    }
-    /**
-     * Replaces all of the retryable code.
-     *
-     * <p>See the class documentation of {@link UnaryCallSettings} for a description of what
-     * retryable codes do.
+     * See the class documentation of {@link UnaryCallSettings} for a description of what retryable
+     * codes do.
      */
     public UnaryCallSettings.Builder<RequestT, ResponseT> setRetryableCodes(
         Set<StatusCode.Code> retryableCodes) {
@@ -163,9 +139,6 @@ public class UnaryCallSettings<RequestT, ResponseT> {
 
     /**
      * Replaces the {@link RetrySettings} for the associated {@link UnaryCallable}.
-     *
-     * <p>Prefer to use {@link #retrySettings()}, which will allow you to partially update the
-     * settings, keeping unset properties as default.
      *
      * <p>When using the method, make sure that the {@link RetrySettings} are complete. For example,
      * the following code will disable retries because the retry delay is not set:

--- a/gax/src/main/java/com/google/api/gax/rpc/UnaryCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/UnaryCallSettings.java
@@ -31,7 +31,6 @@ package com.google.api.gax.rpc;
 
 import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.retrying.RetrySettings;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import java.util.Set;
@@ -85,7 +84,7 @@ public class UnaryCallSettings<RequestT, ResponseT> {
 
   protected UnaryCallSettings(Builder<RequestT, ResponseT> builder) {
     this.retryableCodes = ImmutableSet.copyOf(builder.retryableCodes);
-    this.retrySettings = builder.retrySettings;
+    this.retrySettings = builder.retrySettingsBuilder.build();
   }
 
   /**
@@ -98,11 +97,11 @@ public class UnaryCallSettings<RequestT, ResponseT> {
   public static class Builder<RequestT, ResponseT> {
 
     private Set<StatusCode.Code> retryableCodes;
-    private RetrySettings retrySettings;
+    private RetrySettings.Builder retrySettingsBuilder;
 
     protected Builder() {
       retryableCodes = Sets.newHashSet();
-      retrySettings = RetrySettings.newBuilder().build();
+      retrySettingsBuilder = RetrySettings.newBuilder();
     }
 
     protected Builder(UnaryCallSettings<RequestT, ResponseT> unaryCallSettings) {
@@ -111,8 +110,32 @@ public class UnaryCallSettings<RequestT, ResponseT> {
     }
 
     /**
-     * See the class documentation of {@link UnaryCallSettings} for a description of what retryable
-     * codes do.
+     * Adds a status code to enable retries for.
+     *
+     * <p>See the class documentation of {@link UnaryCallSettings} for a description of what
+     * retryableCodes do.
+     */
+    public UnaryCallSettings.Builder<RequestT, ResponseT> addRetryableCode(StatusCode.Code code) {
+      this.retryableCodes.add(code);
+      return this;
+    }
+
+    /**
+     * Removes a status code to enable retries for.
+     *
+     * <p>See the class documentation of {@link UnaryCallSettings} for a description of what
+     * retryableCodes do.
+     */
+    public UnaryCallSettings.Builder<RequestT, ResponseT> removeRetryableCode(
+        StatusCode.Code code) {
+      this.retryableCodes.remove(code);
+      return this;
+    }
+    /**
+     * Replaces all of the retryable code.
+     *
+     * <p>See the class documentation of {@link UnaryCallSettings} for a description of what
+     * retryable codes do.
      */
     public UnaryCallSettings.Builder<RequestT, ResponseT> setRetryableCodes(
         Set<StatusCode.Code> retryableCodes) {
@@ -130,9 +153,35 @@ public class UnaryCallSettings<RequestT, ResponseT> {
       return this;
     }
 
+    /**
+     * Returns the underlying {@link RetrySettings.Builder}, which allows callers to augment the
+     * existing {@link RetrySettings}.
+     */
+    public RetrySettings.Builder retrySettings() {
+      return this.retrySettingsBuilder;
+    }
+
+    /**
+     * Replaces the {@link RetrySettings} for the associated {@link UnaryCallable}.
+     *
+     * <p>Prefer to use {@link #retrySettings()}, which will allow you to partially update the
+     * settings, keeping unset properties as default.
+     *
+     * <p>When using the method, make sure that the {@link RetrySettings} are complete. For example,
+     * the following code will disable retries because the retry delay is not set:
+     *
+     * <pre>{@code
+     * stubSettings.setRetrySettings(
+     *   RetrySettings.newBuilder()
+     *     .setTotalTimeout(Duration.ofSeconds(10)
+     * );
+     * }</pre>
+     *
+     * @see #retrySettings()
+     */
     public UnaryCallSettings.Builder<RequestT, ResponseT> setRetrySettings(
         RetrySettings retrySettings) {
-      this.retrySettings = Preconditions.checkNotNull(retrySettings);
+      this.retrySettingsBuilder = retrySettings.toBuilder();
       return this;
     }
 
@@ -163,7 +212,7 @@ public class UnaryCallSettings<RequestT, ResponseT> {
     }
 
     public RetrySettings getRetrySettings() {
-      return this.retrySettings;
+      return this.retrySettingsBuilder.build();
     }
 
     /**

--- a/gax/src/main/java/com/google/api/gax/rpc/UnaryCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/UnaryCallSettings.java
@@ -184,6 +184,11 @@ public class UnaryCallSettings<RequestT, ResponseT> {
       return this.retryableCodes;
     }
 
+    /**
+     * Returns an immutable {@link RetrySettings} currently set in this Builder.
+     *
+     * <p>Unlike {@link #retrySettings()}, objects returned by this method are frozen in time.
+     */
     public RetrySettings getRetrySettings() {
       return this.retrySettingsBuilder.build();
     }

--- a/gax/src/test/java/com/google/api/gax/rpc/BatchingCallSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/BatchingCallSettingsTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
+import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class BatchingCallSettingsTest {
@@ -82,7 +83,17 @@ public class BatchingCallSettingsTest {
         BatchingSettings.newBuilder().setElementCountThreshold(1L).build();
     FlowController flowController = Mockito.mock(FlowController.class);
     Set<StatusCode.Code> retryCodes = Sets.newHashSet(Code.UNAVAILABLE);
-    RetrySettings retrySettings = RetrySettings.newBuilder().build();
+    RetrySettings retrySettings =
+        RetrySettings.newBuilder()
+            .setInitialRetryDelay(Duration.ofMillis(5))
+            .setMaxRetryDelay(Duration.ofSeconds(1))
+            .setRetryDelayMultiplier(2)
+            .setInitialRpcTimeout(Duration.ofMillis(100))
+            .setMaxRpcTimeout(Duration.ofMillis(200))
+            .setRpcTimeoutMultiplier(1.1)
+            .setJittered(true)
+            .setMaxAttempts(10)
+            .build();
 
     builder.setBatchingSettings(batchingSettings);
     builder.setFlowController(flowController);
@@ -93,7 +104,7 @@ public class BatchingCallSettingsTest {
     Truth.assertThat(builder.getBatchingSettings()).isSameInstanceAs(batchingSettings);
     Truth.assertThat(builder.getFlowController()).isSameInstanceAs(flowController);
     Truth.assertThat(builder.getRetryableCodes().size()).isEqualTo(1);
-    Truth.assertThat(builder.getRetrySettings()).isSameInstanceAs(retrySettings);
+    Truth.assertThat(builder.getRetrySettings()).isEqualTo(retrySettings);
 
     BatchingCallSettings settings = builder.build();
 
@@ -101,7 +112,7 @@ public class BatchingCallSettingsTest {
     Truth.assertThat(settings.getBatchingSettings()).isSameInstanceAs(batchingSettings);
     Truth.assertThat(settings.getFlowController()).isSameInstanceAs(flowController);
     Truth.assertThat(settings.getRetryableCodes().size()).isEqualTo(1);
-    Truth.assertThat(settings.getRetrySettings()).isSameInstanceAs(retrySettings);
+    Truth.assertThat(settings.getRetrySettings()).isEqualTo(retrySettings);
   }
 
   @Test
@@ -116,7 +127,17 @@ public class BatchingCallSettingsTest {
         BatchingSettings.newBuilder().setElementCountThreshold(1L).build();
     FlowController flowController = Mockito.mock(FlowController.class);
     Set<StatusCode.Code> retryCodes = Sets.newHashSet(Code.UNAVAILABLE);
-    RetrySettings retrySettings = RetrySettings.newBuilder().build();
+    RetrySettings retrySettings =
+        RetrySettings.newBuilder()
+            .setInitialRetryDelay(Duration.ofMillis(5))
+            .setMaxRetryDelay(Duration.ofSeconds(1))
+            .setRetryDelayMultiplier(2)
+            .setInitialRpcTimeout(Duration.ofMillis(100))
+            .setMaxRpcTimeout(Duration.ofMillis(200))
+            .setRpcTimeoutMultiplier(1.1)
+            .setJittered(true)
+            .setMaxAttempts(10)
+            .build();
 
     builder.setBatchingSettings(batchingSettings);
     builder.setFlowController(flowController);
@@ -130,7 +151,7 @@ public class BatchingCallSettingsTest {
     Truth.assertThat(newBuilder.getBatchingSettings()).isSameInstanceAs(batchingSettings);
     Truth.assertThat(newBuilder.getFlowController()).isSameInstanceAs(flowController);
     Truth.assertThat(newBuilder.getRetryableCodes().size()).isEqualTo(1);
-    Truth.assertThat(newBuilder.getRetrySettings()).isSameInstanceAs(retrySettings);
+    Truth.assertThat(newBuilder.getRetrySettings()).isEqualTo(retrySettings);
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/rpc/PagedCallSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/PagedCallSettingsTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
+import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class PagedCallSettingsTest {
@@ -72,18 +73,28 @@ public class PagedCallSettingsTest {
         PagedCallSettings.newBuilder(pagedListResponseFactory);
 
     Set<StatusCode.Code> retryCodes = Sets.newHashSet(Code.UNAVAILABLE);
-    RetrySettings retrySettings = RetrySettings.newBuilder().build();
+    RetrySettings retrySettings =
+        RetrySettings.newBuilder()
+            .setInitialRetryDelay(Duration.ofMillis(5))
+            .setMaxRetryDelay(Duration.ofSeconds(1))
+            .setRetryDelayMultiplier(2)
+            .setInitialRpcTimeout(Duration.ofMillis(100))
+            .setMaxRpcTimeout(Duration.ofMillis(200))
+            .setRpcTimeoutMultiplier(1.1)
+            .setJittered(true)
+            .setMaxAttempts(10)
+            .build();
 
     builder.setRetryableCodes(retryCodes);
     builder.setRetrySettings(retrySettings);
 
     Truth.assertThat(builder.getRetryableCodes().size()).isEqualTo(1);
-    Truth.assertThat(builder.getRetrySettings()).isSameInstanceAs(retrySettings);
+    Truth.assertThat(builder.getRetrySettings()).isEqualTo(retrySettings);
 
     PagedCallSettings settings = builder.build();
 
     Truth.assertThat(settings.getRetryableCodes().size()).isEqualTo(1);
-    Truth.assertThat(settings.getRetrySettings()).isSameInstanceAs(retrySettings);
+    Truth.assertThat(settings.getRetrySettings()).isEqualTo(retrySettings);
   }
 
   @Test
@@ -95,18 +106,28 @@ public class PagedCallSettingsTest {
         PagedCallSettings.newBuilder(pagedListResponseFactory);
 
     Set<StatusCode.Code> retryCodes = Sets.newHashSet(Code.UNAVAILABLE);
-    RetrySettings retrySettings = RetrySettings.newBuilder().build();
+    RetrySettings retrySettings =
+        RetrySettings.newBuilder()
+            .setInitialRetryDelay(Duration.ofMillis(5))
+            .setMaxRetryDelay(Duration.ofSeconds(1))
+            .setRetryDelayMultiplier(2)
+            .setInitialRpcTimeout(Duration.ofMillis(100))
+            .setMaxRpcTimeout(Duration.ofMillis(200))
+            .setRpcTimeoutMultiplier(1.1)
+            .setJittered(true)
+            .setMaxAttempts(10)
+            .build();
 
     builder.setRetryableCodes(retryCodes);
     builder.setRetrySettings(retrySettings);
 
     Truth.assertThat(builder.getRetryableCodes().size()).isEqualTo(1);
-    Truth.assertThat(builder.getRetrySettings()).isSameInstanceAs(retrySettings);
+    Truth.assertThat(builder.getRetrySettings()).isEqualTo(retrySettings);
 
     PagedCallSettings settings = builder.build();
     PagedCallSettings.Builder newBuilder = settings.toBuilder();
 
     Truth.assertThat(newBuilder.getRetryableCodes().size()).isEqualTo(1);
-    Truth.assertThat(newBuilder.getRetrySettings()).isSameInstanceAs(retrySettings);
+    Truth.assertThat(newBuilder.getRetrySettings()).isEqualTo(retrySettings);
   }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallSettingsTest.java
@@ -29,15 +29,15 @@
  */
 package com.google.api.gax.rpc;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.truth.Truth;
 import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mockito;
 import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
@@ -49,10 +49,9 @@ public class ServerStreamingCallSettingsTest {
         ServerStreamingCallSettings.newBuilder();
     builder.setRetryableCodes(codes);
 
-    Truth.assertThat(builder.getRetryableCodes()).containsExactlyElementsIn(codes);
-    Truth.assertThat(builder.build().getRetryableCodes()).containsExactlyElementsIn(codes);
-    Truth.assertThat(builder.build().toBuilder().getRetryableCodes())
-        .containsExactlyElementsIn(codes);
+    assertThat(builder.getRetryableCodes()).containsExactlyElementsIn(codes);
+    assertThat(builder.build().getRetryableCodes()).containsExactlyElementsIn(codes);
+    assertThat(builder.build().toBuilder().getRetryableCodes()).containsExactlyElementsIn(codes);
   }
 
   @Test
@@ -60,21 +59,30 @@ public class ServerStreamingCallSettingsTest {
     ServerStreamingCallSettings.Builder<Object, Object> builder =
         ServerStreamingCallSettings.newBuilder().setRetryableCodes(Code.UNKNOWN, Code.ABORTED);
 
-    Truth.assertThat(builder.getRetryableCodes()).containsExactly(Code.UNKNOWN, Code.ABORTED);
+    assertThat(builder.getRetryableCodes()).containsExactly(Code.UNKNOWN, Code.ABORTED);
   }
 
   @Test
   public void retryableSettingsAreNotLost() {
-    RetrySettings retrySettings = Mockito.mock(RetrySettings.class);
+    RetrySettings retrySettings =
+        RetrySettings.newBuilder()
+            .setInitialRetryDelay(Duration.ofMillis(5))
+            .setMaxRetryDelay(Duration.ofSeconds(1))
+            .setRetryDelayMultiplier(2)
+            .setInitialRpcTimeout(Duration.ofMillis(100))
+            .setMaxRpcTimeout(Duration.ofMillis(200))
+            .setRpcTimeoutMultiplier(1.1)
+            .setJittered(true)
+            .setMaxAttempts(10)
+            .build();
 
     ServerStreamingCallSettings.Builder<Object, Object> builder =
         ServerStreamingCallSettings.newBuilder();
     builder.setRetrySettings(retrySettings);
 
-    Truth.assertThat(builder.getRetrySettings()).isSameInstanceAs(retrySettings);
-    Truth.assertThat(builder.build().getRetrySettings()).isSameInstanceAs(retrySettings);
-    Truth.assertThat(builder.build().toBuilder().getRetrySettings())
-        .isSameInstanceAs(retrySettings);
+    assertThat(builder.getRetrySettings()).isEqualTo(retrySettings);
+    assertThat(builder.build().getRetrySettings()).isEqualTo(retrySettings);
+    assertThat(builder.build().toBuilder().getRetrySettings()).isEqualTo(retrySettings);
   }
 
   @Test
@@ -85,8 +93,53 @@ public class ServerStreamingCallSettingsTest {
         ServerStreamingCallSettings.newBuilder();
     builder.setIdleTimeout(idleTimeout);
 
-    Truth.assertThat(builder.getIdleTimeout()).isEqualTo(idleTimeout);
-    Truth.assertThat(builder.build().getIdleTimeout()).isEqualTo(idleTimeout);
-    Truth.assertThat(builder.build().toBuilder().getIdleTimeout()).isEqualTo(idleTimeout);
+    assertThat(builder.getIdleTimeout()).isEqualTo(idleTimeout);
+    assertThat(builder.build().getIdleTimeout()).isEqualTo(idleTimeout);
+    assertThat(builder.build().toBuilder().getIdleTimeout()).isEqualTo(idleTimeout);
+  }
+
+  @Test
+  public void testAddRetryableCode() {
+    ServerStreamingCallSettings.Builder<Object, Object> builder =
+        ServerStreamingCallSettings.newBuilder();
+
+    builder.addRetryableCode(Code.ABORTED);
+    assertThat(builder.getRetryableCodes()).containsExactly(Code.ABORTED);
+    assertThat(builder.build().getRetryableCodes()).containsExactly(Code.ABORTED);
+  }
+
+  @Test
+  public void testRemoveRetryableCode() {
+    ServerStreamingCallSettings.Builder<Object, Object> builder =
+        ServerStreamingCallSettings.newBuilder()
+            .setRetryableCodes(Code.NOT_FOUND, Code.DEADLINE_EXCEEDED);
+
+    builder.removeRetryableCode(Code.NOT_FOUND);
+    assertThat(builder.getRetryableCodes()).containsExactly(Code.DEADLINE_EXCEEDED);
+    assertThat(builder.build().getRetryableCodes()).containsExactly(Code.DEADLINE_EXCEEDED);
+  }
+
+  @Test
+  public void testRetrySettingsBuilder() {
+    RetrySettings initialSettings =
+        RetrySettings.newBuilder()
+            .setInitialRetryDelay(Duration.ofMillis(5))
+            .setMaxRetryDelay(Duration.ofSeconds(1))
+            .setRetryDelayMultiplier(2)
+            .setInitialRpcTimeout(Duration.ofMillis(100))
+            .setMaxRpcTimeout(Duration.ofMillis(200))
+            .setRpcTimeoutMultiplier(1.1)
+            .setJittered(true)
+            .setMaxAttempts(10)
+            .build();
+
+    ServerStreamingCallSettings.Builder<Object, Object> builder =
+        ServerStreamingCallSettings.newBuilder().setRetrySettings(initialSettings);
+
+    builder.retrySettings().setMaxRetryDelay(Duration.ofMinutes(1));
+
+    assertThat(builder.getRetrySettings().getMaxRetryDelay()).isEqualTo(Duration.ofMinutes(1));
+    assertThat(builder.build().getRetrySettings().getMaxRetryDelay())
+        .isEqualTo(Duration.ofMinutes(1));
   }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallSettingsTest.java
@@ -99,27 +99,6 @@ public class ServerStreamingCallSettingsTest {
   }
 
   @Test
-  public void testAddRetryableCode() {
-    ServerStreamingCallSettings.Builder<Object, Object> builder =
-        ServerStreamingCallSettings.newBuilder();
-
-    builder.addRetryableCode(Code.ABORTED);
-    assertThat(builder.getRetryableCodes()).containsExactly(Code.ABORTED);
-    assertThat(builder.build().getRetryableCodes()).containsExactly(Code.ABORTED);
-  }
-
-  @Test
-  public void testRemoveRetryableCode() {
-    ServerStreamingCallSettings.Builder<Object, Object> builder =
-        ServerStreamingCallSettings.newBuilder()
-            .setRetryableCodes(Code.NOT_FOUND, Code.DEADLINE_EXCEEDED);
-
-    builder.removeRetryableCode(Code.NOT_FOUND);
-    assertThat(builder.getRetryableCodes()).containsExactly(Code.DEADLINE_EXCEEDED);
-    assertThat(builder.build().getRetryableCodes()).containsExactly(Code.DEADLINE_EXCEEDED);
-  }
-
-  @Test
   public void testRetrySettingsBuilder() {
     RetrySettings initialSettings =
         RetrySettings.newBuilder()

--- a/gax/src/test/java/com/google/api/gax/rpc/UnaryCallSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/UnaryCallSettingsTest.java
@@ -32,7 +32,6 @@ package com.google.api.gax.rpc;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.gax.retrying.RetrySettings;
-import com.google.api.gax.rpc.StatusCode.Code;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -49,25 +48,6 @@ public class UnaryCallSettingsTest {
     assertThat(builder.getRetryableCodes().size()).isEqualTo(0);
     assertThat(builder.getRetrySettings().getMaxAttempts()).isEqualTo(1);
     assertThat(builder.getRetrySettings().getTotalTimeout()).isEqualTo(Duration.ofSeconds(13));
-  }
-
-  @Test
-  public void testAddRetryableCode() {
-    UnaryCallSettings.Builder<Object, Object> builder = new UnaryCallSettings.Builder();
-
-    builder.addRetryableCode(Code.ABORTED);
-    assertThat(builder.getRetryableCodes()).containsExactly(Code.ABORTED);
-    assertThat(builder.build().getRetryableCodes()).containsExactly(Code.ABORTED);
-  }
-
-  @Test
-  public void testRemoveRetryableCode() {
-    UnaryCallSettings.Builder<Object, Object> builder =
-        new UnaryCallSettings.Builder().setRetryableCodes(Code.NOT_FOUND, Code.DEADLINE_EXCEEDED);
-
-    builder.removeRetryableCode(Code.NOT_FOUND);
-    assertThat(builder.getRetryableCodes()).containsExactly(Code.DEADLINE_EXCEEDED);
-    assertThat(builder.build().getRetryableCodes()).containsExactly(Code.DEADLINE_EXCEEDED);
   }
 
   @Test


### PR DESCRIPTION
The current approach to updating retry settings is very error prone. We've had a few customers accidentally disable retries trying to update the total timeout doing something like:

```java
SomeClientSettings.Builder clientSettingsBuilder = SomeClientSettings.newBuilder();
SomeClientStubSettings.Builder stubSettingsBuilder = clientSettingsBuilder.stubSettings();

stubSettingsBuilder.someMethod()
  .setRetrySettings(
     RetrySettings.newBuilder().setTotalTimeout(Duration.ofSecond(10)).build()
  );
```

The correct way is not really intuitive and quite verbose:

```java
SomeClientSettings.Builder clientSettingsBuilder = SomeClientSettings.newBuilder();
SomeClientStubSettings.Builder stubSettingsBuilder = clientSettingsBuilder.stubSettings();

stubSettingsBuilder.someMethod()
  .setRetrySettings(
     stubSettingsBuilder.someMethod().getRetrySettings().toBuilder()
        .setTotalTimeout(Duration.ofSecond(10))
        .build()
  );
```

This PR exposes the underlying RetrySettings.Builder in Unary & ServerStreaming CallSettings. This allows the following pattern:

```java
SomeClientSettings.Builder clientSettingsBuilder = SomeClientSettings.newBuilder();
SomeClientStubSettings.Builder stubSettingsBuilder = clientSettingsBuilder.stubSettings();

stubSettingsBuilder.someMethod()
  .addRetryableCode(Code.DEADLINE_EXCEEDED)
  .retrySettings()
     .setTotalTimeout(Duration.ofSecond(10));
```
