### PR TITLE
chore: update cloud-rad doclet

### DIFF
--- a/.kokoro/release/publish_javadoc11.sh
+++ b/.kokoro/release/publish_javadoc11.sh
@@ -36,10 +36,13 @@ VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
 # build the docs
 ./gradlew javadocCombinedV3
 
-# copy README to tmp_docs dir and rename index.md
-cp README.md tmp_docs/index.md
+# copy README to docfx-yml dir and rename index.md
+cp README.md tmp_docs/docfx-yml/index.md
 
-pushd tmp_docs
+# copy CHANGELOG to docfx-yml dir and rename history.md
+cp CHANGELOG.md tmp_docs/docfx-yml/history.md
+
+pushd tmp_docs/docfx-yml/
 
 # create metadata
 python3 -m docuploader create-metadata \

--- a/build.gradle
+++ b/build.gradle
@@ -425,11 +425,12 @@ clean {
 task javadocCombinedV3(type: Javadoc) {
   source subprojects.collect {project -> project.sourceSets.main.allJava }
   classpath = files(subprojects.collect {project -> project.sourceSets.main.compileClasspath})
-  destinationDir = new File(projectDir, 'tmp_docs')
+  destinationDir = new File(projectDir, 'tmp_docs/docfx-yml')
 
   options.addStringOption('encoding', 'UTF-8')
   options.addStringOption("doclet", "com.microsoft.doclet.DocFxDoclet")
-  options.docletpath = [file(System.getenv('KOKORO_GFILE_DIR') + "/docfx-doclet-1.0-SNAPSHOT-jar-with-dependencies-172556.jar")]
+  options.addStringOption("projectname", "gax")
+  options.docletpath = [file(System.getenv('KOKORO_GFILE_DIR') + "/java-docfx-doclet-1.0.jar")]
 }
 
 clean {


### PR DESCRIPTION
Updates cloud rad doc generation to use new [doclet](https://github.com/googleapis/java-docfx-doclet). Added the new doclet jar to cloud-devrel-kokoro-resources/docfx bucket