### PR TITLE
fix: StubSettings build() return type should not be generic

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -489,7 +489,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       }
     }
 
-    public abstract <B extends StubSettings<B>> StubSettings<B> build() throws IOException;
+    public abstract SettingsT build() throws IOException;
 
     public String toString() {
       return MoreObjects.toStringHelper(this)


### PR DESCRIPTION
This must always be the CRTP type passed in as the type of settings, and it currently produces a compiler warning for an unchecked conversion