### PR TITLE
fix: InstantiatingGrpcChannelProvider.toBuilder() should carry over all config data

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -411,6 +411,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
       this.credentials = provider.credentials;
       this.channelPrimer = provider.channelPrimer;
       this.attemptDirectPath = provider.attemptDirectPath;
+      this.directPathServiceConfig = provider.directPathServiceConfig;
     }
 
     /** Sets the number of available CPUs, used internally for testing. */

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProviderTest.java
@@ -158,6 +158,45 @@ public class InstantiatingGrpcChannelProviderTest {
   }
 
   @Test
+  public void testToBuilder() {
+    Duration keepaliveTime = Duration.ofSeconds(1);
+    Duration keepaliveTimeout = Duration.ofSeconds(2);
+    ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> channelConfigurator =
+        new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
+          @Override
+          public ManagedChannelBuilder apply(ManagedChannelBuilder input) {
+            throw new UnsupportedOperationException();
+          }
+        };
+    Map<String, ?> directPathServiceConfig = ImmutableMap.of("loadbalancingConfig", "grpclb");
+
+    InstantiatingGrpcChannelProvider provider =
+        InstantiatingGrpcChannelProvider.newBuilder()
+            .setProcessorCount(2)
+            .setEndpoint("fake.endpoint:443")
+            .setMaxInboundMessageSize(12345678)
+            .setMaxInboundMetadataSize(4096)
+            .setKeepAliveTime(keepaliveTime)
+            .setKeepAliveTimeout(keepaliveTimeout)
+            .setKeepAliveWithoutCalls(true)
+            .setChannelConfigurator(channelConfigurator)
+            .setChannelsPerCpu(2.5)
+            .setDirectPathServiceConfig(directPathServiceConfig)
+            .build();
+
+    InstantiatingGrpcChannelProvider.Builder builder = provider.toBuilder();
+
+    assertThat(builder.getEndpoint()).isEqualTo("fake.endpoint:443");
+    assertThat(builder.getMaxInboundMessageSize()).isEqualTo(12345678);
+    assertThat(builder.getMaxInboundMetadataSize()).isEqualTo(4096);
+    assertThat(builder.getKeepAliveTime()).isEqualTo(keepaliveTime);
+    assertThat(builder.getKeepAliveTimeout()).isEqualTo(keepaliveTimeout);
+    assertThat(builder.getChannelConfigurator()).isEqualTo(channelConfigurator);
+    assertThat(builder.getPoolSize()).isEqualTo(5);
+    assertThat(builder.build().directPathServiceConfig).isEqualTo(directPathServiceConfig);
+  }
+
+  @Test
   public void testWithInterceptors() throws Exception {
     testWithInterceptors(1);
   }


### PR DESCRIPTION
#1235 introduced a bug that InstantiatingGrpcChannelProvider.toBuilder() is missing the config data.

@vam-google 