### PR TITLE
chore: updating required check of Linkage Monitor

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -29,7 +29,8 @@ branchProtectionRules:
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
     - "bazel"
-    - "linkage-monitor"
+    - "linkage-monitor (8)"
+    - "linkage-monitor (11)"
     - "units (7)"
     - "units (8)"
     - "units (11)"


### PR DESCRIPTION
Updating the required check for the gax-java repository
for the pull request that changes the check's name.
https://github.com/googleapis/gax-java/pull/1273