### PR TITLE
feat: self signed jwt support

### DIFF
--- a/gax/src/main/java/com/google/api/gax/core/GoogleCredentialsProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/GoogleCredentialsProvider.java
@@ -161,6 +161,10 @@ public abstract class GoogleCredentialsProvider implements CredentialsProvider {
     @BetaApi
     public abstract List<String> getJwtEnabledScopes();
 
+    /**
+     * Default scopes is for client libraries to use. Users should use setScopesToApply to set
+     * scopes, or setJwtEnabledScopes to force to use ServiceAccountJWTCredentials.
+     */
     @BetaApi
     public abstract Builder setDefaultScopes(List<String> val);
 

--- a/gax/src/main/java/com/google/api/gax/core/GoogleCredentialsProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/GoogleCredentialsProvider.java
@@ -70,6 +70,11 @@ public abstract class GoogleCredentialsProvider implements CredentialsProvider {
     return getCredentials(false, null);
   }
 
+  /**
+   * If user doesn't provide custom endpoint and scopes, and the credentials is service account
+   * credentials, then we need to create a new ServiceAccountJwtAccessCredentials to use self signed
+   * jwt. See https://google.aip.dev/auth/4111.
+   */
   public Credentials getCredentials(boolean endpointIsDefault, URI audienceForSelfSignedJwt)
       throws IOException {
     GoogleCredentials credentials = getOAuth2Credentials();

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -141,6 +141,11 @@ public abstract class ClientContext {
     return create(settings.getStubSettings());
   }
 
+  /**
+   * If user doesn't provide custom endpoint and scopes, and the credentials is service account
+   * credentials, then we need to create a new ServiceAccountJwtAccessCredentials to use self signed
+   * jwt. See https://google.aip.dev/auth/4111.
+   */
   @VisibleForTesting
   public static Credentials determineSelfSignedJWTCredentials(
       CredentialsProvider provider, String endpoint, String defaultEndpoint) throws IOException {

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -62,7 +62,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.apache.http.client.utils.URIBuilder;
 import org.threeten.bp.Duration;
 
 /**
@@ -164,8 +163,7 @@ public abstract class ClientContext {
       // "https://" indicates the client is DIREGAPIC.
       try {
         URI uri = new URI(defaultEndpoint);
-        selfSignedJwtAudience =
-            new URIBuilder().setScheme(uri.getScheme()).setHost(uri.getHost()).setPath("/").build();
+        selfSignedJwtAudience = new URI(uri.getScheme(), uri.getHost(), "/", null);
       } catch (URISyntaxException e) {
         throw new IOException(
             String.format("Default endpoint {%s} cannot be parsed.", defaultEndpoint));

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -146,7 +146,7 @@ public abstract class ClientContext {
    * jwt. See https://google.aip.dev/auth/4111.
    */
   @VisibleForTesting
-  public static Credentials determineSelfSignedJWTCredentials(
+  static Credentials determineSelfSignedJWTCredentials(
       CredentialsProvider provider, String endpoint, String defaultEndpoint) throws IOException {
     if (endpoint == null || defaultEndpoint == null || !endpoint.equals(defaultEndpoint)) {
       return provider.getCredentials();

--- a/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -70,6 +70,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
   private final TransportChannelProvider transportChannelProvider;
   private final ApiClock clock;
   private final String endpoint;
+  private final String defaultEndpoint;
   private final String quotaProjectId;
   @Nullable private final WatchdogProvider streamWatchdogProvider;
   @Nonnull private final Duration streamWatchdogCheckInterval;
@@ -84,6 +85,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     this.internalHeaderProvider = builder.internalHeaderProvider;
     this.clock = builder.clock;
     this.endpoint = builder.endpoint;
+    this.defaultEndpoint = builder.defaultEndpoint;
     this.quotaProjectId = builder.quotaProjectId;
     this.streamWatchdogProvider = builder.streamWatchdogProvider;
     this.streamWatchdogCheckInterval = builder.streamWatchdogCheckInterval;
@@ -118,6 +120,10 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
 
   public final String getEndpoint() {
     return endpoint;
+  }
+
+  public final String getDefaultApiEndpoint() {
+    return defaultEndpoint;
   }
 
   public final String getQuotaProjectId() {
@@ -155,6 +161,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         .add("internalHeaderProvider", internalHeaderProvider)
         .add("clock", clock)
         .add("endpoint", endpoint)
+        .add("defaultEndpoint", defaultEndpoint)
         .add("quotaProjectId", quotaProjectId)
         .add("streamWatchdogProvider", streamWatchdogProvider)
         .add("streamWatchdogCheckInterval", streamWatchdogCheckInterval)
@@ -175,6 +182,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     private ApiClock clock;
     private String endpoint;
     private String quotaProjectId;
+    private String defaultEndpoint = null;
     @Nullable private WatchdogProvider streamWatchdogProvider;
     @Nonnull private Duration streamWatchdogCheckInterval;
     @Nonnull private ApiTracerFactory tracerFactory;
@@ -188,6 +196,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       this.internalHeaderProvider = settings.internalHeaderProvider;
       this.clock = settings.clock;
       this.endpoint = settings.endpoint;
+      this.defaultEndpoint = settings.getDefaultApiEndpoint();
       this.quotaProjectId = settings.quotaProjectId;
       this.streamWatchdogProvider = settings.streamWatchdogProvider;
       this.streamWatchdogCheckInterval = settings.streamWatchdogCheckInterval;
@@ -337,6 +346,11 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       return self();
     }
 
+    public B setDefaultEndpoint(String endpoint) {
+      this.defaultEndpoint = endpoint;
+      return self();
+    }
+
     public B setQuotaProjectId(String quotaProjectId) {
       this.quotaProjectId = quotaProjectId;
       return self();
@@ -408,6 +422,10 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       return endpoint;
     }
 
+    public String getDefaultApiEndpoint() {
+      return defaultEndpoint;
+    }
+
     /** Gets the QuotaProjectId that was previously set on this Builder. */
     public String getQuotaProjectId() {
       return quotaProjectId;
@@ -445,6 +463,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
           .add("internalHeaderProvider", internalHeaderProvider)
           .add("clock", clock)
           .add("endpoint", endpoint)
+          .add("defaultEndpoint", defaultEndpoint)
           .add("quotaProjectId", quotaProjectId)
           .add("streamWatchdogProvider", streamWatchdogProvider)
           .add("streamWatchdogCheckInterval", streamWatchdogCheckInterval)

--- a/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -70,7 +70,8 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
   private final TransportChannelProvider transportChannelProvider;
   private final ApiClock clock;
   private final String endpoint;
-  private final String defaultEndpoint;
+  // defaultApiEndpoint is set by client libraries.
+  private final String defaultApiEndpoint;
   private final String quotaProjectId;
   @Nullable private final WatchdogProvider streamWatchdogProvider;
   @Nonnull private final Duration streamWatchdogCheckInterval;
@@ -85,7 +86,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     this.internalHeaderProvider = builder.internalHeaderProvider;
     this.clock = builder.clock;
     this.endpoint = builder.endpoint;
-    this.defaultEndpoint = builder.defaultEndpoint;
+    this.defaultApiEndpoint = builder.defaultApiEndpoint;
     this.quotaProjectId = builder.quotaProjectId;
     this.streamWatchdogProvider = builder.streamWatchdogProvider;
     this.streamWatchdogCheckInterval = builder.streamWatchdogCheckInterval;
@@ -123,7 +124,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
   }
 
   public final String getDefaultApiEndpoint() {
-    return defaultEndpoint;
+    return defaultApiEndpoint;
   }
 
   public final String getQuotaProjectId() {
@@ -161,7 +162,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         .add("internalHeaderProvider", internalHeaderProvider)
         .add("clock", clock)
         .add("endpoint", endpoint)
-        .add("defaultEndpoint", defaultEndpoint)
+        .add("defaultApiEndpoint", defaultApiEndpoint)
         .add("quotaProjectId", quotaProjectId)
         .add("streamWatchdogProvider", streamWatchdogProvider)
         .add("streamWatchdogCheckInterval", streamWatchdogCheckInterval)
@@ -182,7 +183,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     private ApiClock clock;
     private String endpoint;
     private String quotaProjectId;
-    private String defaultEndpoint = null;
+    private String defaultApiEndpoint = null;
     @Nullable private WatchdogProvider streamWatchdogProvider;
     @Nonnull private Duration streamWatchdogCheckInterval;
     @Nonnull private ApiTracerFactory tracerFactory;
@@ -196,7 +197,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       this.internalHeaderProvider = settings.internalHeaderProvider;
       this.clock = settings.clock;
       this.endpoint = settings.endpoint;
-      this.defaultEndpoint = settings.getDefaultApiEndpoint();
+      this.defaultApiEndpoint = settings.getDefaultApiEndpoint();
       this.quotaProjectId = settings.quotaProjectId;
       this.streamWatchdogProvider = settings.streamWatchdogProvider;
       this.streamWatchdogCheckInterval = settings.streamWatchdogCheckInterval;
@@ -346,8 +347,9 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       return self();
     }
 
-    public B setDefaultEndpoint(String endpoint) {
-      this.defaultEndpoint = endpoint;
+    // Make it protected so only client libraries can set it in client's stubSetting class.
+    protected B setDefaultApiEndpoint(String endpoint) {
+      this.defaultApiEndpoint = endpoint;
       return self();
     }
 
@@ -423,7 +425,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     }
 
     public String getDefaultApiEndpoint() {
-      return defaultEndpoint;
+      return defaultApiEndpoint;
     }
 
     /** Gets the QuotaProjectId that was previously set on this Builder. */
@@ -463,7 +465,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
           .add("internalHeaderProvider", internalHeaderProvider)
           .add("clock", clock)
           .add("endpoint", endpoint)
-          .add("defaultEndpoint", defaultEndpoint)
+          .add("defaultApiEndpoint", defaultApiEndpoint)
           .add("quotaProjectId", quotaProjectId)
           .add("streamWatchdogProvider", streamWatchdogProvider)
           .add("streamWatchdogCheckInterval", streamWatchdogCheckInterval)


### PR DESCRIPTION
This PR adds self signed jwt support (https://google.aip.dev/auth/4111). Googlers see this [doc](go/yoshi-self-signed-jwt) for more details.

If user uses `ServiceAccountCredentials`, and doesn't provide custom endpoint, scopes, and audience, then a new `ServiceAccountJwtAccessCredentials` should be created and used for self signed jwt feature.

This PR doesn't break existing client libraries.

## 1. Details
### endpoint
In `StubSettings.java`, currently because both user and client library set the `endpoint` property, so we cannot tell whether the `endpoint` property is a custom endpoint set by user. To solve this problem, this PR creates a new `defaultApiEndpoint` property for the client libraries to use. Then we can compare `endpoint` with `defaultApiEndpoint` to know if `endpoint` is a custom endpoint. 

[Client library example PR using java-cloudbuild](https://github.com/arithmetic1728/java-cloudbuild/pull/1/files)

Note: once cl/356594013 is checked in and rolled out, then all the changes in this section is not needed anymore. Depending on the actual timeline, I can update this PR or create a subsequent PR.

### scopes
There are two types of `CredentialsProvider` for the user to provide a credentials: `GoogleCredentialsProvider` and `FixedCredentialsProvider`. Whether scopes are provided by user depends on the provider type.

`GoogleCredentialsProvider` provides ADC credential. Currently both user and client library use `setScopesToApply` method to set scopes. To tell the difference, this PR creates a new `setDefaultScopes` method for the client library to use. [Client library example PR using java-cloudbuild](https://github.com/arithmetic1728/java-cloudbuild/pull/1/files)

`FixedCredentialsProvider` wraps a credential created by the user. If the credential is `ServiceAccountCredentials`, then we can look at the `scopes` property.

### audience
Users cannot set audience for `ServiceAccountCredentials` regardless of the credential provider type, so this doesn't apply. 

## 2. Client examples PRs
This PR works for both GAPIC and DIREGAPIC clients. Examples PRs for client libraries:
- java-cloudbuild (GAPIC): [PR](https://github.com/arithmetic1728/java-cloudbuild/pull/1/files)
- java-compute (DIREGAPIC): [PR](https://github.com/arithmetic1728/java-compute/pull/2/files)