### PR TITLE
feat: implement overall timeout strategy

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -118,6 +118,11 @@ public class GrpcCallableFactory {
       overallTimeout = context.getOverallTimeout();
     }
 
+    // The overall timeout must be included with the default call context, otherwise it will be
+    // null.
+    // The context is the main vehicle for the overall timeout through the call stack, so the
+    // default
+    // provided by the UnaryCallSettings must be retained.
     return callable.withDefaultCallContext(context.withOverallTimeout(overallTimeout));
   }
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -32,6 +32,7 @@ package com.google.api.gax.grpc;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.Callables;
@@ -63,6 +64,7 @@ import io.grpc.MethodDescriptor;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
+import org.threeten.bp.Duration;
 
 /** Class with utility methods to create grpc-based direct callables. */
 @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
@@ -110,7 +112,13 @@ public class GrpcCallableFactory {
             clientContext.getTracerFactory(),
             getSpanName(grpcCallSettings.getMethodDescriptor()));
 
-    return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
+    Duration overallTimeout = callSettings.getOverallTimeout();
+    ApiCallContext context = clientContext.getDefaultCallContext();
+    if (context.getOverallTimeout() != null) {
+      overallTimeout = context.getOverallTimeout();
+    }
+
+    return callable.withDefaultCallContext(context.withOverallTimeout(overallTimeout));
   }
 
   /**
@@ -163,7 +171,14 @@ public class GrpcCallableFactory {
 
     UnaryCallable<RequestT, ResponseT> batchingCallable =
         Callables.batching(tracedCallable, batchingCallSettings, clientContext);
-    return batchingCallable.withDefaultCallContext(clientContext.getDefaultCallContext());
+
+    ApiCallContext context = clientContext.getDefaultCallContext();
+    Duration overallTimeout = batchingCallSettings.getOverallTimeout();
+    if (context.getOverallTimeout() != null) {
+      overallTimeout = context.getOverallTimeout();
+    }
+
+    return batchingCallable.withDefaultCallContext(context.withOverallTimeout(overallTimeout));
   }
 
   /**
@@ -299,7 +314,13 @@ public class GrpcCallableFactory {
             clientContext.getTracerFactory(),
             getSpanName(grpcCallSettings.getMethodDescriptor()));
 
-    return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
+    Duration overallTimeout = streamingCallSettings.getOverallTimeout();
+    ApiCallContext context = clientContext.getDefaultCallContext();
+    if (context.getOverallTimeout() != null) {
+      overallTimeout = context.getOverallTimeout();
+    }
+
+    return callable.withDefaultCallContext(context.withOverallTimeout(overallTimeout));
   }
 
   /**

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -122,6 +122,55 @@ public class GrpcCallContextTest {
   }
 
   @Test
+  public void testWithOverallTimeout() {
+    Truth.assertThat(GrpcCallContext.createDefault().withOverallTimeout(null).getOverallTimeout())
+        .isNull();
+  }
+
+  @Test
+  public void testWithNegativeOverallTimeout() {
+    Truth.assertThat(
+            GrpcCallContext.createDefault()
+                .withOverallTimeout(Duration.ofSeconds(-1L))
+                .getOverallTimeout())
+        .isNull();
+  }
+
+  @Test
+  public void testWithZeroOverallTimeout() {
+    Truth.assertThat(
+            GrpcCallContext.createDefault()
+                .withOverallTimeout(Duration.ofSeconds(0L))
+                .getOverallTimeout())
+        .isNull();
+  }
+
+  @Test
+  public void testWithLongerOverallTimeout() {
+    GrpcCallContext ctxWithShortOverallTimeout =
+        GrpcCallContext.createDefault().withOverallTimeout(Duration.ofSeconds(5));
+
+    // Sanity check
+    Truth.assertThat(ctxWithShortOverallTimeout.getOverallTimeout())
+        .isEqualTo(Duration.ofSeconds(5));
+
+    // Try to extend the timeout and verify that it was extended
+    GrpcCallContext ctxWithExtendedOverallTimeout =
+        ctxWithShortOverallTimeout.withOverallTimeout(Duration.ofSeconds(10));
+    Truth.assertThat(ctxWithExtendedOverallTimeout.getOverallTimeout())
+        .isEqualTo(Duration.ofSeconds(10));
+  }
+
+  @Test
+  public void testMergeWithOverallTimeout() {
+    Duration overallTimeout = Duration.ofSeconds(19);
+    GrpcCallContext ctx1 = GrpcCallContext.createDefault();
+    GrpcCallContext ctx2 = GrpcCallContext.createDefault().withOverallTimeout(overallTimeout);
+
+    Truth.assertThat(ctx1.merge(ctx2).getOverallTimeout()).isEqualTo(overallTimeout);
+  }
+
+  @Test
   public void testWithTimeout() {
     Truth.assertThat(GrpcCallContext.createDefault().withTimeout(null).getTimeout()).isNull();
   }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallableFactoryTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallableFactoryTest.java
@@ -30,11 +30,13 @@
 package com.google.api.gax.grpc;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import com.google.api.gax.grpc.testing.FakeServiceGrpc;
 import com.google.api.gax.grpc.testing.FakeServiceImpl;
 import com.google.api.gax.grpc.testing.InProcessServer;
 import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.ServerStreamingCallSettings;
@@ -201,5 +203,35 @@ public class GrpcCallableFactoryTest {
 
       assertThat(actualError).isNotNull();
     }
+  }
+
+  @Test
+  public void testSetDefaultOverallTimeoutRetainContextTimeout() {
+    Duration settingsTimeout = Duration.ofSeconds(3L);
+    Duration contextTimeout = Duration.ofSeconds(2L);
+    ApiCallContext context = GrpcCallContext.createDefault().withOverallTimeout(contextTimeout);
+
+    context = GrpcCallableFactory.setDefaultOverallTimeout(context, settingsTimeout);
+
+    assertEquals(context.getOverallTimeout(), contextTimeout);
+  }
+
+  @Test
+  public void testSetDefaultOverallTimeoutUseDefault() {
+    Duration settingsTimeout = Duration.ofSeconds(3L);
+    ApiCallContext context = GrpcCallContext.createDefault();
+
+    context = GrpcCallableFactory.setDefaultOverallTimeout(context, settingsTimeout);
+
+    assertEquals(context.getOverallTimeout(), settingsTimeout);
+  }
+
+  @Test
+  public void testSetDefaultOverallTimeoutNull() {
+    ApiCallContext context = GrpcCallContext.createDefault();
+
+    context = GrpcCallableFactory.setDefaultOverallTimeout(context, null);
+
+    assertEquals(context.getOverallTimeout(), null);
   }
 }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/SettingsTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/SettingsTest.java
@@ -451,6 +451,7 @@ public class SettingsTest {
     FakeSettings.Builder builderB = FakeSettings.Builder.createDefault();
     builderB
         .fakeMethodSimple()
+        .setOverallTimeout(timeout)
         .setRetryableCodes()
         .setRetrySettings(
             RetrySettings.newBuilder()
@@ -488,6 +489,7 @@ public class SettingsTest {
     UnaryCallSettings.Builder<Integer, Integer> builderB =
         UnaryCallSettings.newUnaryCallSettingsBuilder();
     builderB
+        .setOverallTimeout(timeout)
         .setRetryableCodes()
         .setRetrySettings(
             RetrySettings.newBuilder()

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/TimeoutTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/TimeoutTest.java
@@ -95,6 +95,7 @@ public class TimeoutTest {
             .setMaxAttempts(5)
             .setJittered(true)
             // The RPC timeout backoff options can be set, but are unused if
+            // overallTimeout is set. This helps verify they weren't used when
             // overallTimeout is set.
             .setInitialRpcTimeout(initialRpcTimeout)
             .setRpcTimeoutMultiplier(1.0)
@@ -144,7 +145,8 @@ public class TimeoutTest {
   @Test
   public void testNonRetryUnaryUnsetOverallTimeout() {
     // When the overallTimeout is unset, the RPC timeout backoff logic should
-    // kick in.
+    // kick in, and for a non-retryable RPC, the totalTimeout should be used as
+    // the RPC timeout for the lone RPC made.
     RetrySettings retrySettings = RetrySettings.newBuilder().setTotalTimeout(totalTimeout).build();
     CallOptions callOptionsUsed = setupUnaryCallable(emptyRetryCodes, retrySettings, null);
 

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/TimeoutTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/TimeoutTest.java
@@ -225,7 +225,7 @@ public class TimeoutTest {
 
   @Test
   public void testNonRetryServerStreamingOverallTimeout() {
-    RetrySettings retrySettings = RetrySettings.newBuilder().setTotalTimeout(totalTimeout).build();
+    RetrySettings retrySettings = RetrySettings.newBuilder().build();
     Duration overallTimeout = Duration.ofSeconds(30L);
     CallOptions callOptionsUsed =
         setupServerStreamingCallable(emptyRetryCodes, retrySettings, overallTimeout);

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/TimeoutTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/TimeoutTest.java
@@ -74,6 +74,8 @@ public class TimeoutTest {
   private static final int DEADLINE_IN_MINUTES = 10;
   private static final int DEADLINE_IN_SECONDS = 20;
   private static final ImmutableSet<StatusCode.Code> emptyRetryCodes = ImmutableSet.of();
+  private static final ImmutableSet<StatusCode.Code> retryUnkonwn =
+      ImmutableSet.of(StatusCode.Code.UNKNOWN);
   private static final Duration totalTimeout = Duration.ofDays(DEADLINE_IN_DAYS);
   private static final Duration maxRpcTimeout = Duration.ofMinutes(DEADLINE_IN_MINUTES);
   private static final Duration initialRpcTimeout = Duration.ofSeconds(DEADLINE_IN_SECONDS);
@@ -82,6 +84,78 @@ public class TimeoutTest {
   @Mock private Marshaller<String> stringMarshaller;
   @Mock private RequestParamsExtractor<String> paramsExtractor;
   @Mock private ManagedChannel managedChannel;
+
+  @Test
+  public void testRetryUnaryOverallTimeout() {
+    RetrySettings retrySettings =
+        RetrySettings.newBuilder()
+            .setInitialRetryDelay(Duration.ofMillis(100L))
+            .setRetryDelayMultiplier(1.0)
+            .setMaxRetryDelay(Duration.ofMillis(300L))
+            .setMaxAttempts(5)
+            .setJittered(true)
+            // The RPC timeout backoff options can be set, but are unused if
+            // overallTimeout is set.
+            .setInitialRpcTimeout(initialRpcTimeout)
+            .setRpcTimeoutMultiplier(1.0)
+            .setMaxRpcTimeout(maxRpcTimeout)
+            .setTotalTimeout(totalTimeout)
+            .build();
+    // Use an overallTimeout that is larger than initialRpcTimeout in order to
+    // validate that the timeout expansion logic isn't getting in the way.
+    Duration overallTimeout = Duration.ofSeconds(30);
+
+    CallOptions callOptionsUsed = setupUnaryCallable(retryUnkonwn, retrySettings, overallTimeout);
+
+    // Verify that the gRPC channel used the CallOptions with our custom timeout
+    // by verifying that it is roughly equal to overallTimeout
+    assertThat(callOptionsUsed.getDeadline()).isNotNull();
+    assertThat(callOptionsUsed.getDeadline())
+        .isLessThan(Deadline.after(overallTimeout.toMillis(), TimeUnit.MILLISECONDS));
+    assertThat(callOptionsUsed.getDeadline())
+        .isGreaterThan(
+            Deadline.after(
+                overallTimeout.minus(Duration.ofSeconds(1L)).toMillis(), TimeUnit.MILLISECONDS));
+    assertThat(callOptionsUsed.getAuthority()).isEqualTo(CALL_OPTIONS_AUTHORITY);
+  }
+
+  @Test
+  public void testNonRetryUnaryOverallTimeout() {
+    // In RPC timeout backoff world, the totalTimeout is used as the RPC timeout
+    // for non-retryable RPCs, thus we only provide that option.
+    RetrySettings retrySettings =
+        RetrySettings.newBuilder().setTotalTimeout(Duration.ofSeconds(5)).build();
+    Duration overallTimeout = Duration.ofSeconds(10);
+
+    CallOptions callOptionsUsed =
+        setupUnaryCallable(emptyRetryCodes, retrySettings, overallTimeout);
+
+    // Verify that the gRPC channel used the CallOptions with the overallTimeout
+    // of ~10 seconds, instead of the totalTimeout of ~5 seconds.
+    assertThat(callOptionsUsed.getDeadline()).isNotNull();
+    assertThat(callOptionsUsed.getDeadline())
+        .isLessThan(Deadline.after(overallTimeout.toMillis(), TimeUnit.MILLISECONDS));
+    assertThat(callOptionsUsed.getDeadline())
+        .isGreaterThan(
+            Deadline.after(retrySettings.getTotalTimeout().toMillis(), TimeUnit.MILLISECONDS));
+    assertThat(callOptionsUsed.getAuthority()).isEqualTo(CALL_OPTIONS_AUTHORITY);
+  }
+
+  @Test
+  public void testNonRetryUnaryUnsetOverallTimeout() {
+    // When the overallTimeout is unset, the RPC timeout backoff logic should
+    // kick in.
+    RetrySettings retrySettings = RetrySettings.newBuilder().setTotalTimeout(totalTimeout).build();
+    CallOptions callOptionsUsed = setupUnaryCallable(emptyRetryCodes, retrySettings, null);
+
+    // Verify that the gRPC channel used the CallOptions with the totalTimeout of ~2 Days.
+    assertThat(callOptionsUsed.getDeadline()).isNotNull();
+    assertThat(callOptionsUsed.getDeadline())
+        .isGreaterThan(Deadline.after(DEADLINE_IN_DAYS - 1, TimeUnit.DAYS));
+    assertThat(callOptionsUsed.getDeadline())
+        .isLessThan(Deadline.after(DEADLINE_IN_DAYS, TimeUnit.DAYS));
+    assertThat(callOptionsUsed.getAuthority()).isEqualTo(CALL_OPTIONS_AUTHORITY);
+  }
 
   @Test
   public void testNonRetryUnarySettings() {
@@ -97,57 +171,9 @@ public class TimeoutTest {
             .setRpcTimeoutMultiplier(1.0)
             .setMaxRpcTimeout(maxRpcTimeout)
             .build();
-    CallOptions callOptionsUsed = setupUnaryCallable(retrySettings);
+    CallOptions callOptionsUsed = setupUnaryCallable(emptyRetryCodes, retrySettings, null);
 
-    // Verify that the gRPC channel used the CallOptions with our custom timeout of ~2 Days.
-    assertThat(callOptionsUsed.getDeadline()).isNotNull();
-    assertThat(callOptionsUsed.getDeadline())
-        .isGreaterThan(Deadline.after(DEADLINE_IN_DAYS - 1, TimeUnit.DAYS));
-    assertThat(callOptionsUsed.getDeadline())
-        .isLessThan(Deadline.after(DEADLINE_IN_DAYS, TimeUnit.DAYS));
-    assertThat(callOptionsUsed.getAuthority()).isEqualTo(CALL_OPTIONS_AUTHORITY);
-  }
-
-  @Test
-  public void testNonRetryUnarySettingsWithoutInitialRpcTimeout() {
-    RetrySettings retrySettings =
-        RetrySettings.newBuilder()
-            .setTotalTimeout(totalTimeout)
-            .setInitialRetryDelay(Duration.ZERO)
-            .setRetryDelayMultiplier(1.0)
-            .setMaxRetryDelay(Duration.ZERO)
-            .setMaxAttempts(1)
-            .setJittered(true)
-            .setRpcTimeoutMultiplier(1.0)
-            .setMaxRpcTimeout(maxRpcTimeout)
-            .build();
-    CallOptions callOptionsUsed = setupUnaryCallable(retrySettings);
-
-    // Verify that the gRPC channel used the CallOptions with our custom timeout of ~2 Days.
-    assertThat(callOptionsUsed.getDeadline()).isNotNull();
-    assertThat(callOptionsUsed.getDeadline())
-        .isGreaterThan(Deadline.after(DEADLINE_IN_DAYS - 1, TimeUnit.DAYS));
-    assertThat(callOptionsUsed.getDeadline())
-        .isLessThan(Deadline.after(DEADLINE_IN_DAYS, TimeUnit.DAYS));
-    assertThat(callOptionsUsed.getAuthority()).isEqualTo(CALL_OPTIONS_AUTHORITY);
-  }
-
-  @Test
-  public void testNonRetryUnarySettingsWithoutIndividualRpcTimeout() {
-    RetrySettings retrySettings =
-        RetrySettings.newBuilder()
-            .setTotalTimeout(totalTimeout)
-            .setInitialRetryDelay(Duration.ZERO)
-            .setRetryDelayMultiplier(1.0)
-            .setMaxRetryDelay(Duration.ZERO)
-            .setMaxAttempts(1)
-            .setJittered(true)
-            .setRpcTimeoutMultiplier(1.0)
-            .setRpcTimeoutMultiplier(1.0)
-            .build();
-    CallOptions callOptionsUsed = setupUnaryCallable(retrySettings);
-
-    // Verify that the gRPC channel used the CallOptions with our custom timeout of ~2 Days.
+    // Verify that the gRPC channel used the CallOptions with the totalTimeout of ~2 Days.
     assertThat(callOptionsUsed.getDeadline()).isNotNull();
     assertThat(callOptionsUsed.getDeadline())
         .isGreaterThan(Deadline.after(DEADLINE_IN_DAYS - 1, TimeUnit.DAYS));
@@ -170,9 +196,10 @@ public class TimeoutTest {
             .setRpcTimeoutMultiplier(1.0)
             .setMaxRpcTimeout(maxRpcTimeout)
             .build();
-    CallOptions callOptionsUsed = setupServerStreamingCallable(retrySettings);
+    CallOptions callOptionsUsed =
+        setupServerStreamingCallable(emptyRetryCodes, retrySettings, null);
 
-    // Verify that the gRPC channel used the CallOptions with our custom timeout of ~2 Days.
+    // Verify that the gRPC channel used the CallOptions with the totalTimeout of ~2 Days.
     assertThat(callOptionsUsed.getDeadline()).isNotNull();
     assertThat(callOptionsUsed.getDeadline())
         .isGreaterThan(Deadline.after(DEADLINE_IN_DAYS - 1, TimeUnit.DAYS));
@@ -182,54 +209,71 @@ public class TimeoutTest {
   }
 
   @Test
-  public void testNonRetryServerStreamingSettingsWithoutInitialRpcTimeout() {
+  public void testNonRetryServerStreamingUnsetOverallTimeout() {
+    RetrySettings retrySettings = RetrySettings.newBuilder().setTotalTimeout(totalTimeout).build();
+    CallOptions callOptionsUsed =
+        setupServerStreamingCallable(emptyRetryCodes, retrySettings, null);
+
+    // Verify that the gRPC channel used the CallOptions with the totalTimeout of ~2 Days.
+    assertThat(callOptionsUsed.getDeadline()).isNotNull();
+    assertThat(callOptionsUsed.getDeadline())
+        .isGreaterThan(Deadline.after(DEADLINE_IN_DAYS - 1, TimeUnit.DAYS));
+    assertThat(callOptionsUsed.getDeadline())
+        .isLessThan(Deadline.after(DEADLINE_IN_DAYS, TimeUnit.DAYS));
+    assertThat(callOptionsUsed.getAuthority()).isEqualTo(CALL_OPTIONS_AUTHORITY);
+  }
+
+  @Test
+  public void testNonRetryServerStreamingOverallTimeout() {
+    RetrySettings retrySettings = RetrySettings.newBuilder().setTotalTimeout(totalTimeout).build();
+    Duration overallTimeout = Duration.ofSeconds(30L);
+    CallOptions callOptionsUsed =
+        setupServerStreamingCallable(emptyRetryCodes, retrySettings, overallTimeout);
+
+    // Verify that the gRPC channel used the CallOptions with the overallTimeout of ~30 seconds.
+    assertThat(callOptionsUsed.getDeadline()).isNotNull();
+    assertThat(callOptionsUsed.getDeadline())
+        .isLessThan(Deadline.after(overallTimeout.toMillis(), TimeUnit.MILLISECONDS));
+    assertThat(callOptionsUsed.getDeadline())
+        .isGreaterThan(
+            Deadline.after(
+                overallTimeout.minus(Duration.ofSeconds(1L)).toMillis(), TimeUnit.MILLISECONDS));
+    assertThat(callOptionsUsed.getAuthority()).isEqualTo(CALL_OPTIONS_AUTHORITY);
+  }
+
+  @Test
+  public void testRetryServerStreamingOverallTimeout() {
     RetrySettings retrySettings =
         RetrySettings.newBuilder()
-            .setTotalTimeout(totalTimeout)
             .setInitialRetryDelay(Duration.ZERO)
             .setRetryDelayMultiplier(1.0)
             .setMaxRetryDelay(Duration.ZERO)
             .setMaxAttempts(1)
             .setJittered(true)
+            // The RPC timeout backoff options can be set, but are unused if
+            // overallTimeout is set.
+            .setInitialRpcTimeout(initialRpcTimeout)
             .setRpcTimeoutMultiplier(1.0)
             .setMaxRpcTimeout(maxRpcTimeout)
-            .build();
-    CallOptions callOptionsUsed = setupServerStreamingCallable(retrySettings);
-
-    // Verify that the gRPC channel used the CallOptions with our custom timeout of ~2 Days.
-    assertThat(callOptionsUsed.getDeadline()).isNotNull();
-    assertThat(callOptionsUsed.getDeadline())
-        .isGreaterThan(Deadline.after(DEADLINE_IN_DAYS - 1, TimeUnit.DAYS));
-    assertThat(callOptionsUsed.getDeadline())
-        .isLessThan(Deadline.after(DEADLINE_IN_DAYS, TimeUnit.DAYS));
-    assertThat(callOptionsUsed.getAuthority()).isEqualTo(CALL_OPTIONS_AUTHORITY);
-  }
-
-  @Test
-  public void testNonRetryServerStreamingSettingsWithoutIndividualRpcTimeout() {
-    RetrySettings retrySettings =
-        RetrySettings.newBuilder()
             .setTotalTimeout(totalTimeout)
-            .setInitialRetryDelay(Duration.ZERO)
-            .setRetryDelayMultiplier(1.0)
-            .setMaxRetryDelay(Duration.ZERO)
-            .setMaxAttempts(1)
-            .setJittered(true)
-            .setRpcTimeoutMultiplier(1.0)
-            .setRpcTimeoutMultiplier(1.0)
             .build();
-    CallOptions callOptionsUsed = setupServerStreamingCallable(retrySettings);
+    Duration overallTimeout = Duration.ofSeconds(30L);
+    CallOptions callOptionsUsed =
+        setupServerStreamingCallable(retryUnkonwn, retrySettings, overallTimeout);
 
-    // Verify that the gRPC channel used the CallOptions with our custom timeout of ~2 Days.
+    // Verify that the gRPC channel used the CallOptions with the overallTimeout of ~30 seconds.
     assertThat(callOptionsUsed.getDeadline()).isNotNull();
     assertThat(callOptionsUsed.getDeadline())
-        .isGreaterThan(Deadline.after(DEADLINE_IN_DAYS - 1, TimeUnit.DAYS));
+        .isLessThan(Deadline.after(overallTimeout.toMillis(), TimeUnit.MILLISECONDS));
     assertThat(callOptionsUsed.getDeadline())
-        .isLessThan(Deadline.after(DEADLINE_IN_DAYS, TimeUnit.DAYS));
+        .isGreaterThan(
+            Deadline.after(
+                overallTimeout.minus(Duration.ofSeconds(1L)).toMillis(), TimeUnit.MILLISECONDS));
     assertThat(callOptionsUsed.getAuthority()).isEqualTo(CALL_OPTIONS_AUTHORITY);
   }
 
-  private CallOptions setupUnaryCallable(RetrySettings retrySettings) {
+  private CallOptions setupUnaryCallable(
+      ImmutableSet<StatusCode.Code> codes, RetrySettings retrySettings, Duration overallTimeout) {
     MethodDescriptor<String, String> methodDescriptor =
         MethodDescriptor.<String, String>newBuilder()
             .setSchemaDescriptor("yaml")
@@ -248,7 +292,7 @@ public class TimeoutTest {
     // Clobber the "authority" property with an identifier that allows us to trace
     // the use of this CallOptions variable.
     CallOptions spyCallOptions = CallOptions.DEFAULT.withAuthority("RETRYING_TEST");
-    GrpcCallContext grpcCallContext =
+    GrpcCallContext defaultCallContext =
         GrpcCallContext.createDefault().withChannel(managedChannel).withCallOptions(spyCallOptions);
 
     ArgumentCaptor<CallOptions> callOptionsArgumentCaptor =
@@ -266,16 +310,17 @@ public class TimeoutTest {
             .setMethodDescriptor(methodDescriptor)
             .setParamsExtractor(paramsExtractor)
             .build();
-    UnaryCallSettings<String, String> nonRetriedCallSettings =
+    UnaryCallSettings<String, String> callSettings =
         UnaryCallSettings.<String, String>newUnaryCallSettingsBuilder()
             .setRetrySettings(retrySettings)
-            .setRetryableCodes(emptyRetryCodes)
+            .setRetryableCodes(codes)
+            .setOverallTimeout(overallTimeout)
             .build();
     UnaryCallable<String, String> callable =
         GrpcCallableFactory.createUnaryCallable(
             grpcCallSettings,
-            nonRetriedCallSettings,
-            ClientContext.newBuilder().setDefaultCallContext(grpcCallContext).build());
+            callSettings,
+            ClientContext.newBuilder().setDefaultCallContext(defaultCallContext).build());
 
     try {
       ApiFuture<String> future = callable.futureCall("Is your refrigerator running?");
@@ -287,7 +332,8 @@ public class TimeoutTest {
     return callOptionsArgumentCaptor.getValue();
   }
 
-  private CallOptions setupServerStreamingCallable(RetrySettings retrySettings) {
+  private CallOptions setupServerStreamingCallable(
+      ImmutableSet<StatusCode.Code> codes, RetrySettings retrySettings, Duration overallTimeout) {
     MethodDescriptor<String, String> methodDescriptor =
         MethodDescriptor.<String, String>newBuilder()
             .setSchemaDescriptor("yaml")
@@ -306,7 +352,7 @@ public class TimeoutTest {
     // Clobber the "authority" property with an identifier that allows us to trace
     // the use of this CallOptions variable.
     CallOptions spyCallOptions = CallOptions.DEFAULT.withAuthority("RETRYING_TEST");
-    GrpcCallContext grpcCallContext =
+    GrpcCallContext defaultCallContext =
         GrpcCallContext.createDefault().withChannel(managedChannel).withCallOptions(spyCallOptions);
 
     ArgumentCaptor<CallOptions> callOptionsArgumentCaptor =
@@ -324,16 +370,17 @@ public class TimeoutTest {
             .setMethodDescriptor(methodDescriptor)
             .setParamsExtractor(paramsExtractor)
             .build();
-    ServerStreamingCallSettings<String, String> nonRetriedCallSettings =
+    ServerStreamingCallSettings<String, String> callSettings =
         ServerStreamingCallSettings.<String, String>newBuilder()
             .setRetrySettings(retrySettings)
-            .setRetryableCodes(emptyRetryCodes)
+            .setRetryableCodes(codes)
+            .setOverallTimeout(overallTimeout)
             .build();
     ServerStreamingCallable<String, String> callable =
         GrpcCallableFactory.createServerStreamingCallable(
             grpcCallSettings,
-            nonRetriedCallSettings,
-            ClientContext.newBuilder().setDefaultCallContext(grpcCallContext).build());
+            callSettings,
+            ClientContext.newBuilder().setDefaultCallContext(defaultCallContext).build());
 
     try {
       ServerStream<String> stream = callable.call("Is your refrigerator running?");

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
@@ -80,6 +80,11 @@ public class HttpJsonCallableFactory {
       overallTimeout = context.getOverallTimeout();
     }
 
+    // The overall timeout must be included with the default call context, otherwise it will be
+    // null.
+    // The context is the main vehicle for the overall timeout through the call stack, so the
+    // default
+    // provided by the UnaryCallSettings must be retained.
     return callable.withDefaultCallContext(context.withOverallTimeout(overallTimeout));
   }
 

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
@@ -32,6 +32,7 @@ package com.google.api.gax.httpjson;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.Callables;
 import com.google.api.gax.rpc.ClientContext;
@@ -47,6 +48,7 @@ import com.google.common.base.Preconditions;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
+import org.threeten.bp.Duration;
 
 /** Class with utility methods to create http/json-based direct callables. */
 @BetaApi
@@ -71,7 +73,14 @@ public class HttpJsonCallableFactory {
     UnaryCallable<RequestT, ResponseT> callable =
         new HttpJsonExceptionCallable<>(innerCallable, callSettings.getRetryableCodes());
     callable = Callables.retrying(callable, callSettings, clientContext);
-    return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
+
+    Duration overallTimeout = callSettings.getOverallTimeout();
+    ApiCallContext context = clientContext.getDefaultCallContext();
+    if (context.getOverallTimeout() != null) {
+      overallTimeout = context.getOverallTimeout();
+    }
+
+    return callable.withDefaultCallContext(context.withOverallTimeout(overallTimeout));
   }
 
   /**
@@ -138,7 +147,14 @@ public class HttpJsonCallableFactory {
     callable = createUnaryCallable(callable, pagedCallSettings, clientContext);
     UnaryCallable<RequestT, PagedListResponseT> pagedCallable =
         Callables.paged(callable, pagedCallSettings);
-    return pagedCallable.withDefaultCallContext(clientContext.getDefaultCallContext());
+
+    Duration overallTimeout = pagedCallSettings.getOverallTimeout();
+    ApiCallContext context = clientContext.getDefaultCallContext();
+    if (context.getOverallTimeout() != null) {
+      overallTimeout = context.getOverallTimeout();
+    }
+
+    return pagedCallable.withDefaultCallContext(context.withOverallTimeout(overallTimeout));
   }
 
   /**
@@ -158,7 +174,14 @@ public class HttpJsonCallableFactory {
     UnaryCallable<RequestT, ResponseT> callable = createDirectUnaryCallable(httpJsonCallSettings);
     callable = createUnaryCallable(callable, batchingCallSettings, clientContext);
     callable = Callables.batching(callable, batchingCallSettings, clientContext);
-    return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
+
+    Duration overallTimeout = batchingCallSettings.getOverallTimeout();
+    ApiCallContext context = clientContext.getDefaultCallContext();
+    if (context.getOverallTimeout() != null) {
+      overallTimeout = context.getOverallTimeout();
+    }
+
+    return callable.withDefaultCallContext(context.withOverallTimeout(overallTimeout));
   }
 
   @BetaApi(

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallContextTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallContextTest.java
@@ -170,6 +170,57 @@ public class HttpJsonCallContextTest {
   }
 
   @Test
+  public void testWithOverallTimeout() {
+    Truth.assertThat(
+            HttpJsonCallContext.createDefault().withOverallTimeout(null).getOverallTimeout())
+        .isNull();
+  }
+
+  @Test
+  public void testWithNegativeOverallTimeout() {
+    Truth.assertThat(
+            HttpJsonCallContext.createDefault()
+                .withOverallTimeout(Duration.ofSeconds(-1L))
+                .getOverallTimeout())
+        .isNull();
+  }
+
+  @Test
+  public void testWithZeroOverallTimeout() {
+    Truth.assertThat(
+            HttpJsonCallContext.createDefault()
+                .withOverallTimeout(Duration.ofSeconds(0L))
+                .getOverallTimeout())
+        .isNull();
+  }
+
+  @Test
+  public void testWithLongerOverallTimeout() {
+    HttpJsonCallContext ctxWithShortOverallTimeout =
+        HttpJsonCallContext.createDefault().withOverallTimeout(Duration.ofSeconds(5));
+
+    // Sanity check
+    Truth.assertThat(ctxWithShortOverallTimeout.getOverallTimeout())
+        .isEqualTo(Duration.ofSeconds(5));
+
+    // Try to extend the timeout and verify that it was extended
+    HttpJsonCallContext ctxWithExtendedOverallTimeout =
+        ctxWithShortOverallTimeout.withOverallTimeout(Duration.ofSeconds(10));
+    Truth.assertThat(ctxWithExtendedOverallTimeout.getOverallTimeout())
+        .isEqualTo(Duration.ofSeconds(10));
+  }
+
+  @Test
+  public void testMergeWithOverallTimeout() {
+    Duration overallTimeout = Duration.ofSeconds(19);
+    HttpJsonCallContext ctx1 = HttpJsonCallContext.createDefault();
+    HttpJsonCallContext ctx2 =
+        HttpJsonCallContext.createDefault().withOverallTimeout(overallTimeout);
+
+    Truth.assertThat(ctx1.merge(ctx2).getOverallTimeout()).isEqualTo(overallTimeout);
+  }
+
+  @Test
   public void testMergeWithTracer() {
     ApiTracer explicitTracer = Mockito.mock(ApiTracer.class);
     HttpJsonCallContext ctxWithExplicitTracer =

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallableFactoryTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallableFactoryTest.java
@@ -31,8 +31,10 @@ package com.google.api.gax.httpjson;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.assertEquals;
 
 import com.google.api.client.http.HttpMethods;
+import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.tracing.SpanName;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -43,6 +45,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
+import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class HttpJsonCallableFactoryTest {
@@ -94,5 +97,35 @@ public class HttpJsonCallableFactoryTest {
       }
       assertThat(actualError).isNotNull();
     }
+  }
+
+  @Test
+  public void testSetDefaultOverallTimeoutRetainContextTimeout() {
+    Duration settingsTimeout = Duration.ofSeconds(3L);
+    Duration contextTimeout = Duration.ofSeconds(2L);
+    ApiCallContext context = HttpJsonCallContext.createDefault().withOverallTimeout(contextTimeout);
+
+    context = HttpJsonCallableFactory.setDefaultOverallTimeout(context, settingsTimeout);
+
+    assertEquals(context.getOverallTimeout(), contextTimeout);
+  }
+
+  @Test
+  public void testSetDefaultOverallTimeoutUseDefault() {
+    Duration settingsTimeout = Duration.ofSeconds(3L);
+    ApiCallContext context = HttpJsonCallContext.createDefault();
+
+    context = HttpJsonCallableFactory.setDefaultOverallTimeout(context, settingsTimeout);
+
+    assertEquals(context.getOverallTimeout(), settingsTimeout);
+  }
+
+  @Test
+  public void testSetDefaultOverallTimeoutNull() {
+    ApiCallContext context = HttpJsonCallContext.createDefault();
+
+    context = HttpJsonCallableFactory.setDefaultOverallTimeout(context, null);
+
+    assertEquals(context.getOverallTimeout(), null);
   }
 }

--- a/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
@@ -77,7 +77,7 @@ class BasicRetryingFuture<ResponseT> extends AbstractFuture<ResponseT>
     this.retryAlgorithm = checkNotNull(retryAlgorithm);
     this.retryingContext = checkNotNull(context);
 
-    this.attemptSettings = retryAlgorithm.createFirstAttempt();
+    this.attemptSettings = retryAlgorithm.createFirstAttempt(retryingContext);
 
     // A micro crime, letting "this" reference to escape from constructor before initialization is
     // completed (via internal non-static class CompletionListener). But it is guaranteed to be ok,

--- a/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
@@ -77,6 +77,8 @@ class BasicRetryingFuture<ResponseT> extends AbstractFuture<ResponseT>
     this.retryAlgorithm = checkNotNull(retryAlgorithm);
     this.retryingContext = checkNotNull(context);
 
+    // Supply the RetryingContext to the RetryAlgorithm in order to carry
+    // call-time setting adjustments made by the caller.
     this.attemptSettings = retryAlgorithm.createFirstAttempt(retryingContext);
 
     // A micro crime, letting "this" reference to escape from constructor before initialization is

--- a/gax/src/main/java/com/google/api/gax/retrying/NoopRetryingContext.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/NoopRetryingContext.java
@@ -35,6 +35,8 @@ package com.google.api.gax.retrying;
 import com.google.api.gax.tracing.ApiTracer;
 import com.google.api.gax.tracing.NoopApiTracer;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.threeten.bp.Duration;
 
 /**
  * Backwards compatibility class to aid in transition to adding operation state to {@link
@@ -50,5 +52,10 @@ class NoopRetryingContext implements RetryingContext {
   @Override
   public ApiTracer getTracer() {
     return NoopApiTracer.getInstance();
+  }
+
+  @Nullable
+  public Duration getOverallTimeout() {
+    return null;
   }
 }

--- a/gax/src/main/java/com/google/api/gax/retrying/RetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetryAlgorithm.java
@@ -69,6 +69,23 @@ public class RetryAlgorithm<ResponseT> {
     return timedAlgorithm.createFirstAttempt();
   }
 
+  public TimedAttemptSettings createFirstAttempt(RetryingContext context) {
+    TimedAttemptSettings firstAttempt = timedAlgorithm.createFirstAttempt();
+
+    // Use the overallTimeout as the timeout for the first RPC attempt, and provide
+    // overallTimeout to the settings for future use.
+    if (context.getOverallTimeout() != null) {
+      firstAttempt =
+          firstAttempt
+              .toBuilder()
+              .setRpcTimeout(context.getOverallTimeout())
+              .setOverallTimeout(context.getOverallTimeout())
+              .build();
+    }
+
+    return firstAttempt;
+  }
+
   /**
    * Creates a next attempt {@link TimedAttemptSettings}. This method will return first non-null
    * value, returned by either result or timed retry algorithms in that particular order.

--- a/gax/src/main/java/com/google/api/gax/retrying/RetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetryAlgorithm.java
@@ -69,11 +69,18 @@ public class RetryAlgorithm<ResponseT> {
     return timedAlgorithm.createFirstAttempt();
   }
 
+  /**
+   * Creates a first attempt {@link TimedAttemptSettings} that can be influenced by the
+   * RetryingContext, including use of the overall timeout.
+   *
+   * @return first attempt settings
+   */
   public TimedAttemptSettings createFirstAttempt(RetryingContext context) {
     TimedAttemptSettings firstAttempt = timedAlgorithm.createFirstAttempt();
 
-    // Use the overallTimeout as the timeout for the first RPC attempt, and provide
-    // overallTimeout to the settings for future use.
+    // Use the overall timeout as the timeout for the first RPC attempt, and provide
+    // overall timeout to the TimedAttemptSetings for future use in calculating
+    // per-RPC attempt timeouts relative to it.
     if (context.getOverallTimeout() != null) {
       firstAttempt =
           firstAttempt

--- a/gax/src/main/java/com/google/api/gax/retrying/RetrySettings.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetrySettings.java
@@ -41,6 +41,9 @@ import org.threeten.bp.Duration;
  * fail (and return an error code) or not respond (and cause a timeout). When there is a failure or
  * timeout, the logic should keep trying until the total timeout has passed.
  *
+ * <p>Note: an overall timeout provided via the RetryingContext should take precedence over the
+ * timeout settings defined here.
+ *
  * <p>The "total timeout" and "max attempts" settings have ultimate control over how long the logic
  * should keep trying the remote call until it gives up completely. The remote call will be retried
  * until one of those thresholds is crossed. To avoid unbounded rpc calls, it is required to
@@ -52,14 +55,11 @@ import org.threeten.bp.Duration;
  *
  * <p>If the last remote call is a failure, then the retrier will wait for the current retry delay
  * before attempting another call, and then the retry delay will be multiplied by the retry delay
- * multiplier for the next failure. The timeout will not be affected, except in the case where the
- * timeout would result in a deadline past the total timeout; in that circumstance, a new timeout
- * value is computed which will terminate the call when the total time is up.
+ * multiplier for the next failure.
  *
  * <p>If the last remote call is a timeout, then the retrier will compute a new timeout and make
  * another call. The new timeout is computed by multiplying the current timeout by the timeout
- * multiplier, but if that results in a deadline after the total timeout, then a new timeout value
- * is computed which will terminate the call when the total time is up.
+ * multiplier on each new attempt, with the maximum RPC timeout being the ceiling.
  *
  * <p>Server streaming RPCs interpret RPC timeouts a bit differently. For server streaming RPCs, the
  * RPC timeout gets converted into a wait timeout {@link

--- a/gax/src/main/java/com/google/api/gax/retrying/RetryingContext.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetryingContext.java
@@ -32,6 +32,8 @@ package com.google.api.gax.retrying;
 import com.google.api.core.BetaApi;
 import com.google.api.gax.tracing.ApiTracer;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.threeten.bp.Duration;
 
 /**
  * Context for a retryable operation.
@@ -43,4 +45,7 @@ public interface RetryingContext {
   /** Returns the {@link ApiTracer} associated with the current operation. */
   @Nonnull
   ApiTracer getTracer();
+
+  @Nullable
+  Duration getOverallTimeout();
 }

--- a/gax/src/main/java/com/google/api/gax/retrying/TimedAttemptSettings.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/TimedAttemptSettings.java
@@ -44,6 +44,7 @@ public abstract class TimedAttemptSettings {
   /** Returns global (attempt-independent) retry settings. */
   public abstract RetrySettings getGlobalSettings();
 
+  /** Returns the global (attempt-indepedent) overall timeout */
   @Nullable
   public abstract Duration getOverallTimeout();
 
@@ -92,6 +93,7 @@ public abstract class TimedAttemptSettings {
     /** Sets global (attempt-independent) retry settings. */
     public abstract Builder setGlobalSettings(RetrySettings value);
 
+    /** Sets global (atttempt-independent) overall timeout. */
     public abstract Builder setOverallTimeout(@Nullable Duration value);
 
     /**

--- a/gax/src/main/java/com/google/api/gax/retrying/TimedAttemptSettings.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/TimedAttemptSettings.java
@@ -33,6 +33,7 @@ import com.google.api.core.ApiClock;
 import com.google.api.core.BetaApi;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.AutoValue.Builder;
+import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
 /** Timed attempt execution settings. Defines time-specific properties of a retry attempt. */
@@ -42,6 +43,9 @@ public abstract class TimedAttemptSettings {
 
   /** Returns global (attempt-independent) retry settings. */
   public abstract RetrySettings getGlobalSettings();
+
+  @Nullable
+  public abstract Duration getOverallTimeout();
 
   /**
    * Returns the calculated retry delay. Note that the actual delay used for retry scheduling may be
@@ -87,6 +91,8 @@ public abstract class TimedAttemptSettings {
   public abstract static class Builder {
     /** Sets global (attempt-independent) retry settings. */
     public abstract Builder setGlobalSettings(RetrySettings value);
+
+    public abstract Builder setOverallTimeout(@Nullable Duration value);
 
     /**
      * Sets the calculated retry delay. Note that the actual delay used for retry scheduling may be

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -60,21 +60,35 @@ public interface ApiCallContext extends RetryingContext {
   ApiCallContext withTransportChannel(TransportChannel channel);
 
   /**
-   * Returns a new ApiCallContext with the given timeout set.
+   * Returns a new ApiCallContext with the given RPC timeout set.
    *
    * <p>This sets the maximum amount of time a single unary RPC attempt can take. If retries are
-   * enabled, then this can take much longer. Unlike a deadline, timeouts are relative durations
-   * that are measure from the beginning of each RPC attempt. Please note that this will limit the
-   * duration of a server streaming RPC as well.
+   * enabled, then this can take much longer. Furthermore, the timeout calculated by the {@link
+   * com.google.api.gax.retrying.RetrySettings} may take precedence over any value provided here.
+   * Unlike a deadline, timeouts are relative durations that are measure from the beginning of each
+   * RPC attempt. Please note that this will limit the duration of a server streaming RPC as well.
+   *
+   * <p>To increase the overall timeout of the call rather than individual RPC attempts, use {@link
+   * #withOverallTimeout(Duration)}.
    */
   ApiCallContext withTimeout(@Nullable Duration timeout);
 
+  /**
+   * Returns a new ApiCallContext with the given overall timeout set.
+   *
+   * <p>This sets the maximum amount of time the entire call can take. Unlike a deadline, the
+   * overall timeout is relative duration that is measured from the beginning of the call. If
+   * retries are enabled, RPC attempts will respect the overall timeout and not surpass it. This can
+   * be used instead of {@link #withTimeout(Duration)} to limit the duration of a server streaming
+   * RPC as well.
+   */
   ApiCallContext withOverallTimeout(@Nullable Duration timeout);
 
   /** Returns the configured per-RPC timeout. */
   @Nullable
   Duration getTimeout();
 
+  /** Returns the configured overall timeout. */
   @Nullable
   Duration getOverallTimeout();
 

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -69,9 +69,14 @@ public interface ApiCallContext extends RetryingContext {
    */
   ApiCallContext withTimeout(@Nullable Duration timeout);
 
+  ApiCallContext withOverallTimeout(@Nullable Duration timeout);
+
   /** Returns the configured per-RPC timeout. */
   @Nullable
   Duration getTimeout();
+
+  @Nullable
+  Duration getOverallTimeout();
 
   /**
    * Returns a new ApiCallContext with the given stream timeout set.

--- a/gax/src/main/java/com/google/api/gax/rpc/BatchingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/BatchingCallSettings.java
@@ -37,6 +37,7 @@ import com.google.api.gax.retrying.RetrySettings;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import java.util.Set;
+import org.threeten.bp.Duration;
 
 /**
  * A settings class to configure a {@link UnaryCallable} for calls to an API method that supports
@@ -88,6 +89,7 @@ public final class BatchingCallSettings<RequestT, ResponseT>
     return MoreObjects.toStringHelper(this)
         .add("retryableCodes", getRetryableCodes())
         .add("retrySettings", getRetrySettings())
+        .add("overallTimeout", getOverallTimeout())
         .add("batchingSettings", batchingSettings)
         .toString();
   }
@@ -148,6 +150,12 @@ public final class BatchingCallSettings<RequestT, ResponseT>
     @Override
     public Builder<RequestT, ResponseT> setRetrySettings(RetrySettings retrySettings) {
       super.setRetrySettings(retrySettings);
+      return this;
+    }
+
+    @Override
+    public Builder<RequestT, ResponseT> setOverallTimeout(Duration overallTimeout) {
+      super.setOverallTimeout(overallTimeout);
       return this;
     }
 

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -60,7 +60,7 @@ public class Callables {
     if (areRetriesDisabled(callSettings.getRetryableCodes(), callSettings.getRetrySettings())) {
       // When retries are disabled, the overall timeout or total timeout can be treated as the rpc
       // timeout. The timedAlgorithm used in RetryAlgoirthm will set the first attempt rpcTimeout
-      // to initialRpcTimeout. If the RPC is not retryable, this is wrong, and the totalTimeout
+      // to initialRpcTimeout. If the RPC is not retryable, the totalTimeout
       // or overallTimeout should be used instead for the life of the callable.
       Duration timeout =
           callSettings.getOverallTimeout() != null
@@ -100,7 +100,7 @@ public class Callables {
     if (areRetriesDisabled(callSettings.getRetryableCodes(), callSettings.getRetrySettings())) {
       // When retries are disabled, the overall timeout or total timeout can be treated as the rpc
       // timeout. The timedAlgorithm used in RetryAlgoirthm will set the first attempt rpcTimeout
-      // to initialRpcTimeout. If the RPC is not retryable, this is wrong, and the totalTimeout
+      // to initialRpcTimeout. If the RPC is not retryable, and the totalTimeout
       // or overallTimeout should be used instead for the life of the callable.
       Duration timeout =
           callSettings.getOverallTimeout() != null

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -66,18 +66,7 @@ public class Callables {
           callSettings.getOverallTimeout() != null
               ? callSettings.getOverallTimeout()
               : callSettings.getRetrySettings().getTotalTimeout();
-      callSettings =
-          callSettings
-              .toBuilder()
-              .setRetrySettings(
-                  callSettings
-                      .getRetrySettings()
-                      .toBuilder()
-                      // Initial must never be greater than max, so set both.
-                      .setInitialRpcTimeout(timeout)
-                      .setMaxRpcTimeout(timeout)
-                      .build())
-              .build();
+      callSettings = callSettings.toBuilder().setSimpleTimeoutNoRetries(timeout).build();
     }
 
     RetryAlgorithm<ResponseT> retryAlgorithm =
@@ -100,27 +89,13 @@ public class Callables {
     if (areRetriesDisabled(callSettings.getRetryableCodes(), callSettings.getRetrySettings())) {
       // When retries are disabled, the overall timeout or total timeout can be treated as the rpc
       // timeout. The timedAlgorithm used in RetryAlgoirthm will set the first attempt rpcTimeout
-      // to initialRpcTimeout. If the RPC is not retryable, and the totalTimeout
+      // to initialRpcTimeout. If the RPC is not retryable, the totalTimeout
       // or overallTimeout should be used instead for the life of the callable.
       Duration timeout =
           callSettings.getOverallTimeout() != null
               ? callSettings.getOverallTimeout()
               : callSettings.getRetrySettings().getTotalTimeout();
-      callSettings =
-          callSettings
-              .toBuilder()
-              .setRetrySettings(
-                  callSettings
-                      .getRetrySettings()
-                      .toBuilder()
-                      // Initial must never be greater than max, so set both.
-                      .setInitialRpcTimeout(timeout)
-                      .setMaxRpcTimeout(timeout)
-                      // set totalTimeout to the timeout chosen because it is
-                      // used by ServerStreamingAttemptCallable in start().
-                      .setTotalTimeout(timeout)
-                      .build())
-              .build();
+      callSettings = callSettings.toBuilder().setSimpleTimeoutNoRetries(timeout).build();
     }
 
     StreamingRetryAlgorithm<Void> retryAlgorithm =

--- a/gax/src/main/java/com/google/api/gax/rpc/PagedCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/PagedCallSettings.java
@@ -32,6 +32,7 @@ package com.google.api.gax.rpc;
 import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.retrying.RetrySettings;
 import java.util.Set;
+import org.threeten.bp.Duration;
 
 /**
  * A settings class to configure a {@link UnaryCallable} for calls to an API method that supports
@@ -99,6 +100,13 @@ public final class PagedCallSettings<RequestT, ResponseT, PagedListResponseT>
     public Builder<RequestT, ResponseT, PagedListResponseT> setRetrySettings(
         RetrySettings retrySettings) {
       super.setRetrySettings(retrySettings);
+      return this;
+    }
+
+    @Override
+    public Builder<RequestT, ResponseT, PagedListResponseT> setOverallTimeout(
+        Duration overallTimeout) {
+      super.setOverallTimeout(overallTimeout);
       return this;
     }
 

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
@@ -181,13 +181,17 @@ final class ServerStreamingAttemptCallable<RequestT, ResponseT> implements Calla
     }
     isStarted = true;
 
-    // Propagate the totalTimeout as the overall stream deadline, so long as the user
+    // Propagate the totalTimeout or overallTimeout as the overall stream deadline, so long as the
+    // user
     // has not provided a timeout via the ApiCallContext. If they have, retain it.
-    Duration totalTimeout =
+    Duration timeout =
         outerRetryingFuture.getAttemptSettings().getGlobalSettings().getTotalTimeout();
+    if (context != null && context.getOverallTimeout() != null) {
+      timeout = context.getOverallTimeout();
+    }
 
-    if (totalTimeout != null && context != null && context.getTimeout() == null) {
-      context = context.withTimeout(totalTimeout);
+    if (timeout != null && context != null && context.getTimeout() == null) {
+      context = context.withTimeout(timeout);
     }
 
     // Call the inner callable

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
@@ -184,14 +184,14 @@ final class ServerStreamingAttemptCallable<RequestT, ResponseT> implements Calla
     // Propagate the totalTimeout or overallTimeout as the overall stream deadline, so long as the
     // user
     // has not provided a timeout via the ApiCallContext. If they have, retain it.
-    Duration timeout =
+    Duration overallTimeout =
         outerRetryingFuture.getAttemptSettings().getGlobalSettings().getTotalTimeout();
     if (context != null && context.getOverallTimeout() != null) {
-      timeout = context.getOverallTimeout();
+      overallTimeout = context.getOverallTimeout();
     }
 
-    if (timeout != null && context != null && context.getTimeout() == null) {
-      context = context.withTimeout(timeout);
+    if (overallTimeout != null && context != null && context.getTimeout() == null) {
+      context = context.withTimeout(overallTimeout);
     }
 
     // Call the inner callable

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
@@ -181,9 +181,9 @@ final class ServerStreamingAttemptCallable<RequestT, ResponseT> implements Calla
     }
     isStarted = true;
 
-    // Propagate the totalTimeout or overallTimeout as the overall stream deadline, so long as the
-    // user
-    // has not provided a timeout via the ApiCallContext. If they have, retain it.
+    // Propagate the RetrySettings.totalTimeout or ApiCallContext.overallTimeout
+    // as the overall stream deadline, so long as the user has not provided a timeout
+    // via the ApiCallContext. If they have provided a timeout, retain it.
     Duration overallTimeout =
         outerRetryingFuture.getAttemptSettings().getGlobalSettings().getTotalTimeout();
     if (context != null && context.getOverallTimeout() != null) {

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -82,7 +82,6 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
   @Nonnull private final StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategy;
 
   @Nonnull private final Duration idleTimeout;
-  @Nonnull private final Duration waitTimeout;
   @Nullable private final Duration overallTimeout;
 
   private ServerStreamingCallSettings(Builder<RequestT, ResponseT> builder) {
@@ -90,7 +89,6 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
     this.retrySettings = builder.retrySettingsBuilder.build();
     this.resumptionStrategy = builder.resumptionStrategy;
     this.idleTimeout = builder.idleTimeout;
-    this.waitTimeout = builder.waitTimeout;
     this.overallTimeout = builder.overallTimeout;
   }
 
@@ -132,15 +130,6 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
 
   /**
    * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
-   * the {@link #waitTimeout} does.
-   */
-  @Nonnull
-  public Duration getWaitTimeout() {
-    return waitTimeout;
-  }
-
-  /**
-   * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
    * the {@link #overallTimeout} does.
    */
   @Nonnull
@@ -160,7 +149,6 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("idleTimeout", idleTimeout)
-        .add("waitTimeout", waitTimeout)
         .add("overallTimeout", overallTimeout)
         .add("retryableCodes", retryableCodes)
         .add("retrySettings", retrySettings)
@@ -195,7 +183,6 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
       this.resumptionStrategy = settings.resumptionStrategy;
 
       this.idleTimeout = settings.idleTimeout;
-      this.waitTimeout = settings.waitTimeout;
       this.overallTimeout = settings.overallTimeout;
     }
 

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -162,7 +162,6 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
     @Nonnull private StreamResumptionStrategy<RequestT, ResponseT> resumptionStrategy;
 
     @Nonnull private Duration idleTimeout;
-    @Nonnull private Duration waitTimeout;
     @Nullable private Duration overallTimeout;
 
     /** Initialize the builder with default settings */
@@ -172,7 +171,6 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
       this.resumptionStrategy = new SimpleStreamResumptionStrategy<>();
 
       this.idleTimeout = Duration.ZERO;
-      this.waitTimeout = Duration.ZERO;
       this.overallTimeout = null;
     }
 
@@ -242,21 +240,6 @@ public final class ServerStreamingCallSettings<RequestT, ResponseT>
     @Nonnull
     public RetrySettings getRetrySettings() {
       return retrySettingsBuilder.build();
-    }
-
-    /**
-     * See the class documentation of {@link ServerStreamingCallSettings} for a description of what
-     * waitTimeout does.
-     */
-    public Builder<RequestT, ResponseT> setWaitTimeout(@Nonnull Duration waitTimeout) {
-      Preconditions.checkNotNull(waitTimeout);
-      this.waitTimeout = waitTimeout;
-      return this;
-    }
-
-    @Nonnull
-    public Duration getWaitTimeout() {
-      return waitTimeout;
     }
 
     /**

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallSettingsTest.java
@@ -99,6 +99,19 @@ public class ServerStreamingCallSettingsTest {
   }
 
   @Test
+  public void overallTimeoutIsNotLost() {
+    Duration overallTimeout = Duration.ofSeconds(5);
+
+    ServerStreamingCallSettings.Builder<Object, Object> builder =
+        ServerStreamingCallSettings.newBuilder();
+    builder.setOverallTimeout(overallTimeout);
+
+    assertThat(builder.getOverallTimeout()).isEqualTo(overallTimeout);
+    assertThat(builder.build().getOverallTimeout()).isEqualTo(overallTimeout);
+    assertThat(builder.build().toBuilder().getOverallTimeout()).isEqualTo(overallTimeout);
+  }
+
+  @Test
   public void testRetrySettingsBuilder() {
     RetrySettings initialSettings =
         RetrySettings.newBuilder()

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingCallSettingsTest.java
@@ -136,6 +136,33 @@ public class ServerStreamingCallSettingsTest {
   }
 
   @Test
+  public void testBuilderSetSimpleTimeoutNoRetries() {
+    RetrySettings initialSettings =
+        RetrySettings.newBuilder()
+            .setInitialRetryDelay(Duration.ofMillis(5))
+            .setMaxRetryDelay(Duration.ofSeconds(1))
+            .setRetryDelayMultiplier(2)
+            .setInitialRpcTimeout(Duration.ofMillis(100))
+            .setMaxRpcTimeout(Duration.ofMillis(200))
+            .setRpcTimeoutMultiplier(1.1)
+            .setJittered(true)
+            .setMaxAttempts(10)
+            .build();
+
+    ServerStreamingCallSettings.Builder<Object, Object> builder =
+        ServerStreamingCallSettings.newBuilder().setRetrySettings(initialSettings);
+
+    Duration timeout = Duration.ofSeconds(3L);
+    builder.setSimpleTimeoutNoRetries(timeout);
+
+    assertThat(builder.getRetrySettings().getInitialRetryDelay()).isEqualTo(Duration.ZERO);
+    assertThat(builder.getRetrySettings().getInitialRpcTimeout()).isEqualTo(Duration.ZERO);
+    assertThat(builder.getRetrySettings().getTotalTimeout()).isEqualTo(timeout);
+    assertThat(builder.getOverallTimeout()).isEqualTo(timeout);
+    assertThat(builder.getRetryableCodes()).isEmpty();
+  }
+
+  @Test
   public void testToString() {
     RetrySettings retrySettings = RetrySettings.newBuilder().build();
     Set<StatusCode.Code> retryableCodes = ImmutableSet.of(StatusCode.Code.DEADLINE_EXCEEDED);

--- a/gax/src/test/java/com/google/api/gax/rpc/UnaryCallSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/UnaryCallSettingsTest.java
@@ -45,11 +45,13 @@ public class UnaryCallSettingsTest {
   @Test
   public void testSetSimpleTimeoutNoRetries() {
     UnaryCallSettings.Builder builder = new UnaryCallSettings.Builder();
-    builder.setSimpleTimeoutNoRetries(Duration.ofSeconds(13));
+    Duration timeout = Duration.ofSeconds(13);
+    builder.setSimpleTimeoutNoRetries(timeout);
 
     assertThat(builder.getRetryableCodes().size()).isEqualTo(0);
     assertThat(builder.getRetrySettings().getMaxAttempts()).isEqualTo(1);
-    assertThat(builder.getRetrySettings().getTotalTimeout()).isEqualTo(Duration.ofSeconds(13));
+    assertThat(builder.getRetrySettings().getTotalTimeout()).isEqualTo(timeout);
+    assertThat(builder.getOverallTimeout()).isEqualTo(timeout);
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
@@ -50,6 +50,7 @@ public class FakeCallContext implements ApiCallContext {
   private final Credentials credentials;
   private final FakeChannel channel;
   private final Duration timeout;
+  private final Duration overallTimeout;
   private final Duration streamWaitTimeout;
   private final Duration streamIdleTimeout;
   private final ImmutableMap<String, List<String>> extraHeaders;
@@ -66,6 +67,26 @@ public class FakeCallContext implements ApiCallContext {
     this.credentials = credentials;
     this.channel = channel;
     this.timeout = timeout;
+    this.overallTimeout = null;
+    this.streamWaitTimeout = streamWaitTimeout;
+    this.streamIdleTimeout = streamIdleTimeout;
+    this.extraHeaders = extraHeaders;
+    this.tracer = tracer;
+  }
+
+  private FakeCallContext(
+      Credentials credentials,
+      FakeChannel channel,
+      Duration timeout,
+      Duration overallTimeout,
+      Duration streamWaitTimeout,
+      Duration streamIdleTimeout,
+      ImmutableMap<String, List<String>> extraHeaders,
+      ApiTracer tracer) {
+    this.credentials = credentials;
+    this.channel = channel;
+    this.timeout = timeout;
+    this.overallTimeout = overallTimeout;
     this.streamWaitTimeout = streamWaitTimeout;
     this.streamIdleTimeout = streamIdleTimeout;
     this.extraHeaders = extraHeaders;
@@ -74,7 +95,7 @@ public class FakeCallContext implements ApiCallContext {
 
   public static FakeCallContext createDefault() {
     return new FakeCallContext(
-        null, null, null, null, null, ImmutableMap.<String, List<String>>of(), null);
+        null, null, null, null, null, null, ImmutableMap.<String, List<String>>of(), null);
   }
 
   @Override
@@ -120,6 +141,11 @@ public class FakeCallContext implements ApiCallContext {
       newTimeout = timeout;
     }
 
+    Duration newOverallTimeout = fakeCallContext.overallTimeout;
+    if (newOverallTimeout == null) {
+      newOverallTimeout = this.overallTimeout;
+    }
+
     Duration newStreamWaitTimeout = fakeCallContext.streamWaitTimeout;
     if (newStreamWaitTimeout == null) {
       newStreamWaitTimeout = streamWaitTimeout;
@@ -141,6 +167,7 @@ public class FakeCallContext implements ApiCallContext {
         newCallCredentials,
         newChannel,
         newTimeout,
+        newOverallTimeout,
         newStreamWaitTimeout,
         newStreamIdleTimeout,
         newExtraHeaders,
@@ -158,6 +185,30 @@ public class FakeCallContext implements ApiCallContext {
   @Override
   public Duration getTimeout() {
     return timeout;
+  }
+
+  @Override
+  public FakeCallContext withOverallTimeout(@Nullable Duration overallTimeout) {
+    // Default RetrySettings use 0 for RPC timeout. Treat that as a disabled timeout.
+    if (overallTimeout != null && (overallTimeout.isZero() || overallTimeout.isNegative())) {
+      overallTimeout = null;
+    }
+
+    return new FakeCallContext(
+        this.credentials,
+        this.channel,
+        this.timeout,
+        overallTimeout,
+        this.streamWaitTimeout,
+        this.streamIdleTimeout,
+        this.extraHeaders,
+        this.tracer);
+  }
+
+  @Nullable
+  @Override
+  public Duration getOverallTimeout() {
+    return overallTimeout;
   }
 
   @Nullable
@@ -178,6 +229,7 @@ public class FakeCallContext implements ApiCallContext {
         credentials,
         this.channel,
         this.timeout,
+        this.overallTimeout,
         this.streamWaitTimeout,
         this.streamIdleTimeout,
         this.extraHeaders,
@@ -200,6 +252,7 @@ public class FakeCallContext implements ApiCallContext {
         this.credentials,
         channel,
         this.timeout,
+        this.overallTimeout,
         this.streamWaitTimeout,
         this.streamIdleTimeout,
         this.extraHeaders,
@@ -222,6 +275,7 @@ public class FakeCallContext implements ApiCallContext {
         this.credentials,
         this.channel,
         timeout,
+        this.overallTimeout,
         this.streamWaitTimeout,
         this.streamIdleTimeout,
         this.extraHeaders,
@@ -234,6 +288,7 @@ public class FakeCallContext implements ApiCallContext {
         this.credentials,
         this.channel,
         this.timeout,
+        this.overallTimeout,
         streamWaitTimeout,
         this.streamIdleTimeout,
         this.extraHeaders,
@@ -247,6 +302,7 @@ public class FakeCallContext implements ApiCallContext {
         this.credentials,
         this.channel,
         this.timeout,
+        this.overallTimeout,
         this.streamWaitTimeout,
         streamIdleTimeout,
         this.extraHeaders,
@@ -262,6 +318,7 @@ public class FakeCallContext implements ApiCallContext {
         credentials,
         channel,
         timeout,
+        this.overallTimeout,
         streamWaitTimeout,
         streamIdleTimeout,
         newExtraHeaders,
@@ -292,6 +349,7 @@ public class FakeCallContext implements ApiCallContext {
         this.credentials,
         this.channel,
         this.timeout,
+        this.overallTimeout,
         this.streamWaitTimeout,
         this.streamIdleTimeout,
         this.extraHeaders,


### PR DESCRIPTION
This implements the logical call timeout strategy through the addition of a `CallSettings` & `ApiCallContext` option called `overallTimeout`. Setting an `overallTimeout` will ensure that a `Callable` will not exceed the given amount of time, regardless of how many attempts are made. This is done in part by the new per-RPC attempt timeout calculation logic that accompanies it - each RPC attempt will have the same _deadline_, using only the time remaining to it in the `overallTimeout`, calculated from the start of callable execution, as the per-RPC attempt _timeout_. The `overallTimeout` is configurable on a per-method basis during client creation via the `CallSettings` API, and configurable on a per-call basis via the `ApiCallContext` API. The `overallTimeout` being unset (`null`) on the `CallSettings` means the same timeout-backoff style per-RPC attempt timeout logic is used, for backwards compatibility.