### PR TITLE
fix: fix flaky tests and non blocking semaphore

### DIFF
--- a/gax/src/main/java/com/google/api/gax/batching/NonBlockingSemaphore.java
+++ b/gax/src/main/java/com/google/api/gax/batching/NonBlockingSemaphore.java
@@ -80,7 +80,7 @@ class NonBlockingSemaphore implements Semaphore64 {
     checkNotNegative(permits);
     // To allow individual oversized requests to be sent, clamp the requested permits to the maximum
     // limit. This will allow individual large requests to be sent. Please note that this behavior
-    // will result in availablePermits going negative.
+    // will result in acquiredPermits going over limit.
     while (true) {
       long old = acquiredPermits.get();
       if (old + permits > limit.get() && old > 0) {

--- a/gax/src/main/java/com/google/api/gax/batching/NonBlockingSemaphore.java
+++ b/gax/src/main/java/com/google/api/gax/batching/NonBlockingSemaphore.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /** A {@link Semaphore64} that immediately returns with failure if permits are not available. */
 class NonBlockingSemaphore implements Semaphore64 {
-  private AtomicLong availablePermits;
+  private AtomicLong acquiredPermits;
   private AtomicLong limit;
 
   private static void checkNotNegative(long l) {
@@ -44,7 +44,7 @@ class NonBlockingSemaphore implements Semaphore64 {
 
   NonBlockingSemaphore(long permits) {
     checkNotNegative(permits);
-    this.availablePermits = new AtomicLong(permits);
+    this.acquiredPermits = new AtomicLong(0);
     this.limit = new AtomicLong(permits);
   }
 
@@ -52,9 +52,10 @@ class NonBlockingSemaphore implements Semaphore64 {
   public void release(long permits) {
     checkNotNegative(permits);
     while (true) {
-      long old = availablePermits.get();
+      long old = acquiredPermits.get();
       // TODO: throw exceptions when the permits overflow
-      if (availablePermits.compareAndSet(old, Math.min(old + permits, limit.get()))) {
+      long newAcquired = Math.max(0, old - permits);
+      if (acquiredPermits.compareAndSet(old, newAcquired)) {
         return;
       }
     }
@@ -64,11 +65,11 @@ class NonBlockingSemaphore implements Semaphore64 {
   public boolean acquire(long permits) {
     checkNotNegative(permits);
     while (true) {
-      long old = availablePermits.get();
-      if (old < permits) {
+      long old = acquiredPermits.get();
+      if (old + permits > limit.get()) {
         return false;
       }
-      if (availablePermits.compareAndSet(old, old - permits)) {
+      if (acquiredPermits.compareAndSet(old, old + permits)) {
         return true;
       }
     }
@@ -81,11 +82,11 @@ class NonBlockingSemaphore implements Semaphore64 {
     // limit. This will allow individual large requests to be sent. Please note that this behavior
     // will result in availablePermits going negative.
     while (true) {
-      long old = availablePermits.get();
-      if (old < Math.min(limit.get(), permits)) {
+      long old = acquiredPermits.get();
+      if (old + permits > limit.get() && old > 0) {
         return false;
       }
-      if (availablePermits.compareAndSet(old, old - permits)) {
+      if (acquiredPermits.compareAndSet(old, old + permits)) {
         return true;
       }
     }
@@ -94,7 +95,6 @@ class NonBlockingSemaphore implements Semaphore64 {
   @Override
   public void increasePermitLimit(long permits) {
     checkNotNegative(permits);
-    availablePermits.addAndGet(permits);
     limit.addAndGet(permits);
   }
 
@@ -106,7 +106,6 @@ class NonBlockingSemaphore implements Semaphore64 {
       long oldLimit = limit.get();
       Preconditions.checkState(oldLimit - reduction > 0, "permit limit underflow");
       if (limit.compareAndSet(oldLimit, oldLimit - reduction)) {
-        availablePermits.addAndGet(-reduction);
         return;
       }
     }

--- a/gax/src/test/java/com/google/api/gax/batching/FlowControlEventStatsTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/FlowControlEventStatsTest.java
@@ -36,8 +36,6 @@ import static org.junit.Assert.fail;
 
 import com.google.api.gax.batching.FlowControlEventStats.FlowControlEvent;
 import com.google.api.gax.batching.FlowController.MaxOutstandingRequestBytesReachedException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,27 +69,14 @@ public class FlowControlEventStatsTest {
   }
 
   @Test
-  public void testGetLastEvent() throws InterruptedException {
-    final FlowControlEventStats stats = new FlowControlEventStats();
-    final long currentTime = System.currentTimeMillis();
+  public void testGetLastEvent() {
+    FlowControlEventStats stats = new FlowControlEventStats();
+    long currentTime = System.currentTimeMillis();
 
-    List<Thread> threads = new ArrayList<>();
     for (int i = 1; i <= 10; i++) {
-      final int timeElapsed = i;
-      Thread t =
-          new Thread() {
-            @Override
-            public void run() {
-              stats.recordFlowControlEvent(
-                  FlowControlEvent.createReserveDelayed(currentTime + timeElapsed, timeElapsed));
-            }
-          };
-      threads.add(t);
-      t.start();
-    }
-
-    for (Thread t : threads) {
-      t.join(10);
+      int timeElapsed = i;
+      stats.recordFlowControlEvent(
+          FlowControlEvent.createReserveDelayed(currentTime + timeElapsed, timeElapsed));
     }
 
     assertEquals(currentTime + 10, stats.getLastFlowControlEvent().getTimestampMs());


### PR DESCRIPTION
Fix for https://github.com/googleapis/gax-java/issues/1359

In NonBlockingSemaphore, updating both `limit` and `avaliablePermits` in increase and decrease limits may cause problems. If the limit is lowered but avaliablePermits is not updated yet, and release is called, this statement in release: ` if (availablePermits.compareAndSet(old, Math.min(old + permits, limit.get())))` may update the `availablePermits` incorrectly.

Since we're already tracking the limit in the semaphore class, instead of tracking what's available, we could track how many permits are acquired. So When we're adjusting the limit, we won't need to update both variables and should avoid this problem.

After the change the test succeeded in all 100 runs:

```
//gax:com.google.api.gax.batching.FlowControllerTest                     PASSED in 1.7s
  Stats over 100 runs: max = 1.7s, min = 0.9s, avg = 1.2s, dev = 0.1s
``` 
