### PR TITLE
chore: nexus-publish plugin cannot publish multi-module project to maven central

### DIFF
--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -30,6 +30,9 @@ setup_environment_secrets
 mkdir -p ${HOME}/.gradle
 create_gradle_properties_file "${HOME}/.gradle/gradle.properties"
 
+# This is a multi module project. Cannot publish directly to maven without
+# resolving this issue https://github.com/gradle-nexus/publish-plugin/issues/19
+# Might migrate to maven pom in the future.
 ./gradlew publishToSonatype
 
 if [[ -n "${AUTORELEASE_PR}" ]]


### PR DESCRIPTION
Until [this issue](https://github.com/gradle-nexus/publish-plugin/issues/19) is resolved, gax cannot use nexus-publish to publish to maven central because the plugin do not persist stagingProfile information between command runs. Thus both the staging command and publish command has to be run in a single command. But, since gax has multiple modules(each modules gets staged in separate run) this is not a workable approach.

So currently, the library gets staged to sonatype. Publish it manually from there(Get permission to publish if you frequently publish gax-java or @Neenu1995  can publish). A possible move to maven pom might be a better solution also.