### PR TITLE
fix: Watchdog.shutdownNow() does not shutdown executor

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
@@ -151,7 +151,6 @@ public final class Watchdog implements Runnable, BackgroundResource {
   @Override
   public void shutdownNow() {
     future.cancel(true);
-    executor.shutdownNow();
   }
 
   @Override

--- a/gax/src/test/java/com/google/api/gax/rpc/WatchdogTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/WatchdogTest.java
@@ -191,7 +191,7 @@ public class WatchdogTest {
 
     underTest.shutdownNow();
     Mockito.verify(future).cancel(true);
-    Mockito.verify(mockExecutor).shutdownNow();
+    Mockito.verifyNoMoreInteractions(mockExecutor);
   }
 
   static class AccumulatingObserver<T> implements ResponseObserver<T> {


### PR DESCRIPTION
Fixes #870 , see [my comment](https://github.com/googleapis/gax-java/issues/870#issuecomment-665106904)