### PR TITLE
Adopt GitHub Actions in gax-java: unit tests and linkage monitor

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,25 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+name: ci
+jobs:
+  units:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [7, 8, 11]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - run: java -version
+      - run: .kokoro/build.sh
+        env:
+          JOB_TYPE: test
+      - name: coverage
+        uses: codecov/codecov-action@v1
+        with:
+          name: actions ${{ matrix.java }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,3 +23,12 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           name: actions ${{ matrix.java }}
+  linkage-monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - run: java -version
+      - run: .kokoro/linkage-monitor.sh

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -15,6 +15,8 @@
 
 set -eo pipefail
 
+echo "Hello GitHub Action"
+
 cd github/gax-java/
 
 # Print out Java

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -15,8 +15,6 @@
 
 set -eo pipefail
 
-echo "Hello GitHub Action"
-
 scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 ## cd to the parent directory, i.e. the root of the git repo
 cd ${scriptDir}/..
@@ -28,4 +26,7 @@ echo $JOB_TYPE
 ./gradlew assemble
 ./gradlew build install
 
-bash $KOKORO_GFILE_DIR/codecov.sh
+if [ "${REPORT_COVERAGE}" == "true" ]
+then
+  bash ${KOKORO_GFILE_DIR}/codecov.sh
+fi

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -17,7 +17,9 @@ set -eo pipefail
 
 echo "Hello GitHub Action"
 
-cd github/gax-java/
+scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+## cd to the parent directory, i.e. the root of the git repo
+cd ${scriptDir}/..
 
 # Print out Java
 java -version

--- a/.kokoro/linkage-monitor.sh
+++ b/.kokoro/linkage-monitor.sh
@@ -17,7 +17,9 @@ set -eo pipefail
 # Display commands being run.
 set -x
 
-cd github/gax-java/
+scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+## cd to the parent directory, i.e. the root of the git repo
+cd ${scriptDir}/..
 
 # Print out Java version
 java -version


### PR DESCRIPTION
@chingor13 @stephaniewang526 Would you review this? By using GitHub Actions, we no longer need to worry about Java 7 build failure: [CertPathValidatorException: signature check failed](https://github.com/googleapis/gax-java/pull/1032#issuecomment-627565264).

Worth noting that "Adopt GitHub Actions in Client Libraries" document is quite useful. Thank you.

This setup worked well for my fork in github.com/suztomo/gax-java:

<img width="976" alt="Screen Shot 2020-05-21 at 11 07 49" src="https://user-images.githubusercontent.com/28604/82573082-517da100-9b53-11ea-906f-e63b3c965b87.png">

https://github.com/suztomo/gax-java/pull/3