### PR TITLE
Catch and log exceptions in Watchdog runnable to ensure it never stops running

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
@@ -40,6 +40,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 import org.threeten.bp.Duration;
@@ -61,6 +63,8 @@ import org.threeten.bp.Duration;
  */
 @InternalApi
 public class Watchdog implements Runnable, BackgroundResource {
+  private static final Logger LOG = Logger.getLogger(Watchdog.class.getName());
+
   // Dummy value to convert the ConcurrentHashMap into a Set
   private static Object PRESENT = new Object();
   private final ConcurrentHashMap<WatchdogStream, Object> openStreams = new ConcurrentHashMap<>();
@@ -111,6 +115,14 @@ public class Watchdog implements Runnable, BackgroundResource {
 
   @Override
   public void run() {
+    try {
+      runUnsafe();
+    } catch (Throwable t) {
+      LOG.log(Level.SEVERE, "Caught throwable in periodic Watchdog run. Continuing.", t);
+    }
+  }
+
+  private void runUnsafe() {
     Iterator<Entry<WatchdogStream, Object>> it = openStreams.entrySet().iterator();
 
     while (it.hasNext()) {


### PR DESCRIPTION
See https://stackoverflow.com/questions/6894595/scheduledexecutorservice-exception-handling for details

This is the equivalent of https://github.com/googleapis/java-bigtable-hbase/pull/2529