### PR TITLE
fix: fix dynamic flow control setting checks

### DIFF
--- a/gax/src/main/java/com/google/api/gax/batching/DynamicFlowControlSettings.java
+++ b/gax/src/main/java/com/google/api/gax/batching/DynamicFlowControlSettings.java
@@ -115,12 +115,14 @@ public abstract class DynamicFlowControlSettings {
     }
 
     private void verifyElementCountSettings(DynamicFlowControlSettings settings) {
-      boolean isEnabled =
-          settings.getLimitExceededBehavior() != LimitExceededBehavior.Ignore
-              && (settings.getInitialOutstandingElementCount() != null
-                  || settings.getMinOutstandingElementCount() != null
-                  || settings.getMaxOutstandingElementCount() != null);
-      if (!isEnabled) {
+      // If LimitExceededBehavior is Ignore, dynamic flow control is disabled, there's no need to
+      // check element count limit settings
+      if (settings.getLimitExceededBehavior() == LimitExceededBehavior.Ignore) {
+        return;
+      }
+      if (settings.getInitialOutstandingElementCount() == null
+          && settings.getMinOutstandingElementCount() == null
+          && settings.getMaxOutstandingElementCount() == null) {
         return;
       }
       Preconditions.checkState(
@@ -142,12 +144,14 @@ public abstract class DynamicFlowControlSettings {
     }
 
     private void verifyRequestBytesSettings(DynamicFlowControlSettings settings) {
-      boolean isEnabled =
-          settings.getLimitExceededBehavior() != LimitExceededBehavior.Ignore
-              && (settings.getInitialOutstandingRequestBytes() != null
-                  || settings.getMinOutstandingRequestBytes() != null
-                  || settings.getMaxOutstandingRequestBytes() != null);
-      if (!isEnabled) {
+      // If LimitExceededBehavior is Ignore, dynamic flow control is disabled, there's no need to
+      // check request bytes limit settings
+      if (settings.getLimitExceededBehavior() == LimitExceededBehavior.Ignore) {
+        return;
+      }
+      if (settings.getInitialOutstandingRequestBytes() == null
+          && settings.getMinOutstandingRequestBytes() == null
+          && settings.getMaxOutstandingRequestBytes() == null) {
         return;
       }
       Preconditions.checkState(

--- a/gax/src/main/java/com/google/api/gax/batching/DynamicFlowControlSettings.java
+++ b/gax/src/main/java/com/google/api/gax/batching/DynamicFlowControlSettings.java
@@ -116,9 +116,10 @@ public abstract class DynamicFlowControlSettings {
 
     private void verifyElementCountSettings(DynamicFlowControlSettings settings) {
       boolean isEnabled =
-          settings.getInitialOutstandingElementCount() != null
-              || settings.getMinOutstandingElementCount() != null
-              || settings.getMaxOutstandingElementCount() != null;
+          settings.getLimitExceededBehavior() != LimitExceededBehavior.Ignore
+              && (settings.getInitialOutstandingElementCount() != null
+                  || settings.getMinOutstandingElementCount() != null
+                  || settings.getMaxOutstandingElementCount() != null);
       if (!isEnabled) {
         return;
       }
@@ -142,9 +143,10 @@ public abstract class DynamicFlowControlSettings {
 
     private void verifyRequestBytesSettings(DynamicFlowControlSettings settings) {
       boolean isEnabled =
-          settings.getInitialOutstandingRequestBytes() != null
-              || settings.getMinOutstandingRequestBytes() != null
-              || settings.getMaxOutstandingRequestBytes() != null;
+          settings.getLimitExceededBehavior() != LimitExceededBehavior.Ignore
+              && (settings.getInitialOutstandingRequestBytes() != null
+                  || settings.getMinOutstandingRequestBytes() != null
+                  || settings.getMaxOutstandingRequestBytes() != null);
       if (!isEnabled) {
         return;
       }

--- a/gax/src/test/java/com/google/api/gax/batching/DynamicFlowControlSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/DynamicFlowControlSettingsTest.java
@@ -56,15 +56,18 @@ public class DynamicFlowControlSettingsTest {
   }
 
   @Test
-  public void testSettingsIgnored() {
-    DynamicFlowControlSettings.Builder builder = DynamicFlowControlSettings.newBuilder();
+  public void testPartialSettingsIgnored() {
     // If behavior is ignore, build shouldn't throw exceptions even when only one of the bytes or
     // element limits is set
-    builder
-        .setLimitExceededBehavior(LimitExceededBehavior.Ignore)
-        .setMaxOutstandingRequestBytes(1L);
+    DynamicFlowControlSettings.Builder builder =
+        DynamicFlowControlSettings.newBuilder()
+            .setLimitExceededBehavior(LimitExceededBehavior.Ignore)
+            .setMaxOutstandingElementCount(1L);
     builder.build();
-    builder.setMinOutstandingElementCount(1L);
+    builder =
+        DynamicFlowControlSettings.newBuilder()
+            .setLimitExceededBehavior(LimitExceededBehavior.Ignore)
+            .setMinOutstandingRequestBytes(1L);
     builder.build();
   }
 

--- a/gax/src/test/java/com/google/api/gax/batching/DynamicFlowControlSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/DynamicFlowControlSettingsTest.java
@@ -56,6 +56,19 @@ public class DynamicFlowControlSettingsTest {
   }
 
   @Test
+  public void testSettingsIgnored() {
+    DynamicFlowControlSettings.Builder builder = DynamicFlowControlSettings.newBuilder();
+    // If behavior is ignore, build shouldn't throw exceptions even when only one of the bytes or
+    // element limits is set
+    builder
+        .setLimitExceededBehavior(LimitExceededBehavior.Ignore)
+        .setMaxOutstandingRequestBytes(1L);
+    builder.build();
+    builder.setMinOutstandingElementCount(1L);
+    builder.build();
+  }
+
+  @Test
   public void testBuilder() {
     DynamicFlowControlSettings.Builder builder =
         DynamicFlowControlSettings.newBuilder()


### PR DESCRIPTION
If LimitedExceededBehavior is Ignore, skip checking if all the elements or bytes limit are set.