### PR TITLE
fix: Make watchdog `@BetaApi` and watchdog provider implementations `@InternalApi`

### DIFF
--- a/gax-grpc/BUILD.bazel
+++ b/gax-grpc/BUILD.bazel
@@ -24,6 +24,7 @@ _COMPILE_DEPS = [
     "@com_google_http_client_google_http_client//jar",
     "@io_grpc_grpc_java//context:context",
     "@io_grpc_grpc_netty_shaded//jar",
+    "@io_grpc_grpc_grpclb//jar",
     "@io_grpc_grpc_java//alts:alts",
     "@io_netty_netty_tcnative_boringssl_static//jar",
     "@javax_annotation_javax_annotation_api//jar",

--- a/gax/src/main/java/com/google/api/gax/rpc/FixedWatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FixedWatchdogProvider.java
@@ -37,6 +37,13 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
+/**
+ * A watchdog provider which always returns the same watchdog instance provided to the provider
+ * during construction.
+ *
+ * <p>This is the internal class and is public only for technical reasons. It may change any time
+ * without notice, please do not depend on it explicitly.
+ */
 @BetaApi("The surface for streaming is not stable yet and may change in the future.")
 @InternalApi
 public final class FixedWatchdogProvider implements WatchdogProvider {

--- a/gax/src/main/java/com/google/api/gax/rpc/FixedWatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FixedWatchdogProvider.java
@@ -31,13 +31,15 @@ package com.google.api.gax.rpc;
 
 import com.google.api.core.ApiClock;
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
 @BetaApi("The surface for streaming is not stable yet and may change in the future.")
-public class FixedWatchdogProvider implements WatchdogProvider {
+@InternalApi
+public final class FixedWatchdogProvider implements WatchdogProvider {
   @Nullable private final Watchdog watchdog;
 
   public static WatchdogProvider create(Watchdog watchdog) {

--- a/gax/src/main/java/com/google/api/gax/rpc/InstantiatingWatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/InstantiatingWatchdogProvider.java
@@ -38,6 +38,12 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
+/**
+ * A watchdog provider which instantiates a new provider on every request.
+ *
+ * <p>This is the internal class and is public only for technical reasons. It may change any time
+ * without notice, please do not depend on it explicitly.
+ */
 @BetaApi("The surface for streaming is not stable yet and may change in the future.")
 @InternalApi
 public final class InstantiatingWatchdogProvider implements WatchdogProvider {

--- a/gax/src/main/java/com/google/api/gax/rpc/InstantiatingWatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/InstantiatingWatchdogProvider.java
@@ -31,6 +31,7 @@ package com.google.api.gax.rpc;
 
 import com.google.api.core.ApiClock;
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
 import com.google.common.base.Preconditions;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nonnull;
@@ -38,6 +39,7 @@ import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
 @BetaApi("The surface for streaming is not stable yet and may change in the future.")
+@InternalApi
 public final class InstantiatingWatchdogProvider implements WatchdogProvider {
   @Nullable private final ApiClock clock;
   @Nullable private final ScheduledExecutorService executor;

--- a/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
@@ -30,7 +30,7 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.ApiClock;
-import com.google.api.core.InternalApi;
+import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.common.base.Preconditions;
 import java.util.Iterator;
@@ -59,8 +59,8 @@ import org.threeten.bp.Duration;
  *       had no outstanding demand. Duration.ZERO disables the timeout.
  * </ul>
  */
-@InternalApi
-public class Watchdog implements Runnable, BackgroundResource {
+@BetaApi
+public final class Watchdog implements Runnable, BackgroundResource {
   // Dummy value to convert the ConcurrentHashMap into a Set
   private static Object PRESENT = new Object();
   private final ConcurrentHashMap<WatchdogStream, Object> openStreams = new ConcurrentHashMap<>();

--- a/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
@@ -230,7 +230,11 @@ public class ClientContextTest {
             null);
     Credentials credentials = Mockito.mock(Credentials.class);
     ApiClock clock = Mockito.mock(ApiClock.class);
-    Watchdog watchdog = Mockito.mock(Watchdog.class);
+    Watchdog watchdog =
+        Watchdog.create(
+            Mockito.mock(ApiClock.class),
+            Duration.ZERO,
+            Mockito.mock(ScheduledExecutorService.class));
     Duration watchdogCheckInterval = Duration.ofSeconds(11);
 
     builder.setExecutorProvider(executorProvider);

--- a/gax/src/test/java/com/google/api/gax/rpc/ClientSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ClientSettingsTest.java
@@ -142,7 +142,11 @@ public class ClientSettingsTest {
     ApiClock clock = Mockito.mock(ApiClock.class);
     ApiCallContext callContext = FakeCallContext.createDefault();
     Map<String, String> headers = Collections.singletonMap("spiffykey", "spiffyvalue");
-    Watchdog watchdog = Mockito.mock(Watchdog.class);
+    Watchdog watchdog =
+        Watchdog.create(
+            Mockito.mock(ApiClock.class),
+            Duration.ZERO,
+            Mockito.mock(ScheduledExecutorService.class));
     Duration watchdogCheckInterval = Duration.ofSeconds(12);
 
     ClientContext clientContext =

--- a/gax/src/test/java/com/google/api/gax/rpc/FixedWatchdogProviderTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/FixedWatchdogProviderTest.java
@@ -49,14 +49,24 @@ public class FixedWatchdogProviderTest {
 
   @Test
   public void testSameInstance() {
-    Watchdog watchdog = Mockito.mock(Watchdog.class);
+    Watchdog watchdog =
+        Watchdog.create(
+            Mockito.mock(ApiClock.class),
+            Duration.ZERO,
+            Mockito.mock(ScheduledExecutorService.class));
+
     WatchdogProvider provider = FixedWatchdogProvider.create(watchdog);
     assertThat(provider.getWatchdog()).isSameInstanceAs(watchdog);
   }
 
   @Test
   public void testNoModifications() {
-    WatchdogProvider provider = FixedWatchdogProvider.create(Mockito.mock(Watchdog.class));
+    Watchdog watchdog =
+        Watchdog.create(
+            Mockito.mock(ApiClock.class),
+            Duration.ZERO,
+            Mockito.mock(ScheduledExecutorService.class));
+    WatchdogProvider provider = FixedWatchdogProvider.create(watchdog);
 
     assertThat(provider.needsCheckInterval()).isFalse();
     assertThat(provider.needsClock()).isFalse();

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -81,6 +81,14 @@ def com_google_api_gax_java_repositories():
 
     _maybe(
         jvm_maven_import_external,
+        name = "io_grpc_grpc_grpclb",
+        artifact = "io.grpc:grpc-grpclb:%s" % PROPERTIES["version.io_grpc"],
+        server_urls = ["https://repo.maven.apache.org/maven2/", "http://repo1.maven.org/maven2/"],
+        licenses = ["notice", "reciprocal"],
+    )
+
+    _maybe(
+        jvm_maven_import_external,
         name = "google_java_format_all_deps",
         artifact = "com.google.googlejavaformat:google-java-format:jar:all-deps:%s" % PROPERTIES["version.google_java_format"],
         server_urls = ["https://repo.maven.apache.org/maven2/", "http://repo1.maven.org/maven2/"],


### PR DESCRIPTION
This is to address https://github.com/googleapis/gax-java/issues/829.

Also add grpclb lib to bazel dependencies, as its absence was failing some of the tests well executed from bazel.

This  PR basically repeats https://github.com/googleapis/gax-java/pull/881, with few more things in it (like making watchog final, as requested in the review there)