### PR TITLE
feat: deprecate RetrySettings.isJittered [gax-java]

### DIFF
--- a/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java
@@ -187,7 +187,7 @@ public class ExponentialRetryAlgorithm implements TimedRetryAlgorithm {
 
   // Injecting Random is not possible here, as Random does not provide nextLong(long bound) method
   protected long nextRandomLong(long bound) {
-    return bound > 0 && globalSettings.isJittered()
+    return bound > 0 && globalSettings.isJittered() // Jitter check needed for testing purposes.
         ? ThreadLocalRandom.current().nextLong(bound)
         : bound;
   }

--- a/gax/src/main/java/com/google/api/gax/retrying/RetrySettings.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetrySettings.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.retrying;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.Serializable;
 import org.threeten.bp.Duration;
 
@@ -112,7 +113,11 @@ public abstract class RetrySettings implements Serializable {
    * <pre>{@code actualDelay = rand_between(0, min(maxRetryDelay, delay))}</pre>
    *
    * The default value is {@code true}.
+   *
+   * @deprecated Retries will always jitter.
    */
+  @Deprecated
+  @VisibleForTesting
   public abstract boolean isJittered();
 
   /**
@@ -200,7 +205,11 @@ public abstract class RetrySettings implements Serializable {
      * <pre>{@code actualDelay = rand_between(0, min(maxRetryDelay, exponentialDelay))}</pre>
      *
      * The default value is {@code true}.
+     *
+     * @deprecated Retries will always jitter.
      */
+    @Deprecated
+    @VisibleForTesting
     public abstract Builder setJittered(boolean jittered);
 
     /**

--- a/gax/src/main/java/com/google/api/gax/retrying/RetrySettings.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetrySettings.java
@@ -114,7 +114,7 @@ public abstract class RetrySettings implements Serializable {
    *
    * The default value is {@code true}.
    *
-   * @deprecated Retries will always jitter.
+   * @deprecated Retries always jitter.
    */
   @Deprecated
   @VisibleForTesting
@@ -199,14 +199,14 @@ public abstract class RetrySettings implements Serializable {
     public abstract Builder setMaxAttempts(int maxAttempts);
 
     /**
-     * Jitter determines if the delay time should be randomized. In most cases, if jitter is set to
-     * {@code true} the actual delay time is calculated in the following way:
+     * Jitter determines if the delay time should be randomized. If jitter is set to {@code true}
+     * the actual delay time is calculated in the following way:
      *
      * <pre>{@code actualDelay = rand_between(0, min(maxRetryDelay, exponentialDelay))}</pre>
      *
-     * The default value is {@code true}.
+     * The default value is {@code true}, and this method will be a no-op soon.
      *
-     * @deprecated Retries will always jitter.
+     * @deprecated Retries always jitter.
      */
     @Deprecated
     @VisibleForTesting


### PR DESCRIPTION
starts work on #1292

In the future, full deprecation will involve removing the public scoping, since this is still needed to (a) terminate polling for [OperationCallableImplTest](https://github.com/googleapis/gax-java/blob/master/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java#L92), and (b) set deterministic values for ExpontentialRetryAlgorithmTest's [testCreateNextAttempt](https://github.com/googleapis/gax-java/blob/master/gax/src/test/java/com/google/api/gax/retrying/ExponentialRetryAlgorithmTest.java#L89) and [testTruncateToTotalTimeout](https://github.com/googleapis/gax-java/blob/master/gax/src/test/java/com/google/api/gax/retrying/ExponentialRetryAlgorithmTest.java#L109).