### PR TITLE
ci: linkage-monitor-artifacts.txt generation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,8 @@ jobs:
       - run: java -version
       - name: Build and install local Maven repository
         run: ./gradlew build publishToMavenLocal -x test -x signMavenJavaPublication
+      - name: Generate artifact list (linkage-monitor-artifacts.txt) for Linkage Monitor
+        run: ./gradlew createLinkageMonitorArtifactList
       - name: Check dependency conflicts with the latest Libraries BOM
         uses: GoogleCloudPlatform/cloud-opensource-java/linkage-monitor@v1-linkagemonitor
       - name: Check dependency conflicts in the gax artifacts

--- a/build.gradle
+++ b/build.gradle
@@ -492,3 +492,18 @@ task finalizeRelease {
     }
   }
 }
+
+// Linkage Monitor searches for pom.xml but gax-java uses Gradle. Alternatively Linkage Monitor
+// reads linkage-monitor-artifacts.txt to get list of artifacts.
+// https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/Linkage-Monitor#linkage-monitor-artifactstxt
+task createLinkageMonitorArtifactList {
+  doLast {
+    def httpJsonVersion = project(":gax-httpjson").version
+
+    new File(projectDir, "linkage-monitor-artifacts.txt").text = """
+com.google.api:gax:$version
+com.google.api:gax-grpc:$version
+com.google.api:gax-httpjson:$httpJsonVersion
+"""
+  }
+}


### PR DESCRIPTION
Linkage Monitor by default searches for pom.xml files to get list of the artifacts that are generated by a repository. However certain repositories (such as gax-java) use Gradle and have no pom.xml files. Therefore Linkage Monitor has a functionality to let the repositories tell the list of artifacts. It reads linkage-monitor-artifacts.txt in the root of a repository.

