### PR TITLE
fix: Settings objects should not try to read quotaProjectId from credentials

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -266,14 +266,6 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     /** Sets the CredentialsProvider to use for getting the credentials to make calls with. */
     public B setCredentialsProvider(CredentialsProvider credentialsProvider) {
       this.credentialsProvider = Preconditions.checkNotNull(credentialsProvider);
-      try {
-        Credentials credentials = credentialsProvider.getCredentials();
-        if (this.quotaProjectId == null && credentials instanceof QuotaProjectIdProvider) {
-          this.quotaProjectId = ((QuotaProjectIdProvider) credentials).getQuotaProjectId();
-        }
-      } catch (IOException e) {
-        System.out.println("fail to fetch credentials");
-      }
       return self();
     }
 
@@ -419,6 +411,17 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
 
     /** Gets the QuotaProjectId that was previously set on this Builder. */
     public String getQuotaProjectId() {
+      if (quotaProjectId == null && credentialsProvider != null) {
+        try {
+          Credentials credentials = credentialsProvider.getCredentials();
+          if (this.quotaProjectId == null && credentials instanceof QuotaProjectIdProvider) {
+            this.quotaProjectId = ((QuotaProjectIdProvider) credentials).getQuotaProjectId();
+          }
+        } catch (IOException e) {
+          // ignored
+        }
+      }
+
       return quotaProjectId;
     }
 

--- a/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -41,7 +41,6 @@ import com.google.api.gax.core.InstantiatingExecutorProvider;
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.tracing.ApiTracerFactory;
 import com.google.api.gax.tracing.NoopApiTracerFactory;
-import com.google.auth.Credentials;
 import com.google.auth.oauth2.QuotaProjectIdProvider;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
@@ -411,17 +410,6 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
 
     /** Gets the QuotaProjectId that was previously set on this Builder. */
     public String getQuotaProjectId() {
-      if (quotaProjectId == null && credentialsProvider != null) {
-        try {
-          Credentials credentials = credentialsProvider.getCredentials();
-          if (this.quotaProjectId == null && credentials instanceof QuotaProjectIdProvider) {
-            this.quotaProjectId = ((QuotaProjectIdProvider) credentials).getQuotaProjectId();
-          }
-        } catch (IOException e) {
-          // ignored
-        }
-      }
-
       return quotaProjectId;
     }
 

--- a/gax/src/test/java/com/google/api/gax/rpc/ClientSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ClientSettingsTest.java
@@ -420,8 +420,6 @@ public class ClientSettingsTest {
         .isEqualTo(QUOTA_PROJECT_ID_FROM_INTERNAL_HEADER_VALUE);
     Truth.assertThat(builder_setQuotaFromInternalHeadersAndBuilders.getQuotaProjectId())
         .isEqualTo(QUOTA_PROJECT_ID_FROM_BUILDERS);
-    Truth.assertThat(builder_setQuotaFromCredentialsProvider.getQuotaProjectId())
-        .isEqualTo(QUOTA_PROJECT_ID_FROM_CREDENTIALS_VALUE);
     Truth.assertThat(builder_setQuotaFromCredentialsProviderAndBuilder.getQuotaProjectId())
         .isEqualTo(QUOTA_PROJECT_ID_FROM_BUILDERS);
     Truth.assertThat(builder_setQuotaFromAllSources.getQuotaProjectId())


### PR DESCRIPTION
This is causing downstream errors  in unit tests because the settings are attempting to load credentials while the settings are being built.

This is a behavioral change. The settings object should not care about what's in the credentials provider when being asked for its configured quotaProjectId. We now will only return an explicitly configured quotaProjectId. ClientContext.create will correctly determine the correct value to use. 