### PR TITLE
fix: Preconditions only supports %s format

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -536,7 +536,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
     public Builder setPoolSize(int poolSize) {
       Preconditions.checkArgument(poolSize > 0, "Pool size must be positive");
       Preconditions.checkArgument(
-          poolSize <= MAX_POOL_SIZE, "Pool size must be less than %d", MAX_POOL_SIZE);
+          poolSize <= MAX_POOL_SIZE, "Pool size must be less than %s", MAX_POOL_SIZE);
       this.poolSize = poolSize;
       return this;
     }


### PR DESCRIPTION
`Preconditions` only support use of the `%s` format specifier ([docs](https://guava.dev/releases/20.0/api/docs/com/google/common/base/Preconditions.html)) and gax-java had a `%d` format specifier. This switches it to `%s`.

The following error showed up in bazel builds of `java_gapic_library` targets on HEAD of googleapis:

```
external/com_google_api_gax_java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java:539: error: [PreconditionsInvalidPlaceholder] Preconditions only accepts the %s placeholder in error message strings
          poolSize <= MAX_POOL_SIZE, "Pool size must be less than %d", MAX_POOL_SIZE);
                                     ^
    (see https://errorprone.info/bugpattern/PreconditionsInvalidPlaceholder)
  Did you mean 'poolSize <= MAX_POOL_SIZE, "Pool size must be less than %s", MAX_POOL_SIZE);'?
```

I'm not sure what changed, maybe the dependency version brought was updated transiently to the later versions that throw an exception on format specifier support in `Preconditions`. Regardless, this is an easy fix.