### PR TITLE
fix: fix dependencies.properties resource file creation during deployment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,12 +41,6 @@ googleJavaFormat {
   exclude 'bazel*/**'
 }
 
-task generateProjectProperties {
-    ext.outputFile = file("gax/src/main/resources/dependencies.properties")
-    outputs.file(outputFile)
-    outputFile.text = "version.gax=${project.version}"
-}
-
 // google-java-format-gradle-plugin:0.8 does not work with Java 1.7.
 verifyGoogleJavaFormat.onlyIf { JavaVersion.current().isJava8Compatible() }
 
@@ -91,7 +85,6 @@ allprojects {
     }
   }
   test.dependsOn verifyLicense
-  test.dependsOn generateProjectProperties
 
   gradle.projectsEvaluated {
     tasks.withType(JavaCompile) {
@@ -172,7 +165,6 @@ subprojects {
   // ----------
 
   task sourcesJar(type: Jar, dependsOn: classes) {
-    dependsOn generateProjectProperties
     classifier = 'sources'
 
     from sourceSets.main.allSource, sourceSets.test.allSource, sourceSets.main.resources.srcDirs

--- a/build.gradle
+++ b/build.gradle
@@ -44,9 +44,7 @@ googleJavaFormat {
 task generateProjectProperties {
     ext.outputFile = file("gax/src/main/resources/dependencies.properties")
     outputs.file(outputFile)
-    doLast {
-        outputFile.text = "version.gax=${project.version}"
-    }
+    outputFile.text = "version.gax=${project.version}"
 }
 
 // google-java-format-gradle-plugin:0.8 does not work with Java 1.7.

--- a/gax/build.gradle
+++ b/gax/build.gradle
@@ -23,6 +23,16 @@ dependencies {
   shadowNoGuava libraries['maven.com_google_guava_guava']
 }
 
+ext.generatedOutputDir = file("${buildDir}/generated-resources")
+task generateProjectProperties {
+  ext.outputFile = file("${generatedOutputDir}/dependencies.properties")
+  outputs.file(outputFile)
+  doLast {
+    outputFile.text = "version.gax=${project.version}"
+  }
+}
+sourceSets.main.output.dir generatedOutputDir, builtBy: generateProjectProperties
+
 jar {
   manifest {
     attributes 'Specification-Title': project.name,


### PR DESCRIPTION
This changes the dependencies.properties file to be created into the build/generated-resources directory and includes that directory as part of the sources set.

This should fix the generation version detection.

Verified by running `git clean -fdx && ./gradlew publishToMavenLocal`. The tests pass during the publish and built jar in the local repo includes the dependencies.properties file.

Fixes #1164 