### PR TITLE
fix: add BetaApi tag to setLogicalTimeout

### DIFF
--- a/gax/src/main/java/com/google/api/gax/retrying/RetrySettings.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/RetrySettings.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.retrying;
 
+import com.google.api.core.BetaApi;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.Serializable;
@@ -305,6 +306,7 @@ public abstract class RetrySettings implements Serializable {
      * setters is not advised, because only the order in which they are invoked determines which
      * setter is respected.
      */
+    @BetaApi
     public Builder setLogicalTimeout(Duration timeout) {
       return setRpcTimeoutMultiplier(1)
           .setInitialRpcTimeout(timeout)


### PR DESCRIPTION
I forgot to add the `@BetaApi` annotation to the new `RetrySettings.Builder.setLogicalTimeout` helper in #1334 .