### PR TITLE
fix: truncate RPC timeouts to time remaining in totalTimeout

### DIFF
--- a/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
@@ -118,6 +118,11 @@ public class ExponentialRetryAlgorithm implements TimedRetryAlgorithm {
           Duration.ofNanos(clock.nanoTime())
               .minus(Duration.ofNanos(prevSettings.getFirstAttemptStartTimeNanos()));
       Duration timeLeft = globalSettings.getTotalTimeout().minus(timeElapsed).minus(randomDelay);
+
+      // If timeLeft at this point is < 0, the shouldRetry logic will prevent
+      // the attempt from being made as it would exceed the totalTimeout. A negative RPC timeout
+      // will result in a deadline in the past, which should will always fail prior to making a
+      // network call.
       newRpcTimeout = Math.min(newRpcTimeout, timeLeft.toMillis());
     }
 

--- a/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
@@ -104,7 +104,8 @@ public class ExponentialRetryAlgorithm implements TimedRetryAlgorithm {
 
     // The rpc timeout is determined as follows:
     //     attempt #0  - use the initialRpcTimeout;
-    //     attempt #1+ - use the calculated value or the time remaining in totalTimeout.
+    //     attempt #1+ - use the calculated value, or the time remaining in totalTimeout if the
+    //                   calculated value would exceed the totalTimeout.
     long newRpcTimeout =
         (long) (settings.getRpcTimeoutMultiplier() * prevSettings.getRpcTimeout().toMillis());
     newRpcTimeout = Math.min(newRpcTimeout, settings.getMaxRpcTimeout().toMillis());

--- a/gax/src/test/java/com/google/api/gax/retrying/ExponentialRetryAlgorithmTest.java
+++ b/gax/src/test/java/com/google/api/gax/retrying/ExponentialRetryAlgorithmTest.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.retrying;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -102,10 +103,10 @@ public class ExponentialRetryAlgorithmTest {
 
     TimedAttemptSettings firstAttempt = timeoutAlg.createFirstAttempt();
     TimedAttemptSettings secondAttempt = timeoutAlg.createNextAttempt(firstAttempt);
-    assertTrue(firstAttempt.getRpcTimeout().compareTo(secondAttempt.getRpcTimeout()) > 0);
+    assertThat(firstAttempt.getRpcTimeout()).isGreaterThan(secondAttempt.getRpcTimeout());
 
     TimedAttemptSettings thirdAttempt = timeoutAlg.createNextAttempt(secondAttempt);
-    assertTrue(secondAttempt.getRpcTimeout().compareTo(thirdAttempt.getRpcTimeout()) > 0);
+    assertThat(secondAttempt.getRpcTimeout()).isGreaterThan(thirdAttempt.getRpcTimeout());
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/retrying/ExponentialRetryAlgorithmTest.java
+++ b/gax/src/test/java/com/google/api/gax/retrying/ExponentialRetryAlgorithmTest.java
@@ -90,6 +90,25 @@ public class ExponentialRetryAlgorithmTest {
   }
 
   @Test
+  public void testTruncateToTotalTimeout() {
+    RetrySettings timeoutSettings =
+        retrySettings
+            .toBuilder()
+            .setInitialRpcTimeout(Duration.ofSeconds(4L))
+            .setMaxRpcTimeout(Duration.ofSeconds(4L))
+            .setTotalTimeout(Duration.ofSeconds(4L))
+            .build();
+    ExponentialRetryAlgorithm timeoutAlg = new ExponentialRetryAlgorithm(timeoutSettings, clock);
+
+    TimedAttemptSettings firstAttempt = timeoutAlg.createFirstAttempt();
+    TimedAttemptSettings secondAttempt = timeoutAlg.createNextAttempt(firstAttempt);
+    assertTrue(firstAttempt.getRpcTimeout().compareTo(secondAttempt.getRpcTimeout()) > 0);
+
+    TimedAttemptSettings thirdAttempt = timeoutAlg.createNextAttempt(secondAttempt);
+    assertTrue(secondAttempt.getRpcTimeout().compareTo(thirdAttempt.getRpcTimeout()) > 0);
+  }
+
+  @Test
   public void testShouldRetryTrue() {
     TimedAttemptSettings attempt = algorithm.createFirstAttempt();
     for (int i = 0; i < 2; i++) {

--- a/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
@@ -94,11 +94,14 @@ public class OperationCallableImplTest {
           .setInitialRetryDelay(Duration.ofMillis(1L))
           .setRetryDelayMultiplier(1)
           .setMaxRetryDelay(Duration.ofMillis(1L))
-          .setInitialRpcTimeout(Duration.ZERO) // supposed to be ignored
+          .setInitialRpcTimeout(
+              Duration.ZERO) // supposed to be ignored, but are not actually, so we set to zero
           .setMaxAttempts(0)
           .setJittered(false)
-          .setRpcTimeoutMultiplier(1) // supposed to be ignored
-          .setMaxRpcTimeout(Duration.ZERO) // supposed to be ignored
+          .setRpcTimeoutMultiplier(
+              1) // supposed to be ignored, but are not actually, so we set to one
+          .setMaxRpcTimeout(
+              Duration.ZERO) // supposed to be ignored, but are not actually, so we set to zero
           .setTotalTimeout(Duration.ofMillis(5L))
           .build();
 
@@ -476,6 +479,11 @@ public class OperationCallableImplTest {
             FAST_RECHECKING_SETTINGS
                 .toBuilder()
                 // Update the polling algorithm to set per-RPC timeouts instead of the default zero.
+                //
+                // This is non-standard, as these fields have been documented as "should be ignored"
+                // for LRO polling. They are not actually ignored in code, so they changing them
+                // here has an actual affect. This test verifies that they work as such, but in
+                // practice generated clients set the RPC timeouts to 0 to be ignored.
                 .setInitialRpcTimeout(Duration.ofMillis(100))
                 .setMaxRpcTimeout(Duration.ofSeconds(1))
                 .setRpcTimeoutMultiplier(2)

--- a/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
@@ -475,9 +475,11 @@ public class OperationCallableImplTest {
         OperationTimedPollAlgorithm.create(
             FAST_RECHECKING_SETTINGS
                 .toBuilder()
+                // Update the polling algorithm to set per-RPC timeouts instead of the default zero.
                 .setInitialRpcTimeout(Duration.ofMillis(100))
                 .setMaxRpcTimeout(Duration.ofSeconds(1))
                 .setRpcTimeoutMultiplier(2)
+                .setTotalTimeout(Duration.ofSeconds(5L))
                 .build(),
             clock);
     callSettings = callSettings.toBuilder().setPollingAlgorithm(pollingAlgorithm).build();


### PR DESCRIPTION
The [RetrySettings](https://github.com/googleapis/gax-java/blob/287cadae528549545da9e7e9d63fd70c1268e3c1/gax/src/main/java/com/google/api/gax/retrying/RetrySettings.java#L59-L62) documentation indicated that an RPC timeout would not be allowed to enable an RPC to exceed the `totalTimeout` while in flight. Meaning, if a calculated RPC timeout is greater than the time remaining in the `totalTimeout` (from the start of the first attempt), the RPC timeout should be equal to that time remaining. This prevents an RPC from being sent with a timeout that would allow it to execute beyond the time allotted by the `totalTimeout`.

This was not being done in gax-java, even though the documentation stated it and several other language implementations of GAX are implemented to match this same documentation. 

This PR corrects that.