### PR TITLE
fix: remove `extends ApiMessage` from `HttpJsonStubCallableFactory` definition

### DIFF
--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStubCallableFactory.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStubCallableFactory.java
@@ -41,7 +41,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 
 @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
 public interface HttpJsonStubCallableFactory<
-    OperationT extends ApiMessage, OperationsStub extends BackgroundResource> {
+    OperationT, OperationsStub extends BackgroundResource> {
 
   /**
    * Create a callable object with http/json-specific functionality. Designed for use by generated
@@ -52,7 +52,7 @@ public interface HttpJsonStubCallableFactory<
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link UnaryCallable} callable object.
    */
-  public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createUnaryCallable(
+  <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createUnaryCallable(
       HttpJsonCallSettings<RequestT, ResponseT> httpJsonCallSettings,
       UnaryCallSettings<RequestT, ResponseT> callSettings,
       ClientContext clientContext);
@@ -66,7 +66,7 @@ public interface HttpJsonStubCallableFactory<
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link UnaryCallable} callable object.
    */
-  public <RequestT, ResponseT, PagedListResponseT>
+  <RequestT, ResponseT, PagedListResponseT>
       UnaryCallable<RequestT, PagedListResponseT> createPagedCallable(
           HttpJsonCallSettings<RequestT, ResponseT> httpJsonCallSettings,
           PagedCallSettings<RequestT, ResponseT, PagedListResponseT> pagedCallSettings,
@@ -82,12 +82,12 @@ public interface HttpJsonStubCallableFactory<
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link UnaryCallable} callable object.
    */
-  public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createBatchingCallable(
+  <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createBatchingCallable(
       HttpJsonCallSettings<RequestT, ResponseT> httpJsonCallSettings,
       BatchingCallSettings<RequestT, ResponseT> batchingCallSettings,
       ClientContext clientContext);
 
-  public <RequestT, ResponseT, MetadataT>
+  <RequestT, ResponseT, MetadataT>
       OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
           HttpJsonCallSettings<RequestT, OperationT> httpJsonCallSettings,
           OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings,


### PR DESCRIPTION
This is needed to match DIREGAPIC architecture, which does not rely on ApiMessage but on the proto stubs instead. This is also a prerequisite to making LRO a non-breaking change post GCE client GA.

The full set (without tests) of anticipated changes to support DIREGAPIC LRO can be found in https://github.com/googleapis/gax-java/commit/8588755fc7ac8910c47f836aee43fb2b502673fa (a separate branch now). The rest of the changes are additive, that is why they can wait.