### PR TITLE
WIP: change timeout-backoff to logical call timeout

### DIFF
--- a/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
@@ -105,10 +105,9 @@ public class ExponentialRetryAlgorithm implements TimedRetryAlgorithm {
     // The rpc timeout is determined as follows:
     //     attempt #0  - use the totalRpcTimeout;
     //     attempt #1+ - use the time remaining (including the delay) until the deadline.
+    long timeElapsed = clock.nanoTime() - prevSettings.getFirstAttemptStartTimeNanos();
     long timeLeftNanos =
-        (prevSettings.getFirstAttemptStartTimeNanos() + globalSettings.getTotalTimeout().toNanos())
-            - clock.nanoTime()
-            - randomDelay.toNanos();
+        globalSettings.getTotalTimeout().toNanos() - timeElapsed - randomDelay.toNanos();
 
     return TimedAttemptSettings.newBuilder()
         .setGlobalSettings(prevSettings.getGlobalSettings())

--- a/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
@@ -105,14 +105,14 @@ public class ExponentialRetryAlgorithm implements TimedRetryAlgorithm {
     // The rpc timeout is determined as follows:
     //     attempt #0  - use the totalRpcTimeout;
     //     attempt #1+ - use the time remaining (including the delay) until the deadline.
-    long timeElapsed = clock.nanoTime() - prevSettings.getFirstAttemptStartTimeNanos();
-    long timeLeftNanos =
-        globalSettings.getTotalTimeout().toNanos() - timeElapsed - randomDelay.toNanos();
+    Duration timeElapsed =
+        Duration.ofNanos(clock.nanoTime() - prevSettings.getFirstAttemptStartTimeNanos());
+    Duration timeLeft = globalSettings.getTotalTimeout().minus(timeElapsed).minus(randomDelay);
 
     return TimedAttemptSettings.newBuilder()
         .setGlobalSettings(prevSettings.getGlobalSettings())
         .setRetryDelay(Duration.ofMillis(newRetryDelay))
-        .setRpcTimeout(Duration.ofNanos(timeLeftNanos))
+        .setRpcTimeout(timeLeft)
         .setRandomizedRetryDelay(randomDelay)
         .setAttemptCount(prevSettings.getAttemptCount() + 1)
         .setOverallAttemptCount(prevSettings.getOverallAttemptCount() + 1)

--- a/gax/src/test/java/com/google/api/gax/retrying/ExponentialRetryAlgorithmTest.java
+++ b/gax/src/test/java/com/google/api/gax/retrying/ExponentialRetryAlgorithmTest.java
@@ -66,7 +66,7 @@ public class ExponentialRetryAlgorithmTest {
     assertEquals(0, attempt.getOverallAttemptCount());
     assertEquals(Duration.ZERO, attempt.getRetryDelay());
     assertEquals(Duration.ZERO, attempt.getRandomizedRetryDelay());
-    assertEquals(Duration.ofMillis(1L), attempt.getRpcTimeout());
+    assertEquals(Duration.ofMillis(200L), attempt.getRpcTimeout());
     assertEquals(Duration.ZERO, attempt.getRetryDelay());
   }
 
@@ -80,13 +80,13 @@ public class ExponentialRetryAlgorithmTest {
     assertEquals(1, secondAttempt.getOverallAttemptCount());
     assertEquals(Duration.ofMillis(1L), secondAttempt.getRetryDelay());
     assertEquals(Duration.ofMillis(1L), secondAttempt.getRandomizedRetryDelay());
-    assertEquals(Duration.ofMillis(2L), secondAttempt.getRpcTimeout());
+    assertTrue(secondAttempt.getRpcTimeout().toMillis() <= firstAttempt.getRpcTimeout().toMillis());
 
     TimedAttemptSettings thirdAttempt = algorithm.createNextAttempt(secondAttempt);
     assertEquals(2, thirdAttempt.getAttemptCount());
     assertEquals(Duration.ofMillis(2L), thirdAttempt.getRetryDelay());
     assertEquals(Duration.ofMillis(2L), thirdAttempt.getRandomizedRetryDelay());
-    assertEquals(Duration.ofMillis(4L), thirdAttempt.getRpcTimeout());
+    assertTrue(thirdAttempt.getRpcTimeout().toMillis() <= secondAttempt.getRpcTimeout().toMillis());
   }
 
   @Test


### PR DESCRIPTION
This is a WIP PR that will deprecate the timeout-backoff implementation in ExponentialRetryAlgorithm. The first RPC in a logical call with have a deadline calculated as `now() + totalTimeout`. Should that first RPC fail with a retry-able status code, the deadline of the next attempted RPC will be calculated as `now() + (totalTimeout - timeElapsed - retryDelay)` where `(totalTimeout - timeElapsed - retryDelay)` is the amount of time left in the `totalTimeout` at the start of the next attempt after the `retryDelay`.