### PR TITLE
fix: declare depenencies of API surfaces as api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ subprojects {
       'maven.io_grpc_grpc_core': "io.grpc:grpc-core:${libraries['version.io_grpc']}",
       'maven.io_grpc_grpc_context': "io.grpc:grpc-context:${libraries['version.io_grpc']}",
       'maven.io_grpc_grpc_stub': "io.grpc:grpc-stub:${libraries['version.io_grpc']}",
+      'maven.io_grpc_grpc_api': "io.grpc:grpc-api:${libraries['version.io_grpc']}",
       'maven.io_grpc_grpc_auth': "io.grpc:grpc-auth:${libraries['version.io_grpc']}",
       'maven.io_grpc_grpc_protobuf': "io.grpc:grpc-protobuf:${libraries['version.io_grpc']}",
       'maven.io_grpc_grpc_netty_shaded': "io.grpc:grpc-netty-shaded:${libraries['version.io_grpc']}",

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 subprojects {
-  apply plugin: 'java'
+  apply plugin: 'java-library'
   apply plugin: 'eclipse'
   apply plugin: 'idea'
   apply plugin: 'jacoco'

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -34,8 +34,8 @@ version.io_grpc=1.41.0
 #   2) Replace all characters which are neither alphabetic nor digits with the underscore ('_') character
 maven.com_google_api_grpc_proto_google_common_protos=com.google.api.grpc:proto-google-common-protos:2.4.1
 maven.com_google_api_grpc_grpc_google_common_protos=com.google.api.grpc:grpc-google-common-protos:2.4.1
-maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:0.27.0
-maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:1.0.0
+maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:1.2.1
+maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:1.2.1
 maven.io_opencensus_opencensus_api=io.opencensus:opencensus-api:0.28.0
 maven.io_opencensus_opencensus_contrib_grpc_metrics=io.opencensus:opencensus-contrib-grpc-metrics:0.28.0
 maven.io_opencensus_opencensus_contrib_http_util=io.opencensus:opencensus-contrib-http-util:0.28.0

--- a/gax-grpc/build.gradle
+++ b/gax-grpc/build.gradle
@@ -8,20 +8,21 @@ archivesBaseName = "gax-grpc"
 project.version = "2.6.1-SNAPSHOT" // {x-version-update:gax-grpc:current}
 
 dependencies {
-  api (project(':gax'),
-    libraries['maven.com_google_auth_google_auth_library_credentials'])
-
-  implementation(libraries['maven.io_grpc_grpc_stub'],
-    libraries['maven.io_grpc_grpc_auth'],
-    libraries['maven.io_grpc_grpc_protobuf'],
-    libraries['maven.com_google_guava_guava'],
-    libraries['maven.com_google_code_findbugs_jsr305'],
-    libraries['maven.org_threeten_threetenbp'],
-    libraries['maven.com_google_auth_google_auth_library_oauth2_http'],
-    libraries['maven.com_google_api_grpc_proto_google_common_protos'],
+  api(project(':gax'),
     libraries['maven.com_google_api_api_common'],
+    libraries['maven.com_google_api_grpc_proto_google_common_protos'],
+    libraries['maven.com_google_auth_google_auth_library_credentials'],
+    libraries['maven.com_google_guava_guava'],
+    libraries['maven.io_grpc_grpc_api'],
+    libraries['maven.org_threeten_threetenbp'])
+
+  implementation(libraries['maven.com_google_auth_google_auth_library_oauth2_http'],
+    libraries['maven.com_google_code_findbugs_jsr305'],
+    libraries['maven.io_grpc_grpc_alts'],
+    libraries['maven.io_grpc_grpc_auth'],
     libraries['maven.io_grpc_grpc_netty_shaded'],
-    libraries['maven.io_grpc_grpc_alts'])
+    libraries['maven.io_grpc_grpc_protobuf'],
+    libraries['maven.io_grpc_grpc_stub'])
 
   compileOnly libraries['maven.com_google_auto_value_auto_value']
 

--- a/gax-grpc/build.gradle
+++ b/gax-grpc/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-  id 'java-library'
-}
-
 archivesBaseName = "gax-grpc"
 
 // TODO: Populate this from dependencies.properties version property (for proper Gradle-Bazel sync)

--- a/gax-grpc/build.gradle
+++ b/gax-grpc/build.gradle
@@ -1,18 +1,23 @@
+plugins {
+  id 'java-library'
+}
+
 archivesBaseName = "gax-grpc"
 
 // TODO: Populate this from dependencies.properties version property (for proper Gradle-Bazel sync)
 project.version = "2.6.1-SNAPSHOT" // {x-version-update:gax-grpc:current}
 
 dependencies {
-  implementation( project(':gax'),
-    libraries['maven.io_grpc_grpc_stub'],
+  api (project(':gax'),
+    libraries['maven.com_google_auth_google_auth_library_credentials'])
+
+  implementation(libraries['maven.io_grpc_grpc_stub'],
     libraries['maven.io_grpc_grpc_auth'],
     libraries['maven.io_grpc_grpc_protobuf'],
     libraries['maven.com_google_guava_guava'],
     libraries['maven.com_google_code_findbugs_jsr305'],
     libraries['maven.org_threeten_threetenbp'],
     libraries['maven.com_google_auth_google_auth_library_oauth2_http'],
-    libraries['maven.com_google_auth_google_auth_library_credentials'],
     libraries['maven.com_google_api_grpc_proto_google_common_protos'],
     libraries['maven.com_google_api_api_common'],
     libraries['maven.io_grpc_grpc_netty_shaded'],

--- a/gax-httpjson/build.gradle
+++ b/gax-httpjson/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-  id 'java-library'
-}
-
 archivesBaseName = "gax-httpjson"
 
 // TODO: Populate this from dependencies.properties version property (for proper Gradle-Bazel sync)

--- a/gax-httpjson/build.gradle
+++ b/gax-httpjson/build.gradle
@@ -8,24 +8,24 @@ archivesBaseName = "gax-httpjson"
 project.version = "0.91.1-SNAPSHOT" // {x-version-update:gax-httpjson:current}
 
 dependencies {
-  api ( project(':gax'),
-    libraries['maven.com_google_auth_google_auth_library_credentials'])
-
-  implementation( libraries['maven.com_google_protobuf'],
-    libraries['maven.com_google_protobuf_java_util'],
+  api(project(':gax'),
+    libraries['maven.com_google_api_api_common'],
+    libraries['maven.com_google_api_grpc_proto_google_common_protos'],
+    libraries['maven.com_google_auth_google_auth_library_credentials'],
     libraries['maven.com_google_code_gson_gson'],
     libraries['maven.com_google_guava_guava'],
-    libraries['maven.com_google_code_findbugs_jsr305'],
-    libraries['maven.org_threeten_threetenbp'],
     libraries['maven.com_google_http_client_google_http_client'],
+    libraries['maven.com_google_protobuf'],
+    libraries['maven.org_threeten_threetenbp'])
+
+  implementation(libraries['maven.com_google_auth_google_auth_library_oauth2_http'],
+    libraries['maven.com_google_code_findbugs_jsr305'],
     libraries['maven.com_google_http_client_google_http_client_gson'],
-    libraries['maven.com_google_auth_google_auth_library_oauth2_http'],
-    libraries['maven.com_google_api_grpc_proto_google_common_protos'],
-    libraries['maven.com_google_api_api_common'])
+    libraries['maven.com_google_protobuf_java_util'])
 
   compileOnly libraries['maven.com_google_auto_value_auto_value']
 
-  testImplementation( project(':gax').sourceSets.test.output,
+  testImplementation(project(':gax').sourceSets.test.output,
     libraries['maven.junit_junit'],
     libraries['maven.org_mockito_mockito_core'],
     libraries['maven.com_google_truth_truth'])

--- a/gax-httpjson/build.gradle
+++ b/gax-httpjson/build.gradle
@@ -1,11 +1,17 @@
+plugins {
+  id 'java-library'
+}
+
 archivesBaseName = "gax-httpjson"
 
 // TODO: Populate this from dependencies.properties version property (for proper Gradle-Bazel sync)
 project.version = "0.91.1-SNAPSHOT" // {x-version-update:gax-httpjson:current}
 
 dependencies {
-  implementation( project(':gax'),
-    libraries['maven.com_google_protobuf'],
+  api ( project(':gax'),
+    libraries['maven.com_google_auth_google_auth_library_credentials'])
+
+  implementation( libraries['maven.com_google_protobuf'],
     libraries['maven.com_google_protobuf_java_util'],
     libraries['maven.com_google_code_gson_gson'],
     libraries['maven.com_google_guava_guava'],
@@ -14,7 +20,6 @@ dependencies {
     libraries['maven.com_google_http_client_google_http_client'],
     libraries['maven.com_google_http_client_google_http_client_gson'],
     libraries['maven.com_google_auth_google_auth_library_oauth2_http'],
-    libraries['maven.com_google_auth_google_auth_library_credentials'],
     libraries['maven.com_google_api_grpc_proto_google_common_protos'],
     libraries['maven.com_google_api_api_common'])
 

--- a/gax/build.gradle
+++ b/gax/build.gradle
@@ -1,9 +1,15 @@
+plugins {
+  id 'java-library'
+}
+
 archivesBaseName = "gax"
 
 // TODO: Populate this from dependencies.properties version property (for proper Gradle-Bazel sync)
 project.version = "2.6.1-SNAPSHOT" // {x-version-update:gax:current}
 
 dependencies {
+  api libraries['maven.com_google_auth_google_auth_library_credentials']
+
   implementation (libraries['maven.com_google_guava_guava'],
     libraries['maven.com_google_code_findbugs_jsr305'],
     libraries['maven.org_threeten_threetenbp'],

--- a/gax/build.gradle
+++ b/gax/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-  id 'java-library'
-}
-
 archivesBaseName = "gax"
 
 // TODO: Populate this from dependencies.properties version property (for proper Gradle-Bazel sync)

--- a/gax/build.gradle
+++ b/gax/build.gradle
@@ -8,21 +8,21 @@ archivesBaseName = "gax"
 project.version = "2.6.1-SNAPSHOT" // {x-version-update:gax:current}
 
 dependencies {
-  api libraries['maven.com_google_auth_google_auth_library_credentials']
+  api(libraries['maven.com_google_api_api_common'],
+    libraries['maven.com_google_auth_google_auth_library_credentials'],
+    libraries['maven.org_threeten_threetenbp'])
 
-  implementation (libraries['maven.com_google_guava_guava'],
+  implementation(libraries['maven.com_google_auth_google_auth_library_oauth2_http'],
     libraries['maven.com_google_code_findbugs_jsr305'],
-    libraries['maven.org_threeten_threetenbp'],
-    libraries['maven.com_google_auth_google_auth_library_oauth2_http'],
-    libraries['maven.com_google_api_api_common'],
+    libraries['maven.com_google_guava_guava'],
     libraries['maven.io_opencensus_opencensus_api'])
 
   compileOnly libraries['maven.com_google_auto_value_auto_value']
 
-  testImplementation( libraries['maven.junit_junit'],
+  testImplementation(libraries['maven.junit_junit'],
     libraries['maven.org_mockito_mockito_core'],
     libraries['maven.com_google_truth_truth'],
-    libraries['maven.com_google_auto_value_auto_value'] )
+    libraries['maven.com_google_auto_value_auto_value'])
 
   annotationProcessor libraries['maven.com_google_auto_value_auto_value']
   testAnnotationProcessor libraries['maven.com_google_auto_value_auto_value']


### PR DESCRIPTION
Fixes: #1534.

https://docs.gradle.org/current/userguide/publishing_maven.html says:

> Gradle will also use the versions resolved on the runtimeClasspath for dependencies declared in implementation, which are mapped to the runtime scope of Maven

If a class is exposed as API surface, then the dependency should be declared using 'api'.

# google-auth-library-oauth2-http

For the classes in com.google.auth.oauth2 (com.google.auth.oauth2.QuotaProjectIdProvider, com.google.auth.oauth2.ComputeEngineCredentials, com.google.auth.oauth2.GoogleCredentials, com.google.auth.oauth2.ServiceAccountCredentials, com.google.auth.oauth2.ServiceAccountJwtAccessCredentials, com.google.auth.oauth2.QuotaProjectIdProvider), I didn't find any of them used as API surface. Therefore "implementation" makes sense.

# google-auth-library-credentials

I found com.google.auth.Credentials class in google-auth-library-credentials is exposed in gax. (This artifact is not declared in gax's build.gradle.)

# Other artifacts

## org_threeten_threetenbp

The artifact defines `org.threeten.bp.Duration`.

gax exposes it in its public API https://github.com/googleapis/gax-java/blob/2ce5a2fdb0347045af6550e998e053e17d159e21/gax/src/main/java/com/google/api/gax/batching/BatchingSettings.java#L103

gax-grpc uses it in its public API https://github.com/googleapis/gax-java/blob/0fe20f379feba1570e562e60e3f0bf7cc4e485bd/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java#L202

gax-httpjson uses it in its public API https://github.com/googleapis/gax-java/blob/0fe20f379feba1570e562e60e3f0bf7cc4e485bd/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java#L247


## com_google_api_api_common

gax uses `com.google.api.core.ApiFuture` in its public API https://github.com/googleapis/gax-java/blob/ff4b61e49ab5b6ab91c9c03ee5c5aeb071d3b03c/gax/src/main/java/com/google/api/gax/batching/ThresholdBatcher.java#L217.

gax-grpc uses it https://github.com/googleapis/gax-java/blob/68761a7de17489c02362e079ca766ee06da5e247/gax-grpc/src/main/java/com/google/longrunning/OperationsClient.java#L598

gax-httpjson uses it https://github.com/googleapis/gax-java/blob/8d45d186e36ae97b789a6f89d80ae5213a773b65/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonChannel.java#L38

## io_opencensus_opencensus_api

It doesn't appear in the API surfaces of gax, gax-grpc, and gax-httpjson.

## grpc-api

gax-grpc uses it in public API https://github.com/googleapis/gax-java/blob/4b3f21b999d351b839e1410a8f5f3e03914f680e/gax-grpc/src/main/java/com/google/api/gax/grpc/ResponseMetadataHandler.java#L44 

## grpc-auth, grpc-protobuf, grpc-netty-shaded, grpc-alts, grpc-stub

They are not in public API.

## guava

gax-grpc uses `com.google.common.collect.ImmutableList` in public API https://github.com/googleapis/gax-java/blob/68761a7de17489c02362e079ca766ee06da5e247/gax-grpc/src/main/java/com/google/longrunning/stub/OperationsStubSettings.java#L353

gax-httpjson uses it in public API https://github.com/googleapis/gax-java/blob/2d76bff6d64da818a3aff7ea0bdf5a36b82c3464/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/stub/OperationsStubSettings.java#L398

## com_google_api_grpc_proto_google_common_protos

gax-grpc uses `com.google.longrunning.Operation` in public API https://github.com/googleapis/gax-java/blob/763aafbe5fabda578a1afe2b24a096149c20b947/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java#L184

gax-httpjson uses `com.google.longrunning.ListOperationsRequest` in public API https://github.com/googleapis/gax-java/blob/2d76bff6d64da818a3aff7ea0bdf5a36b82c3464/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/stub/OperationsStub.java#L54

## com_google_protobuf

gax-httpjson uses `com.google.protobuf.TypeRegistry` in public API https://github.com/googleapis/gax-java/blob/95ca3482d272b5c5c5ac2c85ba007f0ba9f7b5cf/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ApiMessageHttpResponseParser.java#L109

## com_google_protobuf_java_util

It's not used as public API.

## com_google_code_gson_gson

gax-httpjson uses `com.google.gson.JsonElement` in public API https://github.com/googleapis/gax-java/blob/8f9d6ce431546fa58b5c1e32f2c44eed145528db/gax-httpjson/src/main/java/com/google/api/gax/httpjson/FieldMaskedSerializer.java#L51

## com_google_http_client_google_http_client

gax-httpjson uses `com.google.api.client.http.HttpTransport` in public API

https://github.com/googleapis/gax-java/blob/8f48b7027b95e8e75872d1f9dac537ea697d0acc/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ManagedHttpJsonChannel.java#L170

## com_google_http_client_google_http_client_gson

This is not used in public API.