### PR TITLE
feat: Allow user-agents to be specified by both internal headers and user headers

### DIFF
--- a/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ClientContextTest.java
@@ -194,14 +194,6 @@ public class ClientContextTest {
     }
   }
 
-  private class FakeChannelWithHeaders extends FakeChannel {
-    private final Map<String, String> headers;
-
-    FakeChannelWithHeaders(Map<String, String> headers) {
-      this.headers = headers;
-    }
-  }
-
   @Test
   public void testNoAutoCloseContextNeedsNoExecutor() throws Exception {
     runTest(false, false, false, false);


### PR DESCRIPTION
This is primarily meant to address the https://github.com/googleapis/java-bigtable/pull/404#pullrequestreview-480972135. Where both the hbase adapter and the core client needs to set the UserAgent. To reconcile the conflict this PR takes grpc's approach and concatenates the values. The reason this needs to happen now is that for DirectPath we need to ship clients that send a UserAgent, however Bigtable needs to keep stats to differentiate client usage.