### PR TITLE
fix: Fix javadoc generation on Java11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,9 @@ subprojects {
     if (JavaVersion.current().isJava8Compatible()) {
       addStringOption('Xdoclint:all,-missing', '-quiet')
     }
+    if (JavaVersion.current().isJava11Compatible()) {
+      addStringOption('-release', '7')
+    }
   }
 
   // Test jar


### PR DESCRIPTION
Without this fix gradle fails witht  he following error for publishing taks (like `./gradlew clean publishMavenJavaPublicationToMavenLocal`) when built on `Java 11` (it used to work  normally on `Java 8`)
```
javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/7/docs/api/ are in the unnamed module
```