### PR TITLE
fix: check Compute Engine environment for DirectPath

### DIFF
--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
@@ -219,7 +219,11 @@ public class InstantiatingGrpcChannelProviderTest {
     ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> channelConfigurator =
         new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
           public ManagedChannelBuilder apply(ManagedChannelBuilder channelBuilder) {
-            assertThat(channelBuilder instanceof ComputeEngineChannelBuilder).isTrue();
+            if (InstantiatingGrpcChannelProvider.isOnComputeEngine()) {
+              assertThat(channelBuilder instanceof ComputeEngineChannelBuilder).isTrue();
+            } else {
+              assertThat(channelBuilder instanceof ComputeEngineChannelBuilder).isFalse();
+            }
             return channelBuilder;
           }
         };
@@ -234,7 +238,11 @@ public class InstantiatingGrpcChannelProviderTest {
             .withEndpoint("localhost:8080");
 
     assertThat(provider.needsCredentials()).isTrue();
-    provider = provider.withCredentials(ComputeEngineCredentials.create());
+    if (InstantiatingGrpcChannelProvider.isOnComputeEngine()) {
+      provider = provider.withCredentials(ComputeEngineCredentials.create());
+    } else {
+      provider = provider.withCredentials(CloudShellCredentials.create(3000));
+    }
     assertThat(provider.needsCredentials()).isFalse();
 
     provider.getTransportChannel().shutdownNow();


### PR DESCRIPTION
Add Compute Engine environment check since DirectPath can only be used on Compute Engine. This doc is used for checking: https://docs.google.com/document/d/1xQXE27x9wTvwPsgiX9Hn0o8mcq5z3SKi-1jwscQsCAk/edit#. Relevant issue and PR: https://github.com/grpc/grpc-java/issues/7604 and https://github.com/googleapis/java-bigtable/pull/520. 