### PR TITLE
chore: fix sync-repo-settings syntax

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -28,10 +28,10 @@ branchProtectionRules:
   requiresStrictStatusChecks: true
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
-    - "linkage-monitor",
-    - "units (7)",
-    - "units (8)",
-    - "units (11)",
+    - "linkage-monitor"
+    - "units (7)"
+    - "units (8)"
+    - "units (11)"
     - "cla/google"
 # List of explicit permissions to add (additive only)
 permissionRules:


### PR DESCRIPTION
This should fix the required checks reverting to the Java defaults. The bot is failing to load from the malformed yaml.

The sync-repo-settings bot's syntax check should prevent this in the future.