### PR TITLE
fix: remove unused @InternalExtensionOnly from CallContext classes [gax-java]

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.grpc;
 
 import com.google.api.core.BetaApi;
-import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.api.gax.rpc.internal.Headers;
@@ -62,7 +61,6 @@ import org.threeten.bp.Duration;
  * and thread safety of the arguments solely depends on the arguments themselves.
  */
 @BetaApi("Reference ApiCallContext instead - this class is likely to experience breaking changes")
-@InternalExtensionOnly
 public final class GrpcCallContext implements ApiCallContext {
   static final CallOptions.Key<ApiTracer> TRACER_KEY = Key.create("gax.tracer");
 

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.httpjson;
 
 import com.google.api.core.BetaApi;
-import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.api.gax.rpc.internal.Headers;
@@ -56,7 +55,6 @@ import org.threeten.bp.Instant;
  * arguments solely depends on the arguments themselves.
  */
 @BetaApi
-@InternalExtensionOnly
 public final class HttpJsonCallContext implements ApiCallContext {
   private final HttpJsonChannel channel;
   private final Duration timeout;


### PR DESCRIPTION
Closes #1291.