### PR TITLE
fix: fix httpjson executor

### DIFF
--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ManagedHttpJsonChannel.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ManagedHttpJsonChannel.java
@@ -153,7 +153,7 @@ public class ManagedHttpJsonChannel implements HttpJsonChannel, BackgroundResour
     private Builder() {}
 
     public Builder setExecutor(Executor executor) {
-      this.executor = Preconditions.checkNotNull(executor);
+      this.executor = executor == null ? DEFAULT_EXECUTOR : executor;
       return this;
     }
 

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/InstantiatingHttpJsonChannelProviderTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/InstantiatingHttpJsonChannelProviderTest.java
@@ -62,6 +62,13 @@ public class InstantiatingHttpJsonChannelProviderTest extends AbstractMtlsTransp
     provider = provider.withEndpoint(endpoint);
     assertThat(provider.needsEndpoint()).isFalse();
 
+    assertThat(provider.needsHeaders()).isTrue();
+    provider = provider.withHeaders(Collections.<String, String>emptyMap());
+    assertThat(provider.needsHeaders()).isFalse();
+
+    // Make sure getTransportChannel works without setting executor
+    assertThat(provider.getTransportChannel()).isInstanceOf(HttpJsonTransportChannel.class);
+
     assertThat(provider.needsExecutor()).isTrue();
     provider = provider.withExecutor((Executor) executor);
     assertThat(provider.needsExecutor()).isFalse();
@@ -70,10 +77,6 @@ public class InstantiatingHttpJsonChannelProviderTest extends AbstractMtlsTransp
     assertThat(provider.needsExecutor()).isFalse();
     provider = provider.withExecutor(executor);
     assertThat(provider.needsExecutor()).isFalse();
-
-    assertThat(provider.needsHeaders()).isTrue();
-    provider = provider.withHeaders(Collections.<String, String>emptyMap());
-    assertThat(provider.needsHeaders()).isFalse();
 
     assertThat(provider.acceptsPoolSize()).isFalse();
     Exception thrownException = null;


### PR DESCRIPTION
Similar to grpc set executor https://github.com/grpc/grpc-java/blob/master/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java#L323-L329, if executor is null, use DEFAULT_EXECUTOR.