### PR TITLE
fix: fix closeAsync

### DIFF
--- a/gax/src/main/java/com/google/api/gax/batching/BatcherImpl.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatcherImpl.java
@@ -328,7 +328,7 @@ public class BatcherImpl<ElementT, ElementResultT, RequestT, ResponseT>
     }
 
     // Clean up accounting
-    scheduledFuture.cancel(true);
+    scheduledFuture.cancel(false);
     currentBatcherReference.closed = true;
     currentBatcherReference.clear();
 


### PR DESCRIPTION
If `closeAsync` is called before sending out all the elements,  it's possible that scheduled `PushCurrentBatchRunnable` is still sending the elements when `scheduledFuture.cancel` is called, and the thread shouldn't be interrupted.