### PR TITLE
chore: make ApiTracer internal API

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -36,7 +36,7 @@ import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.api.gax.rpc.internal.Headers;
 import com.google.api.gax.tracing.ApiTracer;
-import com.google.api.gax.tracing.NoopApiTracer;
+import com.google.api.gax.tracing.BaseApiTracer;
 import com.google.auth.Credentials;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -479,7 +479,7 @@ public final class GrpcCallContext implements ApiCallContext {
   public ApiTracer getTracer() {
     ApiTracer tracer = callOptions.getOption(TRACER_KEY);
     if (tracer == null) {
-      tracer = NoopApiTracer.getInstance();
+      tracer = BaseApiTracer.getInstance();
     }
     return tracer;
   }

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -36,7 +36,7 @@ import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.api.gax.rpc.internal.Headers;
 import com.google.api.gax.tracing.ApiTracer;
-import com.google.api.gax.tracing.NoopApiTracer;
+import com.google.api.gax.tracing.BaseApiTracer;
 import com.google.auth.Credentials;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -352,7 +352,7 @@ public final class HttpJsonCallContext implements ApiCallContext {
   @Override
   public ApiTracer getTracer() {
     if (tracer == null) {
-      return NoopApiTracer.getInstance();
+      return BaseApiTracer.getInstance();
     }
     return tracer;
   }

--- a/gax/src/main/java/com/google/api/gax/retrying/NoopRetryingContext.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/NoopRetryingContext.java
@@ -34,7 +34,7 @@ package com.google.api.gax.retrying;
 
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.api.gax.tracing.ApiTracer;
-import com.google.api.gax.tracing.NoopApiTracer;
+import com.google.api.gax.tracing.BaseApiTracer;
 import java.util.Set;
 import javax.annotation.Nonnull;
 
@@ -51,7 +51,7 @@ class NoopRetryingContext implements RetryingContext {
   @Nonnull
   @Override
   public ApiTracer getTracer() {
-    return NoopApiTracer.getInstance();
+    return BaseApiTracer.getInstance();
   }
 
   @Override

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -38,7 +38,7 @@ import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.rpc.internal.QuotaProjectIdHidingCredentials;
 import com.google.api.gax.rpc.mtls.MtlsProvider;
 import com.google.api.gax.tracing.ApiTracerFactory;
-import com.google.api.gax.tracing.NoopApiTracerFactory;
+import com.google.api.gax.tracing.BaseApiTracerFactory;
 import com.google.auth.Credentials;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
@@ -119,7 +119,7 @@ public abstract class ClientContext {
         .setClock(NanoClock.getDefaultClock())
         .setStreamWatchdog(null)
         .setStreamWatchdogCheckInterval(Duration.ZERO)
-        .setTracerFactory(NoopApiTracerFactory.getInstance())
+        .setTracerFactory(BaseApiTracerFactory.getInstance())
         .setQuotaProjectId(null);
   }
 

--- a/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -40,7 +40,7 @@ import com.google.api.gax.core.FixedExecutorProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.tracing.ApiTracerFactory;
-import com.google.api.gax.tracing.NoopApiTracerFactory;
+import com.google.api.gax.tracing.BaseApiTracerFactory;
 import com.google.auth.oauth2.QuotaProjectIdProvider;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
@@ -257,7 +257,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         this.quotaProjectId = null;
         this.streamWatchdogProvider = InstantiatingWatchdogProvider.create();
         this.streamWatchdogCheckInterval = Duration.ofSeconds(10);
-        this.tracerFactory = NoopApiTracerFactory.getInstance();
+        this.tracerFactory = BaseApiTracerFactory.getInstance();
       } else {
         this.executorProvider = FixedExecutorProvider.create(clientContext.getExecutor());
         this.transportChannelProvider =

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
@@ -39,9 +39,9 @@ import org.threeten.bp.Duration;
  * its lifecycle. Constructing an instance of a subclass will implicitly signal the start of a new
  * operation.
  *
- * <p>For internal use only.
+ * <p>For internal use only. google-cloud-java libraries should extend {@link NoopApiTracer}.
  */
-@InternalApi("For internal use by google-cloud-java clients only")
+@InternalApi
 public interface ApiTracer {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracer.java
@@ -39,7 +39,7 @@ import org.threeten.bp.Duration;
  * its lifecycle. Constructing an instance of a subclass will implicitly signal the start of a new
  * operation.
  *
- * <p>For internal use only. google-cloud-java libraries should extend {@link NoopApiTracer}.
+ * <p>For internal use only. google-cloud-java libraries should extend {@link BaseApiTracer}.
  */
 @InternalApi
 public interface ApiTracer {

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
@@ -38,7 +38,7 @@ import com.google.api.core.InternalExtensionOnly;
  * <p>In general a single instance of an {@link ApiTracer} will correspond to a single logical
  * operation.
  *
- * <p>For internal use only. google-cloud-java libraries should extend {@link NoopApiTracerFactory}.
+ * <p>For internal use only. google-cloud-java libraries should extend {@link BaseApiTracerFactory}.
  */
 @InternalApi
 @InternalExtensionOnly

--- a/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/ApiTracerFactory.java
@@ -38,9 +38,9 @@ import com.google.api.core.InternalExtensionOnly;
  * <p>In general a single instance of an {@link ApiTracer} will correspond to a single logical
  * operation.
  *
- * <p>For internal use only.
+ * <p>For internal use only. google-cloud-java libraries should extend {@link NoopApiTracerFactory}.
  */
-@InternalApi("For internal use by google-cloud-java clients only")
+@InternalApi
 @InternalExtensionOnly
 public interface ApiTracerFactory {
   /** The type of operation the {@link ApiTracer} is tracing. */

--- a/gax/src/main/java/com/google/api/gax/tracing/BaseApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/BaseApiTracer.java
@@ -30,25 +30,109 @@
 package com.google.api.gax.tracing;
 
 import com.google.api.core.InternalApi;
+import org.threeten.bp.Duration;
 
 /**
- * Factory that will build {@link ApiTracer}s that do nothing.
+ * A base implementation of {@link ApiTracer} that does nothing.
  *
  * <p>For internal use only.
  */
 @InternalApi("For internal use by google-cloud-java clients only")
-public class NoopApiTracerFactory implements ApiTracerFactory {
-  private static final NoopApiTracerFactory INSTANCE = new NoopApiTracerFactory();
+public class BaseApiTracer implements ApiTracer {
+  private static final ApiTracer INSTANCE = new BaseApiTracer();
 
-  public static NoopApiTracerFactory getInstance() {
+  private static final Scope NOOP_SCOPE =
+      new Scope() {
+        @Override
+        public void close() {
+          // noop
+        }
+      };
+
+  protected BaseApiTracer() {}
+
+  public static ApiTracer getInstance() {
     return INSTANCE;
   }
 
-  protected NoopApiTracerFactory() {}
-
-  /** {@inheritDoc} */
   @Override
-  public ApiTracer newTracer(ApiTracer parent, SpanName spanName, OperationType operationType) {
-    return NoopApiTracer.getInstance();
+  public Scope inScope() {
+    return NOOP_SCOPE;
+  }
+
+  @Override
+  public void operationSucceeded() {
+    // noop
+  }
+
+  @Override
+  public void operationCancelled() {
+    // noop
+  }
+
+  @Override
+  public void operationFailed(Throwable error) {
+    // noop
+  }
+
+  @Override
+  public void connectionSelected(String id) {
+    // noop
+  }
+
+  @Override
+  public void attemptStarted(int attemptNumber) {
+    // noop
+  }
+
+  @Override
+  public void attemptSucceeded() {
+    // noop
+  }
+
+  @Override
+  public void attemptCancelled() {
+    // noop
+  }
+
+  @Override
+  public void attemptFailed(Throwable error, Duration delay) {
+    // noop
+  }
+
+  @Override
+  public void attemptFailedRetriesExhausted(Throwable error) {
+    // noop
+  }
+
+  @Override
+  public void attemptPermanentFailure(Throwable error) {
+    // noop
+
+  }
+
+  @Override
+  public void lroStartFailed(Throwable error) {
+    // noop
+  }
+
+  @Override
+  public void lroStartSucceeded() {
+    // noop
+  }
+
+  @Override
+  public void responseReceived() {
+    // noop
+  }
+
+  @Override
+  public void requestSent() {
+    // noop
+  }
+
+  @Override
+  public void batchRequestSent(long elementCount, long requestSize) {
+    // noop
   }
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/BaseApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/BaseApiTracerFactory.java
@@ -30,109 +30,25 @@
 package com.google.api.gax.tracing;
 
 import com.google.api.core.InternalApi;
-import org.threeten.bp.Duration;
 
 /**
- * An implementation of {@link ApiTracer} that does nothing.
+ * Base factory that will build {@link ApiTracer}s that do nothing.
  *
  * <p>For internal use only.
  */
 @InternalApi("For internal use by google-cloud-java clients only")
-public class NoopApiTracer implements ApiTracer {
-  private static final ApiTracer INSTANCE = new NoopApiTracer();
+public class BaseApiTracerFactory implements ApiTracerFactory {
+  private static final BaseApiTracerFactory INSTANCE = new BaseApiTracerFactory();
 
-  private static final Scope NOOP_SCOPE =
-      new Scope() {
-        @Override
-        public void close() {
-          // noop
-        }
-      };
-
-  protected NoopApiTracer() {}
-
-  public static ApiTracer getInstance() {
+  public static BaseApiTracerFactory getInstance() {
     return INSTANCE;
   }
 
-  @Override
-  public Scope inScope() {
-    return NOOP_SCOPE;
-  }
+  protected BaseApiTracerFactory() {}
 
+  /** {@inheritDoc} */
   @Override
-  public void operationSucceeded() {
-    // noop
-  }
-
-  @Override
-  public void operationCancelled() {
-    // noop
-  }
-
-  @Override
-  public void operationFailed(Throwable error) {
-    // noop
-  }
-
-  @Override
-  public void connectionSelected(String id) {
-    // noop
-  }
-
-  @Override
-  public void attemptStarted(int attemptNumber) {
-    // noop
-  }
-
-  @Override
-  public void attemptSucceeded() {
-    // noop
-  }
-
-  @Override
-  public void attemptCancelled() {
-    // noop
-  }
-
-  @Override
-  public void attemptFailed(Throwable error, Duration delay) {
-    // noop
-  }
-
-  @Override
-  public void attemptFailedRetriesExhausted(Throwable error) {
-    // noop
-  }
-
-  @Override
-  public void attemptPermanentFailure(Throwable error) {
-    // noop
-
-  }
-
-  @Override
-  public void lroStartFailed(Throwable error) {
-    // noop
-  }
-
-  @Override
-  public void lroStartSucceeded() {
-    // noop
-  }
-
-  @Override
-  public void responseReceived() {
-    // noop
-  }
-
-  @Override
-  public void requestSent() {
-    // noop
-  }
-
-  @Override
-  public void batchRequestSent(long elementCount, long requestSize) {
-    // noop
+  public ApiTracer newTracer(ApiTracer parent, SpanName spanName, OperationType operationType) {
+    return BaseApiTracer.getInstance();
   }
 }

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
@@ -51,7 +51,6 @@ public class NoopApiTracer implements ApiTracer {
 
   public NoopApiTracer() {}
 
-  @InternalApi
   public static ApiTracer getInstance() {
     return INSTANCE;
   }

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
@@ -37,8 +37,8 @@ import org.threeten.bp.Duration;
  *
  * <p>For internal use only.
  */
-@InternalApi
-public final class NoopApiTracer implements ApiTracer {
+@InternalApi("For internal use by google-cloud-java clients only")
+public class NoopApiTracer implements ApiTracer {
   private static final ApiTracer INSTANCE = new NoopApiTracer();
 
   private static final Scope NOOP_SCOPE =
@@ -49,8 +49,9 @@ public final class NoopApiTracer implements ApiTracer {
         }
       };
 
-  private NoopApiTracer() {}
+  public NoopApiTracer() {}
 
+  @InternalApi
   public static ApiTracer getInstance() {
     return INSTANCE;
   }

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracer.java
@@ -49,7 +49,7 @@ public class NoopApiTracer implements ApiTracer {
         }
       };
 
-  public NoopApiTracer() {}
+  protected NoopApiTracer() {}
 
   public static ApiTracer getInstance() {
     return INSTANCE;

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
@@ -40,7 +40,6 @@ import com.google.api.core.InternalApi;
 public class NoopApiTracerFactory implements ApiTracerFactory {
   private static final NoopApiTracerFactory INSTANCE = new NoopApiTracerFactory();
 
-  @InternalApi
   public static NoopApiTracerFactory getInstance() {
     return INSTANCE;
   }

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
@@ -44,7 +44,7 @@ public class NoopApiTracerFactory implements ApiTracerFactory {
     return INSTANCE;
   }
 
-  public NoopApiTracerFactory() {}
+  protected NoopApiTracerFactory() {}
 
   /** {@inheritDoc} */
   @Override

--- a/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/NoopApiTracerFactory.java
@@ -36,15 +36,16 @@ import com.google.api.core.InternalApi;
  *
  * <p>For internal use only.
  */
-@InternalApi
-public final class NoopApiTracerFactory implements ApiTracerFactory {
+@InternalApi("For internal use by google-cloud-java clients only")
+public class NoopApiTracerFactory implements ApiTracerFactory {
   private static final NoopApiTracerFactory INSTANCE = new NoopApiTracerFactory();
 
+  @InternalApi
   public static NoopApiTracerFactory getInstance() {
     return INSTANCE;
   }
 
-  private NoopApiTracerFactory() {}
+  public NoopApiTracerFactory() {}
 
   /** {@inheritDoc} */
   @Override

--- a/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracer.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracer.java
@@ -207,7 +207,7 @@ import org.threeten.bp.Duration;
  * com.google.api.gax.rpc.ApiStreamObserver} for more information.
  */
 @BetaApi("Surface for tracing is not yet stable")
-public class OpencensusTracer implements ApiTracer {
+public class OpencensusTracer extends BaseApiTracer {
   private final Tracer tracer;
   private final Span span;
   private final OperationType operationType;

--- a/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracerFactory.java
+++ b/gax/src/main/java/com/google/api/gax/tracing/OpencensusTracerFactory.java
@@ -49,7 +49,7 @@ import javax.annotation.Nonnull;
  * <p>This class is thread safe.
  */
 @InternalApi("For google-cloud-java client use only")
-public final class OpencensusTracerFactory implements ApiTracerFactory {
+public final class OpencensusTracerFactory extends BaseApiTracerFactory {
   @Nonnull private final Tracer internalTracer;
   @Nonnull private final Map<String, AttributeValue> spanAttributes;
 

--- a/gax/src/test/java/com/google/api/gax/retrying/NoopRetryingContextTest.java
+++ b/gax/src/test/java/com/google/api/gax/retrying/NoopRetryingContextTest.java
@@ -32,7 +32,7 @@ package com.google.api.gax.retrying;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
-import com.google.api.gax.tracing.NoopApiTracer;
+import com.google.api.gax.tracing.BaseApiTracer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -43,7 +43,7 @@ public class NoopRetryingContextTest {
   @Test
   public void testGetTracer() {
     RetryingContext context = NoopRetryingContext.create();
-    assertSame(NoopApiTracer.getInstance(), context.getTracer());
+    assertSame(BaseApiTracer.getInstance(), context.getTracer());
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingAttemptCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ServerStreamingAttemptCallableTest.java
@@ -41,7 +41,7 @@ import com.google.api.gax.rpc.testing.FakeApiException;
 import com.google.api.gax.rpc.testing.FakeCallContext;
 import com.google.api.gax.rpc.testing.MockStreamingApi.MockServerStreamingCall;
 import com.google.api.gax.rpc.testing.MockStreamingApi.MockServerStreamingCallable;
-import com.google.api.gax.tracing.NoopApiTracer;
+import com.google.api.gax.tracing.BaseApiTracer;
 import com.google.common.collect.Queues;
 import com.google.common.truth.Truth;
 import java.util.concurrent.BlockingDeque;
@@ -90,7 +90,7 @@ public class ServerStreamingAttemptCallableTest {
   @Test
   public void testUserProvidedContextTimeout() {
     // Mock up the ApiCallContext as if the user provided a timeout and streamWaitTimeout.
-    Mockito.doReturn(NoopApiTracer.getInstance()).when(mockedCallContext).getTracer();
+    Mockito.doReturn(BaseApiTracer.getInstance()).when(mockedCallContext).getTracer();
     Mockito.doReturn(Duration.ofHours(5)).when(mockedCallContext).getTimeout();
     Mockito.doReturn(Duration.ofHours(5)).when(mockedCallContext).getStreamWaitTimeout();
 
@@ -125,7 +125,7 @@ public class ServerStreamingAttemptCallableTest {
   @Test
   public void testNoUserProvidedContextTimeout() {
     // Mock up the ApiCallContext as if the user did not provide custom timeouts.
-    Mockito.doReturn(NoopApiTracer.getInstance()).when(mockedCallContext).getTracer();
+    Mockito.doReturn(BaseApiTracer.getInstance()).when(mockedCallContext).getTracer();
     Mockito.doReturn(null).when(mockedCallContext).getTimeout();
     Mockito.doReturn(null).when(mockedCallContext).getStreamWaitTimeout();
     Mockito.doReturn(mockedCallContext).when(mockedCallContext).withTimeout(totalTimeout);

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeCallContext.java
@@ -37,7 +37,7 @@ import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.api.gax.rpc.internal.Headers;
 import com.google.api.gax.tracing.ApiTracer;
-import com.google.api.gax.tracing.NoopApiTracer;
+import com.google.api.gax.tracing.BaseApiTracer;
 import com.google.auth.Credentials;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -346,7 +346,7 @@ public class FakeCallContext implements ApiCallContext {
   @Nonnull
   public ApiTracer getTracer() {
     if (tracer == null) {
-      return NoopApiTracer.getInstance();
+      return BaseApiTracer.getInstance();
     }
     return tracer;
   }

--- a/gax/src/test/java/com/google/api/gax/tracing/OpencensusTracerFactoryTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/OpencensusTracerFactoryTest.java
@@ -80,7 +80,7 @@ public class OpencensusTracerFactoryTest {
         new OpencensusTracerFactory(internalTracer, ImmutableMap.<String, String>of());
 
     factory.newTracer(
-        NoopApiTracer.getInstance(), SpanName.of("FakeClient", "FakeMethod"), OperationType.Unary);
+        BaseApiTracer.getInstance(), SpanName.of("FakeClient", "FakeMethod"), OperationType.Unary);
 
     verify(internalTracer)
         .spanBuilderWithExplicitParent(eq("FakeClient.FakeMethod"), nullable(Span.class));
@@ -96,7 +96,7 @@ public class OpencensusTracerFactoryTest {
 
     try {
       factory.newTracer(
-          NoopApiTracer.getInstance(),
+          BaseApiTracer.getInstance(),
           SpanName.of("FakeClient", "FakeMethod"),
           OperationType.Unary);
     } finally {
@@ -146,7 +146,7 @@ public class OpencensusTracerFactoryTest {
         new OpencensusTracerFactory(internalTracer, ImmutableMap.of("gax.version", "1.2.3"));
 
     factory.newTracer(
-        NoopApiTracer.getInstance(), SpanName.of("FakeClient", "FakeMethod"), OperationType.Unary);
+        BaseApiTracer.getInstance(), SpanName.of("FakeClient", "FakeMethod"), OperationType.Unary);
 
     verify(span, times(1))
         .putAttributes(

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedBidiCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedBidiCallableTest.java
@@ -65,7 +65,7 @@ public class TracedBidiCallableTest {
   private FakeCallContext outerCallContext;
 
   @Mock private ApiTracerFactory tracerFactory;
-  private ApiTracer parentTracer = NoopApiTracer.getInstance();
+  private ApiTracer parentTracer = BaseApiTracer.getInstance();
   @Mock private ApiTracer tracer;
 
   private TracedBidiCallable<String, String> tracedCallable;

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedCallableTest.java
@@ -76,7 +76,7 @@ public class TracedCallableTest {
 
   @Before
   public void setUp() {
-    parentTracer = NoopApiTracer.getInstance();
+    parentTracer = BaseApiTracer.getInstance();
 
     // Wire the mock tracer factory
     when(tracerFactory.newTracer(

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedClientStreamingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedClientStreamingCallableTest.java
@@ -63,7 +63,7 @@ public class TracedClientStreamingCallableTest {
   public @Rule MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
 
   @Mock private ApiTracerFactory tracerFactory;
-  private ApiTracer parentTracer = NoopApiTracer.getInstance();
+  private ApiTracer parentTracer = BaseApiTracer.getInstance();
   @Mock private ApiTracer tracer;
 
   private FakeClientCallable innerCallable;

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedOperationCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedOperationCallableTest.java
@@ -76,7 +76,7 @@ public class TracedOperationCallableTest {
 
   @Before
   public void setUp() {
-    parentTracer = NoopApiTracer.getInstance();
+    parentTracer = BaseApiTracer.getInstance();
 
     // Wire the mock tracer factory
     when(tracerFactory.newTracer(

--- a/gax/src/test/java/com/google/api/gax/tracing/TracedUnaryCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/tracing/TracedUnaryCallableTest.java
@@ -70,7 +70,7 @@ public class TracedUnaryCallableTest {
 
   @Before
   public void setUp() {
-    parentTracer = NoopApiTracer.getInstance();
+    parentTracer = BaseApiTracer.getInstance();
 
     // Wire the mock tracer factory
     when(tracerFactory.newTracer(


### PR DESCRIPTION
We want to add a new method to `ApiTracer` interface, but it'll be a breaking change for clients that are implementing `ApiTracer`.

To solve this problem, mark `ApiTracer` and `ApiTracerFactory` as internal api, rename `NoopApiTracer` and `NoopApiTracerFactory` to `BaseApiTracer` and `BaseApiTracerFactory`. Interface changes to `ApiTracer` and `ApiTracerFactory` will be managed in gax, and all the implementations of `ApiTracer` should implement `BaseApiTracer`.