### PR TITLE
feat: introduce closeAsync to Batcher

### DIFF
--- a/gax/src/main/java/com/google/api/gax/batching/Batcher.java
+++ b/gax/src/main/java/com/google/api/gax/batching/Batcher.java
@@ -76,15 +76,15 @@ public interface Batcher<ElementT, ElementResultT> extends AutoCloseable {
   void sendOutstanding();
 
   /**
-   * Closes this Batcher by preventing new elements from being added and flushing the existing
+   * Closes this Batcher by preventing new elements from being added, and then flushing the existing
    * elements.
    */
   @Override
   void close() throws InterruptedException;
 
   /**
-   * Closes this Batcher by preventing new elements from being added and send outstanding elements.
-   * The returned future will be resolved when the last element completes
+   * Closes this Batcher by preventing new elements from being added, and then sending outstanding
+   * elements. The returned future will be resolved when the last element completes
    */
   ApiFuture<Void> closeAsync();
 }

--- a/gax/src/main/java/com/google/api/gax/batching/Batcher.java
+++ b/gax/src/main/java/com/google/api/gax/batching/Batcher.java
@@ -31,6 +31,7 @@ package com.google.api.gax.batching;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
 
 /**
  * Represents a batching context where individual elements will be accumulated and flushed in a
@@ -45,6 +46,7 @@ import com.google.api.core.BetaApi;
  * @param <ElementResultT> The type of the result for each individual element.
  */
 @BetaApi("The surface for batching is not stable yet and may change in the future.")
+@InternalExtensionOnly
 public interface Batcher<ElementT, ElementResultT> extends AutoCloseable {
 
   /**
@@ -79,4 +81,10 @@ public interface Batcher<ElementT, ElementResultT> extends AutoCloseable {
    */
   @Override
   void close() throws InterruptedException;
+
+  /**
+   * Closes this Batcher by preventing new elements from being added and send outstanding elements.
+   * The returned future will be resolved when the last element completes
+   */
+  ApiFuture<Void> closeAsync();
 }

--- a/gax/src/test/java/com/google/api/gax/batching/BatcherImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/BatcherImplTest.java
@@ -45,6 +45,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.gax.rpc.testing.FakeBatchableApi.LabeledIntList;
 import com.google.api.gax.rpc.testing.FakeBatchableApi.LabeledIntSquarerCallable;
 import com.google.api.gax.rpc.testing.FakeBatchableApi.SquarerBatchingDescriptorV2;
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Queues;
 import java.util.ArrayList;
@@ -69,7 +70,9 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.threeten.bp.Duration;
@@ -175,6 +178,55 @@ public class BatcherImplTest {
     assertThat(addOnClosedError)
         .hasMessageThat()
         .matches("Cannot add elements on a closed batcher");
+  }
+
+  /** Validates exception when batch is called after {@link Batcher#close()}. */
+  @Test
+  public void testNoElementAdditionAfterCloseAsync() throws Exception {
+    underTest = createDefaultBatcherImpl(batchingSettings, null);
+    underTest.add(1);
+    underTest.closeAsync();
+
+    IllegalStateException e = Assert.assertThrows(IllegalStateException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() throws Throwable {
+            underTest.add(1);
+          }
+        });
+
+    assertThat(e)
+        .hasMessageThat()
+        .matches("Cannot add elements on a closed batcher");
+  }
+
+  @Test
+  public void testCloseAsyncNonblocking() throws ExecutionException, InterruptedException {
+    final SettableApiFuture<List<Integer>> innerFuture = SettableApiFuture.create();
+
+    UnaryCallable<LabeledIntList, List<Integer>> unaryCallable =
+        new UnaryCallable<LabeledIntList, List<Integer>>() {
+          @Override
+          public ApiFuture<List<Integer>> futureCall(
+              LabeledIntList request, ApiCallContext context) {
+            return innerFuture;
+          }
+        };
+    underTest =
+        new BatcherImpl<>(
+            SQUARER_BATCHING_DESC_V2, unaryCallable, labeledIntList, batchingSettings, EXECUTOR);
+
+    ApiFuture<Integer> elementFuture = underTest.add(1);
+
+    Stopwatch stopwatch = Stopwatch.createStarted();
+    ApiFuture<Void> closeFuture = underTest.closeAsync();
+    assertThat(stopwatch.elapsed(TimeUnit.MILLISECONDS)).isAtMost(100);
+
+    assertThat(closeFuture.isDone()).isFalse();
+    assertThat(elementFuture.isDone()).isFalse();
+
+    innerFuture.set(ImmutableList.of(1));
+    closeFuture.get();
   }
 
   /** Verifies exception occurred at RPC is propagated to element results */
@@ -615,6 +667,74 @@ public class BatcherImplTest {
       assertThat(lr.getMessage()).contains("not closed properly");
       assertThat(lr.getLevel()).isEqualTo(Level.SEVERE);
     } finally {
+      batcherLogger.setFilter(oldFilter);
+    }
+  }
+
+  /**
+   * Validates the absence of warning in case {@link BatcherImpl} is garbage collected after
+   * being closed.
+   *
+   * <p>Note:This test cannot run concurrently with other tests that use Batchers.
+   */
+  @Test
+  public void testClosedBatchersAreNotLogged() throws Exception {
+    // Clean out the existing instances
+    final long DELAY_TIME = 30L;
+    int actualRemaining = 0;
+    for (int retry = 0; retry < 3; retry++) {
+      System.gc();
+      System.runFinalization();
+      actualRemaining = BatcherReference.cleanQueue();
+      if (actualRemaining == 0) {
+        break;
+      }
+      Thread.sleep(DELAY_TIME * (1L << retry));
+    }
+    assertThat(actualRemaining).isAtMost(0);
+
+    // Capture logs
+    final List<LogRecord> records = new ArrayList<>(1);
+    Logger batcherLogger = Logger.getLogger(BatcherImpl.class.getName());
+    Filter oldFilter = batcherLogger.getFilter();
+    batcherLogger.setFilter(
+        new Filter() {
+          @Override
+          public boolean isLoggable(LogRecord record) {
+            synchronized (records) {
+              records.add(record);
+            }
+            return false;
+          }
+        });
+
+
+    try {
+      // Create a bunch of batchers that will garbage collected after being closed
+      for (int i = 0; i < 1_000; i++) {
+        BatcherImpl<Integer, Integer, LabeledIntList, List<Integer>> batcher =
+            createDefaultBatcherImpl(batchingSettings, null);
+        batcher.add(1);
+
+        if (i%2 == 0) {
+          batcher.close();
+        } else {
+          batcher.closeAsync();
+        }
+      }
+      // Run GC a few times to give the batchers a chance to be collected
+      for (int retry = 0; retry < 100; retry++) {
+        System.gc();
+        System.runFinalization();
+        BatcherReference.cleanQueue();
+        Thread.sleep(10);
+      }
+
+      synchronized (records) {
+        assertThat(records).isEmpty();
+      }
+    } finally {
+      // reset logging
       batcherLogger.setFilter(oldFilter);
     }
   }

--- a/gax/src/test/java/com/google/api/gax/batching/BatcherImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/BatcherImplTest.java
@@ -92,7 +92,11 @@ public class BatcherImplTest {
   @After
   public void tearDown() throws InterruptedException {
     if (underTest != null) {
-      underTest.close();
+      try {
+        underTest.close();
+      } catch (BatchingException ignored) {
+
+      }
     }
   }
 

--- a/gax/src/test/java/com/google/api/gax/batching/BatcherImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/BatcherImplTest.java
@@ -93,9 +93,10 @@ public class BatcherImplTest {
   public void tearDown() throws InterruptedException {
     if (underTest != null) {
       try {
+        // Close the batcher to avoid warnings of orphaned batchers
         underTest.close();
       } catch (BatchingException ignored) {
-
+        // Some tests intentionally inject failures into mutations
       }
     }
   }

--- a/gax/src/test/java/com/google/api/gax/batching/BatcherImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/BatcherImplTest.java
@@ -187,17 +187,17 @@ public class BatcherImplTest {
     underTest.add(1);
     underTest.closeAsync();
 
-    IllegalStateException e = Assert.assertThrows(IllegalStateException.class,
-        new ThrowingRunnable() {
-          @Override
-          public void run() throws Throwable {
-            underTest.add(1);
-          }
-        });
+    IllegalStateException e =
+        Assert.assertThrows(
+            IllegalStateException.class,
+            new ThrowingRunnable() {
+              @Override
+              public void run() throws Throwable {
+                underTest.add(1);
+              }
+            });
 
-    assertThat(e)
-        .hasMessageThat()
-        .matches("Cannot add elements on a closed batcher");
+    assertThat(e).hasMessageThat().matches("Cannot add elements on a closed batcher");
   }
 
   @Test
@@ -672,8 +672,8 @@ public class BatcherImplTest {
   }
 
   /**
-   * Validates the absence of warning in case {@link BatcherImpl} is garbage collected after
-   * being closed.
+   * Validates the absence of warning in case {@link BatcherImpl} is garbage collected after being
+   * closed.
    *
    * <p>Note:This test cannot run concurrently with other tests that use Batchers.
    */
@@ -708,7 +708,6 @@ public class BatcherImplTest {
           }
         });
 
-
     try {
       // Create a bunch of batchers that will garbage collected after being closed
       for (int i = 0; i < 1_000; i++) {
@@ -716,7 +715,7 @@ public class BatcherImplTest {
             createDefaultBatcherImpl(batchingSettings, null);
         batcher.add(1);
 
-        if (i%2 == 0) {
+        if (i % 2 == 0) {
           batcher.close();
         } else {
           batcher.closeAsync();


### PR DESCRIPTION
This should allow callers to signal that they are done using a batcher without blocking their thread.
This will be used in bigtable-hbase to implement async batching cleanup