### PR TITLE
fix: retain user RPC timeout if set via withTimeout

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -65,11 +65,11 @@ public interface ApiCallContext extends RetryingContext {
    * <p>This sets the maximum amount of time a single unary RPC attempt can take. If retries are
    * enabled, then this can take much longer, as each RPC attempt will have the same constant
    * timeout. Unlike a deadline, timeouts are relative durations that are measure from the beginning
-   * of each RPC attempt. Please note that this will limit the duration of a server streaming RPC as
+   * of each RPC attempt. Please note that this limits the duration of a server streaming RPC as
    * well.
    *
    * <p>If a method has default {@link com.google.api.gax.retrying.RetrySettings}, the max attempts
-   * and/or total timeout will still be respected when scheduling each RPC attempt.
+   * and/or total timeout is still respected when scheduling each RPC attempt.
    */
   ApiCallContext withTimeout(@Nullable Duration timeout);
 

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -63,9 +63,13 @@ public interface ApiCallContext extends RetryingContext {
    * Returns a new ApiCallContext with the given timeout set.
    *
    * <p>This sets the maximum amount of time a single unary RPC attempt can take. If retries are
-   * enabled, then this can take much longer. Unlike a deadline, timeouts are relative durations
-   * that are measure from the beginning of each RPC attempt. Please note that this will limit the
-   * duration of a server streaming RPC as well.
+   * enabled, then this can take much longer, as each RPC attempt will have the same constant
+   * timeout. Unlike a deadline, timeouts are relative durations that are measure from the beginning
+   * of each RPC attempt. Please note that this will limit the duration of a server streaming RPC as
+   * well.
+   *
+   * <p>If a method has default {@link com.google.api.gax.retrying.RetrySettings}, the max attempts
+   * and/or total timeout will still be respected when scheduling each RPC attempt.
    */
   ApiCallContext withTimeout(@Nullable Duration timeout);
 

--- a/gax/src/main/java/com/google/api/gax/rpc/AttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/AttemptCallable.java
@@ -69,8 +69,9 @@ class AttemptCallable<RequestT, ResponseT> implements Callable<ResponseT> {
     ApiCallContext callContext = originalCallContext;
 
     try {
+      // Only attempt to set the RPC timeout if the caller did not provide their own.
       Duration rpcTimeout = externalFuture.getAttemptSettings().getRpcTimeout();
-      if (!rpcTimeout.isZero()) {
+      if (!rpcTimeout.isZero() && callContext.getTimeout() == null) {
         callContext = callContext.withTimeout(rpcTimeout);
       }
 

--- a/gax/src/main/java/com/google/api/gax/rpc/AttemptCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/AttemptCallable.java
@@ -69,7 +69,7 @@ class AttemptCallable<RequestT, ResponseT> implements Callable<ResponseT> {
     ApiCallContext callContext = originalCallContext;
 
     try {
-      // Only attempt to set the RPC timeout if the caller did not provide their own.
+      // Set the RPC timeout if the caller did not provide their own.
       Duration rpcTimeout = externalFuture.getAttemptSettings().getRpcTimeout();
       if (!rpcTimeout.isZero() && callContext.getTimeout() == null) {
         callContext = callContext.withTimeout(rpcTimeout);

--- a/gax/src/test/java/com/google/api/gax/rpc/AttemptCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/AttemptCallableTest.java
@@ -108,6 +108,9 @@ public class AttemptCallableTest {
     Duration callerTimeout = Duration.ofMillis(10);
     ApiCallContext callerCallContext = FakeCallContext.createDefault().withTimeout(callerTimeout);
 
+    Duration timeout = Duration.ofMillis(5);
+    currentAttemptSettings = currentAttemptSettings.toBuilder().setRpcTimeout(timeout).build();
+
     AttemptCallable<String, String> callable =
         new AttemptCallable<>(mockInnerCallable, "fake-request", callerCallContext);
     callable.setExternalFuture(mockExternalFuture);


### PR DESCRIPTION
If a Callable has `RetrySettings` and the calculated RPC Timeout for an attempt is less than the constant, RPC timeout provided by the user via `ApiCallContext.withTimeout`, the attempt settings will win. This is not caller friendly. 

This PR changes `AttemptCallable`, used for Unary RPCs, only attempts to set the `ApiCallContext.withTimeout` when it is not already set by the caller. 

This was fixed for ServerStreaming RPCs in https://github.com/googleapis/gax-java/pull/1155

Addresses commentary in https://github.com/googleapis/gax-java/issues/1144.