### PR TITLE
feat: add self signed jwt support

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -34,8 +34,8 @@ version.io_grpc=1.37.0
 #   2) Replace all characters which are neither alphabetic nor digits with the underscore ('_') character
 maven.com_google_api_grpc_proto_google_common_protos=com.google.api.grpc:proto-google-common-protos:2.0.1
 maven.com_google_api_grpc_grpc_google_common_protos=com.google.api.grpc:grpc-google-common-protos:2.0.1
-maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:0.24.0
-maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:0.24.0
+maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:0.27.0
+maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:0.27.0
 maven.io_opencensus_opencensus_api=io.opencensus:opencensus-api:0.28.0
 maven.io_opencensus_opencensus_contrib_grpc_metrics=io.opencensus:opencensus-contrib-grpc-metrics:0.28.0
 maven.io_opencensus_opencensus_contrib_http_util=io.opencensus:opencensus-contrib-http-util:0.28.0


### PR DESCRIPTION
Add `UseJwtAccessWithScope` property to `GoogleCredentialsProvider`, which passes the property value to `ServiceAccountCredentials` to trigger self signed JWT.

This property will be set by GAPIC clients, example PR: https://github.com/arithmetic1728/java-kms/pull/3