### PR TITLE
feat: add self signed jwt feature

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -34,8 +34,8 @@ version.io_grpc=1.36.0
 #   2) Replace all characters which are neither alphabetic nor digits with the underscore ('_') character
 maven.com_google_api_grpc_proto_google_common_protos=com.google.api.grpc:proto-google-common-protos:2.0.1
 maven.com_google_api_grpc_grpc_google_common_protos=com.google.api.grpc:grpc-google-common-protos:2.0.1
-maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:0.25.0
-maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:0.25.0
+maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:0.25.2
+maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:0.25.2
 maven.io_opencensus_opencensus_api=io.opencensus:opencensus-api:0.28.0
 maven.io_opencensus_opencensus_contrib_grpc_metrics=io.opencensus:opencensus-contrib-grpc-metrics:0.28.0
 maven.io_opencensus_opencensus_contrib_http_util=io.opencensus:opencensus-contrib-http-util:0.28.0

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -34,8 +34,8 @@ version.io_grpc=1.36.0
 #   2) Replace all characters which are neither alphabetic nor digits with the underscore ('_') character
 maven.com_google_api_grpc_proto_google_common_protos=com.google.api.grpc:proto-google-common-protos:2.0.1
 maven.com_google_api_grpc_grpc_google_common_protos=com.google.api.grpc:grpc-google-common-protos:2.0.1
-maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:0.24.0
-maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:0.24.0
+maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:0.25.0
+maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:0.25.0
 maven.io_opencensus_opencensus_api=io.opencensus:opencensus-api:0.28.0
 maven.io_opencensus_opencensus_contrib_grpc_metrics=io.opencensus:opencensus-contrib-grpc-metrics:0.28.0
 maven.io_opencensus_opencensus_contrib_http_util=io.opencensus:opencensus-contrib-http-util:0.28.0
@@ -66,8 +66,8 @@ maven.com_google_api_api_common=com.google.api:api-common:1.10.1
 maven.org_threeten_threetenbp=org.threeten:threetenbp:1.5.0
 maven.com_google_api_grpc_grpc_google_iam_v1=com.google.api.grpc:grpc-google-iam-v1:1.0.9
 maven.com_google_api_grpc_proto_google_iam_v1=com.google.api.grpc:proto-google-iam-v1:1.0.9
-maven.com_google_http_client_google_http_client=com.google.http-client:google-http-client:1.39.0
-maven.com_google_http_client_google_http_client_gson=com.google.http-client:google-http-client-gson:1.39.0
+maven.com_google_http_client_google_http_client=com.google.http-client:google-http-client:1.39.1
+maven.com_google_http_client_google_http_client_gson=com.google.http-client:google-http-client-gson:1.39.1
 maven.org_codehaus_mojo_animal_sniffer_annotations=org.codehaus.mojo:animal-sniffer-annotations:1.18
 maven.javax_annotation_javax_annotation_api=javax.annotation:javax.annotation-api:1.3.2
 

--- a/gax/src/main/java/com/google/api/gax/core/GoogleCredentialsProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/GoogleCredentialsProvider.java
@@ -54,6 +54,9 @@ public abstract class GoogleCredentialsProvider implements CredentialsProvider {
   public abstract List<String> getScopesToApply();
 
   @BetaApi
+  public abstract List<String> getDefaultScopes();
+
+  @BetaApi
   public abstract List<String> getJwtEnabledScopes();
 
   @VisibleForTesting
@@ -88,15 +91,18 @@ public abstract class GoogleCredentialsProvider implements CredentialsProvider {
           .build();
     }
 
-    if (credentials.createScopedRequired()) {
-      credentials = credentials.createScoped(getScopesToApply());
+    if (credentials.createScopedRequired() || credentials instanceof ServiceAccountCredentials) {
+      credentials = credentials.createScoped(getScopesToApply(), getDefaultScopes());
     }
+
     return credentials;
   }
 
   public static Builder newBuilder() {
     return new AutoValue_GoogleCredentialsProvider.Builder()
-        .setJwtEnabledScopes(ImmutableList.<String>of());
+        .setJwtEnabledScopes(ImmutableList.<String>of())
+        .setScopesToApply(ImmutableList.<String>of())
+        .setDefaultScopes(ImmutableList.<String>of());
   }
 
   public abstract Builder toBuilder();
@@ -134,9 +140,16 @@ public abstract class GoogleCredentialsProvider implements CredentialsProvider {
     @BetaApi
     public abstract List<String> getJwtEnabledScopes();
 
+    @BetaApi
+    public abstract Builder setDefaultScopes(List<String> val);
+
+    @BetaApi
+    public abstract List<String> getDefaultScopes();
+
     public GoogleCredentialsProvider build() {
       setScopesToApply(ImmutableList.copyOf(getScopesToApply()));
       setJwtEnabledScopes(ImmutableList.copyOf(getJwtEnabledScopes()));
+      setDefaultScopes(ImmutableList.copyOf(getDefaultScopes()));
       return autoBuild();
     }
 

--- a/gax/src/main/java/com/google/api/gax/core/GoogleCredentialsProvider.java
+++ b/gax/src/main/java/com/google/api/gax/core/GoogleCredentialsProvider.java
@@ -91,7 +91,7 @@ public abstract class GoogleCredentialsProvider implements CredentialsProvider {
           .build();
     }
 
-    if (credentials.createScopedRequired() || credentials instanceof ServiceAccountCredentials) {
+    if (credentials.createScopedRequired()) {
       credentials = credentials.createScoped(getScopesToApply(), getDefaultScopes());
     }
 


### PR DESCRIPTION
follow up PR of https://github.com/googleapis/google-auth-library-java/pull/572

This PR does the following:
(1) added `defaultScopes` getter/setter to `GoogleCredentialsProvider`, and let `GoogleCredentialsProvider` passes the `defaultScopes` to `ServiceAccountCredentials`.
(2) updated `google-auth-library-java` version