### PR TITLE
fix: make getMetadata always return an already-completed future once the initial request completes

### DIFF
--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationFuture.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationFuture.java
@@ -31,6 +31,7 @@ package com.google.api.gax.longrunning;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
 import com.google.api.gax.retrying.RetryingFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -43,22 +44,52 @@ import java.util.concurrent.ExecutionException;
 @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public interface OperationFuture<ResponseT, MetadataT> extends ApiFuture<ResponseT> {
   /**
+   * Gets the metadata of the operation tracked by this {@link OperationFuture}. This method returns
+   * the current poll metadata result or the initial call metadata if no poll has completed yet. The
+   * returned future completes immediately after the initial call has completed.
+   *
+   * <p>Note, some APIs may return {@code null} in metadata response message. In such cases this
+   * method may return a non-null future whose {@code get()} method will return the initial call
+   * metadata. This behavior is API specific an should be considered a valid case, which indicates
+   * that the recent poll request has completed, but no specific metadata was provided by the
+   * server. (i.e. most probably providing metadata for an intermediate result is not supported by
+   * the server).
+   *
+   * <p>If this operation future is completed, this method always returns the metadata from the last
+   * poll request (which completed the operation future).
+   *
+   * <p>If this operation future failed, this method may (depending on the failure type) return a
+   * non-failing future, representing the metadata from the last poll request (which failed the
+   * operation future).
+   *
+   * <p>If this operation future was cancelled, this method returns a canceled metatata future as
+   * well.
+   */
+  ApiFuture<MetadataT> getMetadata();
+
+  /**
    * Returns the value of the name of the operation from the initial operation object returned from
    * the initial call to start the operation. Blocks if the initial call to start the operation
    * hasn't returned yet.
    */
   String getName() throws InterruptedException, ExecutionException;
 
+  // INTERNAL ONLY METHODS BELOW
   /**
    * Returns the {@link OperationSnapshot} future of the initial request which started this {@code
    * OperationFuture}.
    */
+  @InternalApi
   ApiFuture<OperationSnapshot> getInitialFuture();
 
   /** Returns the {@link RetryingFuture} which continues to poll {@link OperationSnapshot}. */
+  @InternalApi
   RetryingFuture<OperationSnapshot> getPollingFuture();
 
   /**
+   * DEPRECATED: Subsumed by getMetadata. Calling getMetadata.isDone() will return false if the
+   * initial future has not yet completed.
+   *
    * Peeks at the metadata of the operation tracked by this {@link OperationFuture}. If the initial
    * future hasn't completed yet this method returns {@code null}, otherwise it returns the latest
    * metadata returned from the server (i.e. either initial call metadata or the metadata received
@@ -91,40 +122,6 @@ public interface OperationFuture<ResponseT, MetadataT> extends ApiFuture<Respons
    *
    * <p>In general this method behaves similarly to {@link RetryingFuture#peekAttemptResult()}.
    */
+  @Deprecated
   ApiFuture<MetadataT> peekMetadata();
-
-  /**
-   * Gets the metadata of the operation tracked by this {@link OperationFuture}. This method returns
-   * the current poll metadata result (or the initial call metadata if it hasn't completed yet). The
-   * returned future completes once the current scheduled poll request (or the initial request if it
-   * hasn't completed yet) is executed and response is received from the server. The time when the
-   * polling request is executed is determined by the underlying polling algorithm.
-   *
-   * <p>Adding direct executor (same thread) callbacks to the future returned by this method is
-   * strongly not recommended, since the future is resolved under retrying future's internal lock
-   * and may affect the operation polling process. Adding separate thread callbacks is ok.
-   *
-   * <p>Note, some APIs may return {@code null} in metadata response message. In such cases this
-   * method may return a non-null future whose {@code get()} method will return {@code null}. This
-   * behavior is API specific an should be considered a valid case, which indicates that the recent
-   * poll request has completed, but no specific metadata was provided by the server. (i.e. most
-   * probably providing metadata for an intermediate result is not supported by the server).
-   *
-   * <p>In most cases this method returns a future which is not completed yet, so calling {@link
-   * ApiFuture#get()} is a potentially blocking operation. To get metadata without blocking the
-   * current thread use the {@link #peekMetadata()} method instead.
-   *
-   * <p>If this operation future is completed, this method always returns the metadata from the last
-   * poll request (which completed the operation future).
-   *
-   * <p>If this operation future failed, this method may (depending on the failure type) return a
-   * non-failing future, representing the metadata from the last poll request (which failed the
-   * operation future).
-   *
-   * <p>If this operation future was cancelled, this method returns a canceled metatata future as
-   * well.
-   *
-   * <p>In general this method behaves similarly to {@link RetryingFuture#getAttemptResult()}.
-   */
-  ApiFuture<MetadataT> getMetadata();
 }

--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationFuture.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationFuture.java
@@ -90,10 +90,10 @@ public interface OperationFuture<ResponseT, MetadataT> extends ApiFuture<Respons
    * DEPRECATED: Subsumed by getMetadata. Calling getMetadata.isDone() will return false if the
    * initial future has not yet completed.
    *
-   * Peeks at the metadata of the operation tracked by this {@link OperationFuture}. If the initial
-   * future hasn't completed yet this method returns {@code null}, otherwise it returns the latest
-   * metadata returned from the server (i.e. either initial call metadata or the metadata received
-   * from the latest completed poll iteration).
+   * <p>Peeks at the metadata of the operation tracked by this {@link OperationFuture}. If the
+   * initial future hasn't completed yet this method returns {@code null}, otherwise it returns the
+   * latest metadata returned from the server (i.e. either initial call metadata or the metadata
+   * received from the latest completed poll iteration).
    *
    * <p>If not {@code null}, the returned result is guaranteed to be an already completed future, so
    * {@link ApiFuture#isDone()} will always be {@code true} and {@link ApiFuture#get()} will always

--- a/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/OperationCallableImplTest.java
@@ -397,7 +397,7 @@ public class OperationCallableImplTest {
     assertThat(future.getInitialFuture().isDone()).isTrue();
     assertThat(future.getInitialFuture().isCancelled()).isTrue();
 
-    assertFutureCancelMetaCancel(future);
+    assertFutureCancelMetaCancel(future, false);
     assertThat(executor.getIterationsCount()).isEqualTo(0);
   }
 
@@ -676,7 +676,7 @@ public class OperationCallableImplTest {
     OperationFuture<Color, Currency> future =
         callable.futureCall(2, FakeCallContext.createDefault());
 
-    assertFutureCancelMetaCancel(future);
+    assertFutureCancelMetaCancel(future, true);
     assertThat(executor.getIterationsCount()).isEqualTo(5);
   }
 
@@ -707,7 +707,7 @@ public class OperationCallableImplTest {
     OperationFuture<Color, Currency> future =
         callable.futureCall(2, FakeCallContext.createDefault());
 
-    assertFutureCancelMetaCancel(future);
+    assertFutureCancelMetaCancel(future, true);
     assertThat(executor.getIterationsCount()).isEqualTo(iterationsCount);
   }
 
@@ -743,7 +743,7 @@ public class OperationCallableImplTest {
       LockSupport.parkNanos(1000L);
     }
 
-    assertFutureCancelMetaCancel(future);
+    assertFutureCancelMetaCancel(future, true);
     scheduler.shutdownNow();
   }
 
@@ -776,7 +776,7 @@ public class OperationCallableImplTest {
 
     CancellationHelpers.cancelInThreadAfterLatchCountDown(future, retryScheduledLatch);
 
-    assertFutureCancelMetaCancel(future);
+    assertFutureCancelMetaCancel(future, true);
   }
 
   @Test
@@ -1081,7 +1081,8 @@ public class OperationCallableImplTest {
     assertThat(future.getMetadata().isCancelled()).isFalse();
   }
 
-  private void assertFutureCancelMetaCancel(OperationFuture<Color, Currency> future)
+  private void assertFutureCancelMetaCancel(
+      OperationFuture<Color, Currency> future, boolean initialDone)
       throws InterruptedException, ExecutionException, TimeoutException {
     Exception exception = null;
     try {
@@ -1111,7 +1112,8 @@ public class OperationCallableImplTest {
     assertThat(future.getMetadata()).isSameInstanceAs(future.getMetadata());
     assertThat(exception).isNotNull();
     assertThat(future.getMetadata().isDone()).isTrue();
-    assertThat(future.getMetadata().isCancelled()).isTrue();
+    // The metadata future will always be resolved immediately once the initial request resolves.
+    assertThat(future.getMetadata().isCancelled()).isEqualTo(!initialDone);
   }
 
   private Color getColor(float blueValue) {


### PR DESCRIPTION
This semantic change makes getMetadata always return an already-completed future once the initial request completes. This enables its use to determine when the

Also mark peekMetadata as deprecated, since it is subsumed by the new behavior.

Also mark intended internal-only APIs as such. Note that both of these can probably be removed, but I didn't want to make any breaking surface changes.