### PR TITLE
fix: fix watchdog NPE red herring

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
@@ -183,7 +183,7 @@ public final class Watchdog implements Runnable, BackgroundResource {
     private boolean autoAutoFlowControl = true;
 
     private final ResponseObserver<ResponseT> outerResponseObserver;
-    private StreamController innerController;
+    private volatile StreamController innerController;
 
     @GuardedBy("lock")
     private State state = State.IDLE;

--- a/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
@@ -296,6 +296,12 @@ public final class Watchdog implements Runnable, BackgroundResource {
      * @return True if the stream was canceled.
      */
     boolean cancelIfStale() {
+      // If the stream hasn't started yet, innerController will be null. Skip the check this time
+      // and return false so the stream is still watched.
+      if (innerController == null) {
+        return false;
+      }
+
       Throwable myError = null;
 
       synchronized (lock) {

--- a/gax/src/test/java/com/google/api/gax/rpc/WatchdogTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/WatchdogTest.java
@@ -129,17 +129,28 @@ public class WatchdogTest {
   }
 
   @Test
-  public void testTimedOutBeforeStart() {
+  public void testTimedOutBeforeStart() throws InterruptedException {
     MockServerStreamingCallable<String, String> callable1 = new MockServerStreamingCallable<>();
     AccumulatingObserver<String> downstreamObserver1 = new AccumulatingObserver<>();
     ResponseObserver observer = watchdog.watch(downstreamObserver1, waitTime, idleTime);
     clock.incrementNanoTime(idleTime.toNanos() + 1);
     // This should not remove callable1 from watched list
     watchdog.run();
+    assertThat(downstreamObserver1.done.isDone()).isFalse();
+
     callable1.call("request", observer);
     // This should cancel callable1
     watchdog.run();
-    assertThat(callable1.popLastCall().getController().isCancelled()).isTrue();
+    MockServerStreamingCall<String, String> call1 = callable1.popLastCall();
+    assertThat(call1.getController().isCancelled()).isTrue();
+    call1.getController().getObserver().onError(new CancellationException("User cancelled"));
+    Throwable error = null;
+    try {
+      downstreamObserver1.done.get();
+    } catch (ExecutionException t) {
+      error = t.getCause();
+    }
+    assertThat(error).isInstanceOf(WatchdogTimeoutException.class);
   }
 
   @Test


### PR DESCRIPTION
If CPU is overloaded, it's possible that the stream doesn't get started after idle timeout. In this case, innerController is not set and innerController.cancel() will throw NPE. The NPE is caught in `run()` and watchdog will still behave correctly, but the exception could be confusing. Adding a check to skip cancelIfStale to avoid the red herring.