### PR TITLE
fix: Fix race condition in BatcherImpl flush

### DIFF
--- a/gax/src/main/java/com/google/api/gax/batching/BatcherImpl.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatcherImpl.java
@@ -198,6 +198,10 @@ public class BatcherImpl<ElementT, ElementResultT, RequestT, ResponseT>
   private void awaitAllOutstandingBatches() throws InterruptedException {
     while (numOfOutstandingBatches.get() > 0) {
       synchronized (flushLock) {
+        // Check again under lock to avoid racing with onBatchCompletion
+        if (numOfOutstandingBatches.get() == 0) {
+          break;
+        }
         flushLock.wait();
       }
     }


### PR DESCRIPTION
Currently the following race condition exists:

T1 - awaitAllOutstandingBatches checks that numOfOutstandingBatches > 0
T2 - onBatchCompletion decrements numOfOutstandingBatches
T2 - flushLock.notifyAll()
T1 - flushLock.wait()

so T1 will wait indefinitely

The fix is quite simple: make sure that the there batches to wait for after acquiring the lock