### PR TITLE
Add setAttemptDirectPath(boolean) for InstantiatingGrpcChannelProvider.Builder 

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -243,7 +243,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     // TODO(weiranf): Add API in ComputeEngineCredentials to check default service account.
     // TODO(weiranf): Remove isDirectPathEnvVarEnabled once setAttemptDirectPath is adapted and the
     //                env var is removed from client environment.
-    if ((attemptDirectPath | isDirectPathEnvVarEnabled(serviceAddress))
+    if ((attemptDirectPath || isDirectPathEnvVarEnabled(serviceAddress))
         && credentials instanceof ComputeEngineCredentials) {
       builder = ComputeEngineChannelBuilder.forAddress(serviceAddress, port);
       // Set default keepAliveTime and keepAliveTimeout when directpath environment is enabled.

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.grpc;
 
-import static com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.DIRECT_PATH_ENV_VAR;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -37,7 +36,6 @@ import static org.junit.Assert.fail;
 import com.google.api.core.ApiFunction;
 import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.Builder;
-import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.EnvironmentProvider;
 import com.google.api.gax.rpc.HeaderProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.auth.oauth2.CloudShellCredentials;
@@ -215,9 +213,6 @@ public class InstantiatingGrpcChannelProviderTest {
 
   @Test
   public void testWithGCECredentials() throws IOException {
-    EnvironmentProvider mockEnvProvider = Mockito.mock(EnvironmentProvider.class);
-    Mockito.when(mockEnvProvider.getenv(DIRECT_PATH_ENV_VAR)).thenReturn("localhost");
-
     ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(1);
     executor.shutdown();
 
@@ -231,7 +226,7 @@ public class InstantiatingGrpcChannelProviderTest {
 
     TransportChannelProvider provider =
         InstantiatingGrpcChannelProvider.newBuilder()
-            .setEnvironmentProvider(mockEnvProvider)
+            .setAttemptDirectPath(true)
             .setChannelConfigurator(channelConfigurator)
             .build()
             .withExecutor(executor)
@@ -247,9 +242,6 @@ public class InstantiatingGrpcChannelProviderTest {
 
   @Test
   public void testWithNonGCECredentials() throws IOException {
-    EnvironmentProvider mockEnvProvider = Mockito.mock(EnvironmentProvider.class);
-    Mockito.when(mockEnvProvider.getenv(DIRECT_PATH_ENV_VAR)).thenReturn("localhost");
-
     ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(1);
     executor.shutdown();
 
@@ -264,7 +256,7 @@ public class InstantiatingGrpcChannelProviderTest {
 
     TransportChannelProvider provider =
         InstantiatingGrpcChannelProvider.newBuilder()
-            .setEnvironmentProvider(mockEnvProvider)
+            .setAttemptDirectPath(true)
             .setChannelConfigurator(channelConfigurator)
             .build()
             .withExecutor(executor)
@@ -280,9 +272,6 @@ public class InstantiatingGrpcChannelProviderTest {
 
   @Test
   public void testWithDirectPathDisabled() throws IOException {
-    EnvironmentProvider mockEnvProvider = Mockito.mock(EnvironmentProvider.class);
-    Mockito.when(mockEnvProvider.getenv(DIRECT_PATH_ENV_VAR)).thenReturn("otherhost");
-
     ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(1);
     executor.shutdown();
 
@@ -297,7 +286,7 @@ public class InstantiatingGrpcChannelProviderTest {
 
     TransportChannelProvider provider =
         InstantiatingGrpcChannelProvider.newBuilder()
-            .setEnvironmentProvider(mockEnvProvider)
+            .setAttemptDirectPath(false)
             .setChannelConfigurator(channelConfigurator)
             .build()
             .withExecutor(executor)
@@ -312,10 +301,7 @@ public class InstantiatingGrpcChannelProviderTest {
   }
 
   @Test
-  public void testWithNoDirectPathEnvironment() throws IOException {
-    EnvironmentProvider mockEnvProvider = Mockito.mock(EnvironmentProvider.class);
-    Mockito.when(mockEnvProvider.getenv(DIRECT_PATH_ENV_VAR)).thenReturn(null);
-
+  public void testWithNoDirectPathFlagSet() throws IOException {
     ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(1);
     executor.shutdown();
 
@@ -330,7 +316,6 @@ public class InstantiatingGrpcChannelProviderTest {
 
     TransportChannelProvider provider =
         InstantiatingGrpcChannelProvider.newBuilder()
-            .setEnvironmentProvider(mockEnvProvider)
             .setChannelConfigurator(channelConfigurator)
             .build()
             .withExecutor(executor)

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
@@ -278,7 +278,7 @@ public class InstantiatingGrpcChannelProviderTest {
     ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> channelConfigurator =
         new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
           public ManagedChannelBuilder apply(ManagedChannelBuilder channelBuilder) {
-            // Clients without DirectPath environment variable will not attempt DirectPath
+            // Clients without setting attemptDirectPath flag will not attempt DirectPath
             assertThat(channelBuilder instanceof ComputeEngineChannelBuilder).isFalse();
             return channelBuilder;
           }
@@ -308,7 +308,7 @@ public class InstantiatingGrpcChannelProviderTest {
     ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> channelConfigurator =
         new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
           public ManagedChannelBuilder apply(ManagedChannelBuilder channelBuilder) {
-            // Clients without DirectPath environment variable will not attempt DirectPath
+            // Clients without setting attemptDirectPath flag will not attempt DirectPath
             assertThat(channelBuilder instanceof ComputeEngineChannelBuilder).isFalse();
             return channelBuilder;
           }


### PR DESCRIPTION
The current logic for deciding whether or not to attempt DirectPath is by checking the environment variable `GOOGLE_CLOUD_ENABLE_DIRECT_PATH`. However, we have decided to remove the dependency on this env variable and instead we should allow Yoshi library to attempt DirectPath by default. 

Added `setAttemptDirectPath()` so that Yoshi client library can use this API to set whether the client uses the DirectPath code path by default. The default value for attemptDirectPath is false.

+cc @igorbernstein2 