### PR TITLE
chore: display call settings configuration through toString

### DIFF
--- a/gax/src/main/java/com/google/api/gax/batching/BatchingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingCallSettings.java
@@ -35,6 +35,7 @@ import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import java.util.Set;
 
@@ -102,6 +103,15 @@ public final class BatchingCallSettings<ElementT, ElementResultT, RequestT, Resp
   @Override
   public final Builder<ElementT, ElementResultT, RequestT, ResponseT> toBuilder() {
     return new Builder<>(this);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("retryableCodes", getRetryableCodes())
+        .add("retrySettings", getRetrySettings())
+        .add("batchingSettings", batchingSettings)
+        .toString();
   }
 
   /**

--- a/gax/src/main/java/com/google/api/gax/rpc/BatchingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/BatchingCallSettings.java
@@ -34,6 +34,7 @@ import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowController;
 import com.google.api.gax.retrying.RetrySettings;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import java.util.Set;
 
@@ -80,6 +81,15 @@ public final class BatchingCallSettings<RequestT, ResponseT>
   @Override
   public final Builder<RequestT, ResponseT> toBuilder() {
     return new Builder<>(this);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("retryableCodes", getRetryableCodes())
+        .add("retrySettings", getRetrySettings())
+        .add("batchingSettings", batchingSettings)
+        .toString();
   }
 
   public static class Builder<RequestT, ResponseT>

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -34,6 +34,7 @@ import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.retrying.SimpleStreamResumptionStrategy;
 import com.google.api.gax.retrying.StreamResumptionStrategy;
 import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -130,6 +131,15 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
 
   public static <RequestT, ResponseT> Builder<RequestT, ResponseT> newBuilder() {
     return new Builder<>();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("idleTimeout", idleTimeout)
+        .add("retryableCodes", retryableCodes)
+        .add("retrySettings", retrySettings)
+        .toString();
   }
 
   public static class Builder<RequestT, ResponseT>

--- a/gax/src/main/java/com/google/api/gax/rpc/UnaryCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/UnaryCallSettings.java
@@ -31,6 +31,7 @@ package com.google.api.gax.rpc;
 
 import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.retrying.RetrySettings;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import java.util.Set;
@@ -85,6 +86,14 @@ public class UnaryCallSettings<RequestT, ResponseT> {
   protected UnaryCallSettings(Builder<RequestT, ResponseT> builder) {
     this.retryableCodes = ImmutableSet.copyOf(builder.retryableCodes);
     this.retrySettings = builder.retrySettingsBuilder.build();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("retryableCodes", retryableCodes)
+        .add("retrySettings", retrySettings)
+        .toString();
   }
 
   /**

--- a/gax/src/test/java/com/google/api/gax/batching/BatchingCallSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/BatchingCallSettingsTest.java
@@ -123,4 +123,20 @@ public class BatchingCallSettingsTest {
     }
     assertThat(actualEx).isInstanceOf(IllegalStateException.class);
   }
+
+  @Test
+  public void testToString() {
+    RetrySettings retrySettings = RetrySettings.newBuilder().build();
+    Set<StatusCode.Code> retryCodes = ImmutableSet.of(StatusCode.Code.UNAUTHENTICATED);
+    BatchingCallSettings<Integer, Integer, LabeledIntList, List<Integer>> batchingCallSettings =
+        BatchingCallSettings.newBuilder(SQUARER_BATCHING_DESC_V2)
+            .setRetryableCodes(retryCodes)
+            .setRetrySettings(retrySettings)
+            .setBatchingSettings(BATCHING_SETTINGS)
+            .build();
+
+    assertThat(batchingCallSettings.toString()).contains("retryableCodes=" + retryCodes);
+    assertThat(batchingCallSettings.toString()).contains("retrySettings=" + retrySettings);
+    assertThat(batchingCallSettings.toString()).contains("batchingSettings=" + BATCHING_SETTINGS);
+  }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/BatchingCallSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/BatchingCallSettingsTest.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowController;
 import com.google.api.gax.retrying.RetrySettings;
@@ -194,8 +192,8 @@ public class BatchingCallSettingsTest {
         .setBatchingSettings(batchingSettings)
         .setFlowController(flowController);
 
-    assertThat(builder.build().toString()).contains("retryableCodes=" + retryCodes);
-    assertThat(builder.build().toString()).contains("retrySettings=" + retrySettings);
-    assertThat(builder.build().toString()).contains("batchingSettings=" + batchingSettings);
+    Truth.assertThat(builder.build().toString()).contains("retryableCodes=" + retryCodes);
+    Truth.assertThat(builder.build().toString()).contains("retrySettings=" + retrySettings);
+    Truth.assertThat(builder.build().toString()).contains("batchingSettings=" + batchingSettings);
   }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/BatchingCallSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/BatchingCallSettingsTest.java
@@ -29,6 +29,8 @@
  */
 package com.google.api.gax.rpc;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowController;
 import com.google.api.gax.retrying.RetrySettings;
@@ -170,5 +172,30 @@ public class BatchingCallSettingsTest {
     BatchingCallSettings settings = builder.build();
 
     Truth.assertThat(settings.getFlowController()).isNotNull();
+  }
+
+  @Test
+  public void testToString() {
+    @SuppressWarnings("unchecked")
+    BatchingDescriptor<Integer, Integer> batchingDescriptor =
+        Mockito.mock(BatchingDescriptor.class);
+    BatchingCallSettings.Builder<Integer, Integer> builder =
+        BatchingCallSettings.newBuilder(batchingDescriptor);
+
+    BatchingSettings batchingSettings =
+        BatchingSettings.newBuilder().setElementCountThreshold(1L).build();
+    FlowController flowController = Mockito.mock(FlowController.class);
+    Set<StatusCode.Code> retryCodes = Sets.newHashSet(Code.UNAVAILABLE);
+    RetrySettings retrySettings = RetrySettings.newBuilder().build();
+
+    builder
+        .setRetryableCodes(retryCodes)
+        .setRetrySettings(retrySettings)
+        .setBatchingSettings(batchingSettings)
+        .setFlowController(flowController);
+
+    assertThat(builder.build().toString()).contains("retryableCodes=" + retryCodes);
+    assertThat(builder.build().toString()).contains("retrySettings=" + retrySettings);
+    assertThat(builder.build().toString()).contains("batchingSettings=" + batchingSettings);
   }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallSettingsTest.java
@@ -121,4 +121,20 @@ public class ServerStreamingCallSettingsTest {
     assertThat(builder.build().getRetrySettings().getMaxRetryDelay())
         .isEqualTo(Duration.ofMinutes(1));
   }
+
+  @Test
+  public void testToString() {
+    RetrySettings retrySettings = RetrySettings.newBuilder().build();
+    Set<StatusCode.Code> retryableCodes = ImmutableSet.of(StatusCode.Code.DEADLINE_EXCEEDED);
+    Duration idleTime = Duration.ofSeconds(100);
+    ServerStreamingCallSettings serverCallSettings =
+        ServerStreamingCallSettings.newBuilder()
+            .setRetrySettings(retrySettings)
+            .setRetryableCodes(retryableCodes)
+            .setIdleTimeout(idleTime)
+            .build();
+    assertThat(serverCallSettings.toString()).contains("idleTimeout=" + idleTime);
+    assertThat(serverCallSettings.toString()).contains("retryableCodes=" + retryableCodes);
+    assertThat(serverCallSettings.toString()).contains("retrySettings=" + retrySettings);
+  }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/UnaryCallSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/UnaryCallSettingsTest.java
@@ -32,6 +32,8 @@ package com.google.api.gax.rpc;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.gax.retrying.RetrySettings;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -72,5 +74,18 @@ public class UnaryCallSettingsTest {
     assertThat(builder.getRetrySettings().getMaxRetryDelay()).isEqualTo(Duration.ofMinutes(1));
     assertThat(builder.build().getRetrySettings().getMaxRetryDelay())
         .isEqualTo(Duration.ofMinutes(1));
+  }
+
+  @Test
+  public void testToString() {
+    RetrySettings retrySettings = RetrySettings.newBuilder().build();
+    Set<StatusCode.Code> retryableCodes = ImmutableSet.of(StatusCode.Code.DEADLINE_EXCEEDED);
+    UnaryCallSettings unaryCallSettings =
+        UnaryCallSettings.newUnaryCallSettingsBuilder()
+            .setRetrySettings(retrySettings)
+            .setRetryableCodes(retryableCodes)
+            .build();
+    assertThat(unaryCallSettings.toString()).contains("retryableCodes=" + retryableCodes);
+    assertThat(unaryCallSettings.toString()).contains("retrySettings=" + retrySettings);
   }
 }


### PR DESCRIPTION
This enables displaying `UnaryCallSettings`, `ServerStreamingCallSettings` & `BatchingCallSettings` configuration values through toString().

Did not include `BatchingDescriptor`, `FlowController` and `StreamResumptionStrategy` from these callSetting's `toString()` as these does not contain any settings.

Towards [Bigtable#233](https://github.com/googleapis/java-bigtable/issues/233)
This would enable us to display client-specific default settings