### PR TITLE
feat: wrap non-retryable RPCs in retry machinery

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -56,20 +56,21 @@ public class Callables {
       UnaryCallSettings<?, ?> callSettings,
       ClientContext clientContext) {
 
-    if (areRetriesDisabled(callSettings.getRetryableCodes(), callSettings.getRetrySettings())) {
+    UnaryCallSettings<?, ?> settings = callSettings;
+
+    if (areRetriesDisabled(settings.getRetryableCodes(), settings.getRetrySettings())) {
       // When retries are disabled, the total timeout can be treated as the rpc timeout.
-      callSettings =
-          callSettings
+      settings =
+          settings
               .toBuilder()
-              .setSimpleTimeoutNoRetries(callSettings.getRetrySettings().getTotalTimeout())
+              .setSimpleTimeoutNoRetries(settings.getRetrySettings().getTotalTimeout())
               .build();
     }
 
     RetryAlgorithm<ResponseT> retryAlgorithm =
         new RetryAlgorithm<>(
             new ApiResultRetryAlgorithm<ResponseT>(),
-            new ExponentialRetryAlgorithm(
-                callSettings.getRetrySettings(), clientContext.getClock()));
+            new ExponentialRetryAlgorithm(settings.getRetrySettings(), clientContext.getClock()));
     ScheduledRetryingExecutor<ResponseT> retryingExecutor =
         new ScheduledRetryingExecutor<>(retryAlgorithm, clientContext.getExecutor());
     return new RetryingCallable<>(
@@ -82,26 +83,26 @@ public class Callables {
       ServerStreamingCallSettings<RequestT, ResponseT> callSettings,
       ClientContext clientContext) {
 
-    if (areRetriesDisabled(callSettings.getRetryableCodes(), callSettings.getRetrySettings())) {
+    ServerStreamingCallSettings<RequestT, ResponseT> settings = callSettings;
+    if (areRetriesDisabled(settings.getRetryableCodes(), settings.getRetrySettings())) {
       // When retries are disabled, the total timeout can be treated as the rpc timeout.
-      callSettings =
-          callSettings
+      settings =
+          settings
               .toBuilder()
-              .setSimpleTimeoutNoRetries(callSettings.getRetrySettings().getTotalTimeout())
+              .setSimpleTimeoutNoRetries(settings.getRetrySettings().getTotalTimeout())
               .build();
     }
 
     StreamingRetryAlgorithm<Void> retryAlgorithm =
         new StreamingRetryAlgorithm<>(
             new ApiResultRetryAlgorithm<Void>(),
-            new ExponentialRetryAlgorithm(
-                callSettings.getRetrySettings(), clientContext.getClock()));
+            new ExponentialRetryAlgorithm(settings.getRetrySettings(), clientContext.getClock()));
 
     ScheduledRetryingExecutor<Void> retryingExecutor =
         new ScheduledRetryingExecutor<>(retryAlgorithm, clientContext.getExecutor());
 
     return new RetryingServerStreamingCallable<>(
-        innerCallable, retryingExecutor, callSettings.getResumptionStrategy());
+        innerCallable, retryingExecutor, settings.getResumptionStrategy());
   }
 
   @BetaApi("The surface for streaming is not stable yet and may change in the future.")

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -58,10 +58,11 @@ public class Callables {
 
     if (areRetriesDisabled(callSettings.getRetryableCodes(), callSettings.getRetrySettings())) {
       // When retries are disabled, the total timeout can be treated as the rpc timeout.
-      return innerCallable.withDefaultCallContext(
-          clientContext
-              .getDefaultCallContext()
-              .withTimeout(callSettings.getRetrySettings().getTotalTimeout()));
+      callSettings =
+          callSettings
+              .toBuilder()
+              .setSimpleTimeoutNoRetries(callSettings.getRetrySettings().getTotalTimeout())
+              .build();
     }
 
     RetryAlgorithm<ResponseT> retryAlgorithm =
@@ -83,10 +84,11 @@ public class Callables {
 
     if (areRetriesDisabled(callSettings.getRetryableCodes(), callSettings.getRetrySettings())) {
       // When retries are disabled, the total timeout can be treated as the rpc timeout.
-      return innerCallable.withDefaultCallContext(
-          clientContext
-              .getDefaultCallContext()
-              .withTimeout(callSettings.getRetrySettings().getTotalTimeout()));
+      callSettings =
+          callSettings
+              .toBuilder()
+              .setSimpleTimeoutNoRetries(callSettings.getRetrySettings().getTotalTimeout())
+              .build();
     }
 
     StreamingRetryAlgorithm<Void> retryAlgorithm =

--- a/gax/src/test/java/com/google/api/gax/rpc/CallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/CallableTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.rpc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.testing.FakeCallContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+import org.threeten.bp.Duration;
+
+public class CallableTest {
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  @Mock private UnaryCallable<String, String> innerCallable;
+  private SettableApiFuture<String> innerResult;
+
+  private RetrySettings retrySettings =
+      RetrySettings.newBuilder()
+          .setInitialRpcTimeout(Duration.ofMillis(5L))
+          .setMaxRpcTimeout(Duration.ofMillis(5L))
+          .setTotalTimeout(Duration.ofMillis(10L))
+          .build();
+
+  @Spy private ApiCallContext callContext = FakeCallContext.createDefault();
+
+  @Spy
+  private ApiCallContext callContextWithRetrySettings =
+      FakeCallContext.createDefault().withRetrySettings(retrySettings);
+
+  private ClientContext clientContext;
+
+  @Before
+  public void setUp() {
+    // Wire the mock inner callable
+    innerResult = SettableApiFuture.create();
+    when(innerCallable.futureCall(anyString(), any(ApiCallContext.class))).thenReturn(innerResult);
+
+    clientContext = ClientContext.newBuilder().setDefaultCallContext(callContext).build();
+  }
+
+  @Test
+  public void testNonRetriedCallable() throws Exception {
+    Duration timeout = Duration.ofMillis(5L);
+
+    // Verify that callables configured to not retry have context interactions.
+    UnaryCallSettings<Object, Object> callSettings =
+        UnaryCallSettings.newUnaryCallSettingsBuilder().setSimpleTimeoutNoRetries(timeout).build();
+    UnaryCallable<String, String> callable =
+        Callables.retrying(innerCallable, callSettings, clientContext);
+    innerResult.set("No, my refrigerator is not running!");
+
+    ApiFuture<String> future = callable.futureCall("Is your refrigerator running?", callContext);
+    verify(callContext, atLeastOnce()).getRetrySettings();
+    verify(callContext).getTimeout();
+    verify(callContext).withTimeout(timeout);
+  }
+
+  @Test
+  public void testNonRetriedCallableWithRetrySettings() throws Exception {
+    // Verify that callables configured to not retry have context interactions.
+    UnaryCallSettings<Object, Object> callSettings =
+        UnaryCallSettings.newUnaryCallSettingsBuilder()
+            .setSimpleTimeoutNoRetries(Duration.ofMillis(10L))
+            .build();
+    UnaryCallable<String, String> callable =
+        Callables.retrying(innerCallable, callSettings, clientContext);
+    innerResult.set("No, my refrigerator is not running!");
+
+    Duration timeout = retrySettings.getInitialRpcTimeout();
+
+    ApiFuture<String> future =
+        callable.futureCall("Is your refrigerator running?", callContextWithRetrySettings);
+
+    verify(callContextWithRetrySettings, atLeastOnce()).getRetrySettings();
+    verify(callContextWithRetrySettings).getTimeout();
+    verify(callContextWithRetrySettings).withTimeout(timeout);
+  }
+}

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedCallableTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.tracing;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.Callables;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.gax.rpc.testing.FakeCallContext;
+import com.google.api.gax.tracing.ApiTracerFactory.OperationType;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+import org.threeten.bp.Duration;
+
+@RunWith(JUnit4.class)
+public class TracedCallableTest {
+  private static final SpanName SPAN_NAME = SpanName.of("FakeClient", "FakeRpc");
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  @Mock private ApiTracerFactory tracerFactory;
+  private ApiTracer parentTracer;
+  @Mock private ApiTracer tracer;
+  @Mock private UnaryCallable<String, String> innerCallable;
+  private SettableApiFuture<String> innerResult;
+
+  private ApiCallContext callContext;
+  private ClientContext clientContext;
+
+  @Before
+  public void setUp() {
+    parentTracer = NoopApiTracer.getInstance();
+
+    // Wire the mock tracer factory
+    when(tracerFactory.newTracer(
+            any(ApiTracer.class), any(SpanName.class), eq(OperationType.Unary)))
+        .thenReturn(tracer);
+
+    // Wire the mock inner callable
+    innerResult = SettableApiFuture.create();
+    when(innerCallable.futureCall(anyString(), any(ApiCallContext.class))).thenReturn(innerResult);
+
+    callContext = FakeCallContext.createDefault();
+    clientContext = ClientContext.newBuilder().setDefaultCallContext(callContext).build();
+  }
+
+  public UnaryCallable<String, String> setupTracedUnaryCallable(
+      UnaryCallSettings<Object, Object> callSettings) {
+    UnaryCallable<String, String> callable =
+        Callables.retrying(innerCallable, callSettings, clientContext);
+    return new TracedUnaryCallable<>(callable, tracerFactory, SPAN_NAME);
+  }
+
+  @Test
+  public void testNonRetriedCallable() throws Exception {
+    // Verify that callables configured to not retry have the appropriate tracer interactions.
+    UnaryCallSettings<Object, Object> callSettings =
+        UnaryCallSettings.newUnaryCallSettingsBuilder()
+            .setSimpleTimeoutNoRetries(Duration.ofMillis(5L))
+            .build();
+    UnaryCallable<String, String> callable = setupTracedUnaryCallable(callSettings);
+    innerResult.set("No, my refrigerator is not running!");
+
+    ApiFuture<String> future = callable.futureCall("Is your refrigerator running?", callContext);
+
+    verify(tracerFactory, times(1)).newTracer(parentTracer, SPAN_NAME, OperationType.Unary);
+    verify(tracer, times(1)).attemptStarted(anyInt());
+    verify(tracer, times(1)).attemptSucceeded();
+    verify(tracer, times(1)).operationSucceeded();
+    verifyNoMoreInteractions(tracer);
+  }
+}


### PR DESCRIPTION
RPCs that are configured at the client-level to be non-retryable still get wrapped in the retry machinery to ensure features like #1238 that depend on call-time context options still work for non-retryable methods.

In order to ensure that the proper timeout is used by default, the call settings are overridden with `setSimpleTimeoutNoRetries`.

There are already tests that verify the proper timeout is used for non-retryable RPCs, for example: https://github.com/googleapis/gax-java/blob/3fe1db913b134e4fddee4c769ee4497847d8e01f/gax-grpc/src/test/java/com/google/api/gax/grpc/TimeoutTest.java#L87

Fixes #1327 