### PR TITLE
fix: Make x-goog-api-client header report rest-based transport clients with `rest/` token instead of `httpson/`

### DIFF
--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/GaxHttpJsonProperties.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/GaxHttpJsonProperties.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
 @InternalApi
 public class GaxHttpJsonProperties {
   private static final Pattern DEFAULT_API_CLIENT_HEADER_PATTERN =
-      Pattern.compile("gl-java/.+ gapic/.* gax/.+ httpjson/.*");
+      Pattern.compile("gl-java/.+ gapic/.* gax/.+ rest/.*");
 
   /** Returns default api client header pattern (to facilitate testing) */
   public static Pattern getDefaultApiClientHeaderPattern() {
@@ -44,7 +44,7 @@ public class GaxHttpJsonProperties {
   }
 
   public static String getHttpJsonTokenName() {
-    return "httpjson";
+    return "rest";
   }
 
   public static String getHttpJsonVersion() {

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/GaxHttpJsonPropertiesTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/GaxHttpJsonPropertiesTest.java
@@ -41,7 +41,7 @@ public class GaxHttpJsonPropertiesTest {
   public void testDefaultHeaderPattern() {
     assertTrue(
         GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
-            .matcher("gl-java/1.8_00 gapic/1.2.3-alpha gax/1.5.0 httpjson/1.7.0")
+            .matcher("gl-java/1.8_00 gapic/1.2.3-alpha gax/1.5.0 rest/1.7.0")
             .matches());
   }
 }


### PR DESCRIPTION
We will still be able to disambiguate between discogapic and diregapic for compute by the `gapic/` token in the same header. Discogapic clients will be versioned as `0.x.x`, while diregapics are `1.x.x-alpha`