### PR TITLE
chore: enable release-please bot

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,2 @@
+releaseType: java-yoshi
+bumpMinorPreMajor: true


### PR DESCRIPTION
[Version 5.3.0](https://github.com/googleapis/release-please/releases/tag/v5.3.0) of release-please added support for our gradle builds

This should allow the bot to propose releases based on the conventional commit messages.