### PR TITLE
fix: non-retryable RPCs use totalTimeout

### DIFF
--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/TimeoutTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/TimeoutTest.java
@@ -102,9 +102,9 @@ public class TimeoutTest {
     // Verify that the gRPC channel used the CallOptions with our custom timeout of ~2 Days.
     assertThat(callOptionsUsed.getDeadline()).isNotNull();
     assertThat(callOptionsUsed.getDeadline())
-        .isGreaterThan(Deadline.after(DEADLINE_IN_SECONDS - 1, TimeUnit.SECONDS));
+        .isGreaterThan(Deadline.after(DEADLINE_IN_DAYS - 1, TimeUnit.DAYS));
     assertThat(callOptionsUsed.getDeadline())
-        .isLessThan(Deadline.after(DEADLINE_IN_SECONDS, TimeUnit.SECONDS));
+        .isLessThan(Deadline.after(DEADLINE_IN_DAYS, TimeUnit.DAYS));
     assertThat(callOptionsUsed.getAuthority()).isEqualTo(CALL_OPTIONS_AUTHORITY);
   }
 
@@ -126,9 +126,9 @@ public class TimeoutTest {
     // Verify that the gRPC channel used the CallOptions with our custom timeout of ~2 Days.
     assertThat(callOptionsUsed.getDeadline()).isNotNull();
     assertThat(callOptionsUsed.getDeadline())
-        .isGreaterThan(Deadline.after(DEADLINE_IN_MINUTES - 1, TimeUnit.MINUTES));
+        .isGreaterThan(Deadline.after(DEADLINE_IN_DAYS - 1, TimeUnit.DAYS));
     assertThat(callOptionsUsed.getDeadline())
-        .isLessThan(Deadline.after(DEADLINE_IN_MINUTES, TimeUnit.MINUTES));
+        .isLessThan(Deadline.after(DEADLINE_IN_DAYS, TimeUnit.DAYS));
     assertThat(callOptionsUsed.getAuthority()).isEqualTo(CALL_OPTIONS_AUTHORITY);
   }
 
@@ -175,9 +175,9 @@ public class TimeoutTest {
     // Verify that the gRPC channel used the CallOptions with our custom timeout of ~2 Days.
     assertThat(callOptionsUsed.getDeadline()).isNotNull();
     assertThat(callOptionsUsed.getDeadline())
-        .isGreaterThan(Deadline.after(DEADLINE_IN_SECONDS - 1, TimeUnit.SECONDS));
+        .isGreaterThan(Deadline.after(DEADLINE_IN_DAYS - 1, TimeUnit.DAYS));
     assertThat(callOptionsUsed.getDeadline())
-        .isLessThan(Deadline.after(DEADLINE_IN_SECONDS, TimeUnit.SECONDS));
+        .isLessThan(Deadline.after(DEADLINE_IN_DAYS, TimeUnit.DAYS));
     assertThat(callOptionsUsed.getAuthority()).isEqualTo(CALL_OPTIONS_AUTHORITY);
   }
 
@@ -199,9 +199,9 @@ public class TimeoutTest {
     // Verify that the gRPC channel used the CallOptions with our custom timeout of ~2 Days.
     assertThat(callOptionsUsed.getDeadline()).isNotNull();
     assertThat(callOptionsUsed.getDeadline())
-        .isGreaterThan(Deadline.after(DEADLINE_IN_MINUTES - 1, TimeUnit.MINUTES));
+        .isGreaterThan(Deadline.after(DEADLINE_IN_DAYS - 1, TimeUnit.DAYS));
     assertThat(callOptionsUsed.getDeadline())
-        .isLessThan(Deadline.after(DEADLINE_IN_MINUTES, TimeUnit.MINUTES));
+        .isLessThan(Deadline.after(DEADLINE_IN_DAYS, TimeUnit.DAYS));
     assertThat(callOptionsUsed.getAuthority()).isEqualTo(CALL_OPTIONS_AUTHORITY);
   }
 


### PR DESCRIPTION
This PR essentially reverts #745, thus making non-retryable RPCs reference the `totalTimeout` as the single RPC timeout (which was done in #712), rather than choosing from (intial | max | total).

The impetus for #745 was https://github.com/googleapis/google-cloud-java/issues/5555, where a `gax-java` change to using `totalTimeout` for non-retried RPCs resulted in an API returning validation errors for its specific-client, because that timeout value was too high. The Cloud Tasks library has since had its timeouts lowered to below the backend validation threshold.

Prioritizing initial over max over total, based on if the value was set or not, we effectively lowered the timeouts for all non-retryable RPCs to the (historically) lowest of the three config values. This is because historically all three values are always set to something. Service teams might simply change an RPC from retryable to non-retryable not knowing that they have lowered the user-perceived timeout of the method. 

Furthermore, in order for a user to change the timeout of a non-retryable RPC, they have to change all three timeout config values because gax-java asserts that `initialTimeout` <= `maxTimeout` <= `totalTimeout`. Generated documentation in clients shows an example of increasing a method's timeout by changing the `totalTimeout` value alone. This would do nothing for a non-retryable RPC, because the `initialTimeout` value would still be set and chosen. Similarly for service producers, if they wanted to increase the timeout for a non-retryable RPC in the generation config, they'd need to change all three values to satisfy the gax-java assertions, or set `initial` && `maxTimeout` to 0 and setting `totalTimeout` to the desired value.

IMO, it is slightly more intuitive to change the `totalTimeout` when a user (at runtime via gax-java api) or service team (at generation time via config) wants to increase the timeout perceived by the GAPIC-caller, rather all three values. I believe this is generated as example documentation in Java GAPICs for the same reason. This also lines up better with other languages that use the method-level `timeout_millis` config value to specify timeout for non-retryable RPCs.