### PR TITLE
feat: dynamic flow control part 1 - add FlowController to Batcher

### DIFF
--- a/gax/src/main/java/com/google/api/gax/batching/BatcherImpl.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatcherImpl.java
@@ -145,13 +145,15 @@ public class BatcherImpl<ElementT, ElementResultT, RequestT, ResponseT>
               || batchingSettings.getElementCountThreshold() == null
               || flowController.getMaxOutstandingElementCount()
                   >= batchingSettings.getElementCountThreshold(),
-          "if throttling and batching on element count are enabled, FlowController#maxOutstandingElementCount must be greater or equal to elementCountThreshold");
+          "If throttling and batching on element count are enabled, FlowController"
+              + "#maxOutstandingElementCount must be greater or equal to elementCountThreshold");
       Preconditions.checkArgument(
           flowController.getMaxOutstandingRequestBytes() == null
               || batchingSettings.getRequestByteThreshold() == null
               || flowController.getMaxOutstandingRequestBytes()
                   >= batchingSettings.getRequestByteThreshold(),
-          "if throttling and batching on request bytes are enabled, FlowController#maxOutstandingRequestBytes must be greater or equal to requestByteThreshold");
+          "If throttling and batching on request bytes are enabled, FlowController"
+              + "#maxOutstandingRequestBytes must be greater or equal to requestByteThreshold");
     }
     this.flowController = flowController;
     currentOpenBatch = new Batch<>(prototype, batchingDescriptor, batchingSettings, batcherStats);
@@ -291,6 +293,8 @@ public class BatcherImpl<ElementT, ElementResultT, RequestT, ResponseT>
     }
   }
 
+  /** Package-private for use in testing. */
+  @VisibleForTesting
   FlowController getFlowController() {
     return flowController;
   }

--- a/gax/src/main/java/com/google/api/gax/batching/BatcherImpl.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatcherImpl.java
@@ -183,7 +183,7 @@ public class BatcherImpl<ElementT, ElementResultT, RequestT, ResponseT>
     // However, with the current FlowController implementation, adding a tryReserve() could be
     // confusing. FlowController will end up having 3 different reserve behaviors: blocking,
     // non blocking and try reserve. And we'll also need to add a tryAcquire() to the Semaphore64
-    // class, which makes it seemed unnecessary to have blocking and non-blocking semaphore
+    // class, which made it seem unnecessary to have blocking and non-blocking semaphore
     // implementations. Some refactoring may be needed for the optimized implementation. So we'll
     // defer it till we decide on if refactoring FlowController is necessary.
     try {

--- a/gax/src/main/java/com/google/api/gax/batching/BatcherImpl.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatcherImpl.java
@@ -116,8 +116,8 @@ public class BatcherImpl<ElementT, ElementResultT, RequestT, ResponseT>
    * @param unaryCallable a {@link UnaryCallable} object
    * @param prototype a {@link RequestT} object
    * @param batchingSettings a {@link BatchingSettings} with configuration of thresholds
-   * @param flowController a {@link FlowController} for throttling requests. If it's null, create
-   *     a {@link FlowController} object from {@link BatchingSettings#getFlowControlSettings()}.
+   * @param flowController a {@link FlowController} for throttling requests. If it's null, create a
+   *     {@link FlowController} object from {@link BatchingSettings#getFlowControlSettings()}.
    */
   public BatcherImpl(
       BatchingDescriptor<ElementT, ElementResultT, RequestT, ResponseT> batchingDescriptor,

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingSettings.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingSettings.java
@@ -174,21 +174,6 @@ public abstract class BatchingSettings {
           settings.getDelayThreshold() == null
               || settings.getDelayThreshold().compareTo(Duration.ZERO) > 0,
           "delayThreshold must be either unset or positive");
-      if (settings.getFlowControlSettings().getLimitExceededBehavior()
-          != LimitExceededBehavior.Ignore) {
-        Preconditions.checkArgument(
-            settings.getFlowControlSettings().getMaxOutstandingElementCount() == null
-                || settings.getElementCountThreshold() == null
-                || settings.getFlowControlSettings().getMaxOutstandingElementCount()
-                    >= settings.getElementCountThreshold(),
-            "if throttling and batching on element count are enabled, FlowController#maxOutstandingElementCount must be greater or equal to elementCountThreshold");
-        Preconditions.checkArgument(
-            settings.getFlowControlSettings().getMaxOutstandingRequestBytes() == null
-                || settings.getRequestByteThreshold() == null
-                || settings.getFlowControlSettings().getMaxOutstandingRequestBytes()
-                    >= settings.getRequestByteThreshold(),
-            "if throttling and batching on request bytes are enabled, FlowController#maxOutstandingRequestBytes must be greater or equal to requestByteThreshold");
-      }
       return settings;
     }
   }

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingSettings.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingSettings.java
@@ -174,6 +174,21 @@ public abstract class BatchingSettings {
           settings.getDelayThreshold() == null
               || settings.getDelayThreshold().compareTo(Duration.ZERO) > 0,
           "delayThreshold must be either unset or positive");
+      if (settings.getFlowControlSettings().getLimitExceededBehavior()
+          != LimitExceededBehavior.Ignore) {
+        Preconditions.checkArgument(
+            settings.getFlowControlSettings().getMaxOutstandingElementCount() == null
+                || settings.getElementCountThreshold() == null
+                || settings.getFlowControlSettings().getMaxOutstandingElementCount()
+                    >= settings.getElementCountThreshold(),
+            "if throttling and batching on element count are enabled, FlowController#maxOutstandingElementCount must be greater or equal to elementCountThreshold");
+        Preconditions.checkArgument(
+            settings.getFlowControlSettings().getMaxOutstandingRequestBytes() == null
+                || settings.getRequestByteThreshold() == null
+                || settings.getFlowControlSettings().getMaxOutstandingRequestBytes()
+                    >= settings.getRequestByteThreshold(),
+            "if throttling and batching on request bytes are enabled, FlowController#maxOutstandingRequestBytes must be greater or equal to requestByteThreshold");
+      }
       return settings;
     }
   }

--- a/gax/src/main/java/com/google/api/gax/batching/FlowController.java
+++ b/gax/src/main/java/com/google/api/gax/batching/FlowController.java
@@ -223,13 +223,13 @@ public class FlowController {
     return limitExceededBehavior;
   }
 
-  @InternalApi
+  @InternalApi("For internal use by google-cloud-java clients only")
   @Nullable
   public Long getMaxOutstandingElementCount() {
     return maxOutstandingElementCount;
   }
 
-  @InternalApi
+  @InternalApi("For internal use by google-cloud-java clients only")
   @Nullable
   public Long getMaxOutstandingRequestBytes() {
     return maxOutstandingRequestBytes;

--- a/gax/src/main/java/com/google/api/gax/batching/FlowController.java
+++ b/gax/src/main/java/com/google/api/gax/batching/FlowController.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.batching;
 
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
 import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
 
@@ -143,9 +144,10 @@ public class FlowController {
   @Nullable private final Semaphore64 outstandingByteCount;
   @Nullable private final Long maxOutstandingElementCount;
   @Nullable private final Long maxOutstandingRequestBytes;
+  private final LimitExceededBehavior limitExceededBehavior;
 
   public FlowController(FlowControlSettings settings) {
-    boolean failOnLimits;
+    this.limitExceededBehavior = settings.getLimitExceededBehavior();
     switch (settings.getLimitExceededBehavior()) {
       case ThrowException:
       case Block:
@@ -215,5 +217,21 @@ public class FlowController {
       long permitsToReturn = Math.min(bytes, maxOutstandingRequestBytes);
       outstandingByteCount.release(permitsToReturn);
     }
+  }
+
+  LimitExceededBehavior getLimitExceededBehavior() {
+    return limitExceededBehavior;
+  }
+
+  @InternalApi
+  @Nullable
+  public Long getMaxOutstandingElementCount() {
+    return maxOutstandingElementCount;
+  }
+
+  @InternalApi
+  @Nullable
+  public Long getMaxOutstandingRequestBytes() {
+    return maxOutstandingRequestBytes;
   }
 }

--- a/gax/src/test/java/com/google/api/gax/batching/BatcherImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/BatcherImplTest.java
@@ -104,13 +104,7 @@ public class BatcherImplTest {
   /** The accumulated results in the test are resolved when {@link Batcher#flush()} is called. */
   @Test
   public void testResultsAreResolvedAfterFlush() throws Exception {
-    underTest =
-        new BatcherImpl<>(
-            SQUARER_BATCHING_DESC_V2,
-            callLabeledIntSquarer,
-            labeledIntList,
-            batchingSettings,
-            EXECUTOR);
+    underTest = createDefaultBatcherImpl(batchingSettings, null);
     Future<Integer> result = underTest.add(4);
     assertThat(result.isDone()).isFalse();
     underTest.flush();
@@ -154,13 +148,7 @@ public class BatcherImplTest {
   @Test
   public void testWhenBatcherIsClose() throws Exception {
     Future<Integer> result;
-    try (Batcher<Integer, Integer> batcher =
-        new BatcherImpl<>(
-            SQUARER_BATCHING_DESC_V2,
-            callLabeledIntSquarer,
-            labeledIntList,
-            batchingSettings,
-            EXECUTOR)) {
+    try (Batcher<Integer, Integer> batcher = createDefaultBatcherImpl(batchingSettings, null)) {
       result = batcher.add(5);
     }
     assertThat(result.isDone()).isTrue();
@@ -170,13 +158,7 @@ public class BatcherImplTest {
   /** Validates exception when batch is called after {@link Batcher#close()}. */
   @Test
   public void testNoElementAdditionAfterClose() throws Exception {
-    underTest =
-        new BatcherImpl<>(
-            SQUARER_BATCHING_DESC_V2,
-            callLabeledIntSquarer,
-            labeledIntList,
-            batchingSettings,
-            EXECUTOR);
+    underTest = createDefaultBatcherImpl(batchingSettings, null);
     underTest.close();
     Throwable addOnClosedError = null;
     try {
@@ -330,9 +312,7 @@ public class BatcherImplTest {
             .setRequestByteThreshold(null)
             .setDelayThreshold(null)
             .build();
-    underTest =
-        new BatcherImpl<>(
-            SQUARER_BATCHING_DESC_V2, callLabeledIntSquarer, labeledIntList, settings, EXECUTOR);
+    underTest = createDefaultBatcherImpl(settings, null);
     Future<Integer> result = underTest.add(2);
     assertThat(result.isDone()).isTrue();
     assertThat(result.get()).isEqualTo(4);
@@ -342,9 +322,7 @@ public class BatcherImplTest {
   public void testWhenDelayThresholdExceeds() throws Exception {
     BatchingSettings settings =
         batchingSettings.toBuilder().setDelayThreshold(Duration.ofMillis(100)).build();
-    underTest =
-        new BatcherImpl<>(
-            SQUARER_BATCHING_DESC_V2, callLabeledIntSquarer, labeledIntList, settings, EXECUTOR);
+    underTest = createDefaultBatcherImpl(settings, null);
     Future<Integer> result = underTest.add(6);
     assertThat(result.isDone()).isFalse();
     assertThat(result.get()).isEqualTo(36);
@@ -420,8 +398,7 @@ public class BatcherImplTest {
     BatchingSettings settings =
         batchingSettings.toBuilder().setDelayThreshold(Duration.ofMillis(DELAY_TIME)).build();
     BatcherImpl<Integer, Integer, LabeledIntList, List<Integer>> batcher =
-        new BatcherImpl<>(
-            SQUARER_BATCHING_DESC_V2, callLabeledIntSquarer, labeledIntList, settings, EXECUTOR);
+        createDefaultBatcherImpl(settings, null);
 
     BatcherImpl.PushCurrentBatchRunnable<Integer, Integer, LabeledIntList, List<Integer>>
         pushBatchRunnable = new BatcherImpl.PushCurrentBatchRunnable<>(batcher);
@@ -584,20 +561,8 @@ public class BatcherImplTest {
       Thread.sleep(DELAY_TIME * (1L << retry));
     }
     assertThat(actualRemaining).isAtMost(0);
-    underTest =
-        new BatcherImpl<>(
-            SQUARER_BATCHING_DESC_V2,
-            callLabeledIntSquarer,
-            labeledIntList,
-            batchingSettings,
-            EXECUTOR);
-    Batcher<Integer, Integer> extraBatcher =
-        new BatcherImpl<>(
-            SQUARER_BATCHING_DESC_V2,
-            callLabeledIntSquarer,
-            labeledIntList,
-            batchingSettings,
-            EXECUTOR);
+    underTest = createDefaultBatcherImpl(batchingSettings, null);
+    Batcher<Integer, Integer> extraBatcher = createDefaultBatcherImpl(batchingSettings, null);
 
     // Try to capture the log output but without causing terminal noise.  Adding the filter must
     // be done before clearing the ref or else it might be missed.
@@ -715,13 +680,7 @@ public class BatcherImplTest {
 
   @Test
   public void testConstructors() throws InterruptedException {
-    try (BatcherImpl batcher1 =
-        new BatcherImpl<>(
-            SQUARER_BATCHING_DESC_V2,
-            callLabeledIntSquarer,
-            labeledIntList,
-            batchingSettings,
-            EXECUTOR)) {
+    try (BatcherImpl batcher1 = createDefaultBatcherImpl(batchingSettings, null)) {
       assertThat(batcher1.getFlowController()).isNotNull();
       assertThat(batcher1.getFlowController().getLimitExceededBehavior())
           .isEqualTo(batchingSettings.getFlowControlSettings().getLimitExceededBehavior());
@@ -737,14 +696,7 @@ public class BatcherImplTest {
                 .setLimitExceededBehavior(LimitExceededBehavior.ThrowException.ThrowException)
                 .setMaxOutstandingRequestBytes(6000L)
                 .build());
-    try (BatcherImpl batcher2 =
-        new BatcherImpl<>(
-            SQUARER_BATCHING_DESC_V2,
-            callLabeledIntSquarer,
-            labeledIntList,
-            batchingSettings,
-            EXECUTOR,
-            flowController)) {
+    try (BatcherImpl batcher2 = createDefaultBatcherImpl(batchingSettings, flowController)) {
       assertThat(batcher2.getFlowController()).isSameInstanceAs(flowController);
     }
   }
@@ -764,13 +716,7 @@ public class BatcherImplTest {
                 .build());
     ExecutorService executor = Executors.newSingleThreadExecutor();
     try (final Batcher<Integer, Integer> batcher =
-        new BatcherImpl<>(
-            SQUARER_BATCHING_DESC_V2,
-            callLabeledIntSquarer,
-            labeledIntList,
-            settings,
-            EXECUTOR,
-            flowController)) {
+        createDefaultBatcherImpl(settings, flowController)) {
       flowController.reserve(1, 1);
       Future future =
           executor.submit(
@@ -781,7 +727,7 @@ public class BatcherImplTest {
                 }
               });
       try {
-        future.get(100, TimeUnit.MILLISECONDS);
+        future.get(10, TimeUnit.MILLISECONDS);
         assertWithMessage("adding elements to batcher should be blocked by FlowControlled").fail();
       } catch (TimeoutException e) {
         // expected
@@ -811,13 +757,7 @@ public class BatcherImplTest {
                 .setMaxOutstandingElementCount(1L)
                 .build());
     try (final Batcher<Integer, Integer> batcher =
-        new BatcherImpl<>(
-            SQUARER_BATCHING_DESC_V2,
-            callLabeledIntSquarer,
-            labeledIntList,
-            settings,
-            EXECUTOR,
-            flowController)) {
+        createDefaultBatcherImpl(settings, flowController)) {
       flowController.reserve(1, 1);
       try {
         batcher.add(1);
@@ -831,9 +771,7 @@ public class BatcherImplTest {
   }
 
   private void testElementTriggers(BatchingSettings settings) throws Exception {
-    underTest =
-        new BatcherImpl<>(
-            SQUARER_BATCHING_DESC_V2, callLabeledIntSquarer, labeledIntList, settings, EXECUTOR);
+    underTest = createDefaultBatcherImpl(settings, null);
     Future<Integer> result = underTest.add(4);
     assertThat(result.isDone()).isFalse();
     // After this element is added, the batch triggers sendOutstanding().
@@ -842,5 +780,16 @@ public class BatcherImplTest {
     assertThat(result.isDone()).isTrue();
     assertThat(result.get()).isEqualTo(16);
     assertThat(anotherResult.isDone()).isTrue();
+  }
+
+  private BatcherImpl<Integer, Integer, LabeledIntList, List<Integer>> createDefaultBatcherImpl(
+      BatchingSettings settings, FlowController flowController) {
+    return new BatcherImpl<>(
+        SQUARER_BATCHING_DESC_V2,
+        callLabeledIntSquarer,
+        labeledIntList,
+        settings,
+        EXECUTOR,
+        flowController);
   }
 }


### PR DESCRIPTION
Splitting https://github.com/googleapis/gax-java/pull/1288 into smaller prs.

Implementing go/veneer-dynamic-flow-control. Adding a FlowController to Batcher so in flight requests can be throttled.