### PR TITLE
[gax-java] fix: add back javax.annotation dependency

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -45,7 +45,7 @@ maven.com_google_code_findbugs_jsr305=com.google.code.findbugs:jsr305:3.0.2
 maven.com_google_errorprone_error_prone_annotations=com.google.errorprone:error_prone_annotations:2.3.4
 maven.com_google_j2objc_j2objc_annotations=com.google.j2objc:j2objc-annotations:1.3
 maven.com_google_auto_value_auto_value=com.google.auto.value:auto-value:1.4
-maven.com_google_api_api_common=com.google.api:api-common:1.9.0
+maven.com_google_api_api_common=com.google.api:api-common:1.9.2
 maven.org_threeten_threetenbp=org.threeten:threetenbp:1.4.1
 maven.com_google_api_grpc_grpc_google_iam_v1=com.google.api.grpc:grpc-google-iam-v1:0.13.0
 maven.com_google_api_grpc_proto_google_iam_v1=com.google.api.grpc:proto-google-iam-v1:0.13.0
@@ -54,6 +54,7 @@ maven.com_google_http_client_google_http_client_jackson2=com.google.http-client:
 maven.com_fasterxml_jackson_core_jackson_core=com.fasterxml.jackson.core:jackson-core:2.10.1
 maven.org_codehaus_mojo_animal_sniffer_annotations=org.codehaus.mojo:animal-sniffer-annotations:1.18
 maven.org_apache_commons_commons_lang3=org.apache.commons:commons-lang3:3.6
+maven.javax_annotation_javax_annotation_api=javax.annotation:javax.annotation-api:1.3.2
 
 # Testing maven artifacts
 maven.junit_junit=junit:junit:4.13


### PR DESCRIPTION
This dependency was removed in PR #1000 in favor of transitively pulling it in from another project. However, it doesn't build in Kokoro when updating the WORKSPACE hash in g3/tp, which is currently set just past v1.55.0. We get errors like this:

```
/<path>/<project>/BUILD.bazel:71:1: no such package '@javax_annotation_javax_annotation_api//jar': The repository '@javax_annotation_javax_annotation_api' could not be resolved and referenced by  <project>:<project>_java_gapic
```