### PR TITLE
fix: declare depenencies of API surfaces as api (#1535)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 subprojects {
-  apply plugin: 'java'
+  apply plugin: 'java-library'
   apply plugin: 'eclipse'
   apply plugin: 'idea'
   apply plugin: 'jacoco'
@@ -109,6 +109,7 @@ subprojects {
       'maven.io_grpc_grpc_core': "io.grpc:grpc-core:${libraries['version.io_grpc']}",
       'maven.io_grpc_grpc_context': "io.grpc:grpc-context:${libraries['version.io_grpc']}",
       'maven.io_grpc_grpc_stub': "io.grpc:grpc-stub:${libraries['version.io_grpc']}",
+      'maven.io_grpc_grpc_api': "io.grpc:grpc-api:${libraries['version.io_grpc']}",
       'maven.io_grpc_grpc_auth': "io.grpc:grpc-auth:${libraries['version.io_grpc']}",
       'maven.io_grpc_grpc_protobuf': "io.grpc:grpc-protobuf:${libraries['version.io_grpc']}",
       'maven.io_grpc_grpc_netty_shaded': "io.grpc:grpc-netty-shaded:${libraries['version.io_grpc']}",

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -34,8 +34,8 @@ version.io_grpc=1.41.0
 #   2) Replace all characters which are neither alphabetic nor digits with the underscore ('_') character
 maven.com_google_api_grpc_proto_google_common_protos=com.google.api.grpc:proto-google-common-protos:2.4.1
 maven.com_google_api_grpc_grpc_google_common_protos=com.google.api.grpc:grpc-google-common-protos:2.4.1
-maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:0.27.0
-maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:1.0.0
+maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:1.2.1
+maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:1.2.1
 maven.io_opencensus_opencensus_api=io.opencensus:opencensus-api:0.28.0
 maven.io_opencensus_opencensus_contrib_grpc_metrics=io.opencensus:opencensus-contrib-grpc-metrics:0.28.0
 maven.io_opencensus_opencensus_contrib_http_util=io.opencensus:opencensus-contrib-http-util:0.28.0

--- a/gax-grpc/build.gradle
+++ b/gax-grpc/build.gradle
@@ -4,19 +4,21 @@ archivesBaseName = "gax-grpc"
 project.version = "2.6.1-SNAPSHOT" // {x-version-update:gax-grpc:current}
 
 dependencies {
-  implementation( project(':gax'),
-    libraries['maven.io_grpc_grpc_stub'],
-    libraries['maven.io_grpc_grpc_auth'],
-    libraries['maven.io_grpc_grpc_protobuf'],
-    libraries['maven.com_google_guava_guava'],
-    libraries['maven.com_google_code_findbugs_jsr305'],
-    libraries['maven.org_threeten_threetenbp'],
-    libraries['maven.com_google_auth_google_auth_library_oauth2_http'],
-    libraries['maven.com_google_auth_google_auth_library_credentials'],
-    libraries['maven.com_google_api_grpc_proto_google_common_protos'],
+  api(project(':gax'),
     libraries['maven.com_google_api_api_common'],
+    libraries['maven.com_google_api_grpc_proto_google_common_protos'],
+    libraries['maven.com_google_auth_google_auth_library_credentials'],
+    libraries['maven.com_google_guava_guava'],
+    libraries['maven.io_grpc_grpc_api'],
+    libraries['maven.org_threeten_threetenbp'])
+
+  implementation(libraries['maven.com_google_auth_google_auth_library_oauth2_http'],
+    libraries['maven.com_google_code_findbugs_jsr305'],
+    libraries['maven.io_grpc_grpc_alts'],
+    libraries['maven.io_grpc_grpc_auth'],
     libraries['maven.io_grpc_grpc_netty_shaded'],
-    libraries['maven.io_grpc_grpc_alts'])
+    libraries['maven.io_grpc_grpc_protobuf'],
+    libraries['maven.io_grpc_grpc_stub'])
 
   compileOnly libraries['maven.com_google_auto_value_auto_value']
 

--- a/gax-httpjson/build.gradle
+++ b/gax-httpjson/build.gradle
@@ -4,23 +4,24 @@ archivesBaseName = "gax-httpjson"
 project.version = "0.91.1-SNAPSHOT" // {x-version-update:gax-httpjson:current}
 
 dependencies {
-  implementation( project(':gax'),
-    libraries['maven.com_google_protobuf'],
-    libraries['maven.com_google_protobuf_java_util'],
+  api(project(':gax'),
+    libraries['maven.com_google_api_api_common'],
+    libraries['maven.com_google_api_grpc_proto_google_common_protos'],
+    libraries['maven.com_google_auth_google_auth_library_credentials'],
     libraries['maven.com_google_code_gson_gson'],
     libraries['maven.com_google_guava_guava'],
-    libraries['maven.com_google_code_findbugs_jsr305'],
-    libraries['maven.org_threeten_threetenbp'],
     libraries['maven.com_google_http_client_google_http_client'],
+    libraries['maven.com_google_protobuf'],
+    libraries['maven.org_threeten_threetenbp'])
+
+  implementation(libraries['maven.com_google_auth_google_auth_library_oauth2_http'],
+    libraries['maven.com_google_code_findbugs_jsr305'],
     libraries['maven.com_google_http_client_google_http_client_gson'],
-    libraries['maven.com_google_auth_google_auth_library_oauth2_http'],
-    libraries['maven.com_google_auth_google_auth_library_credentials'],
-    libraries['maven.com_google_api_grpc_proto_google_common_protos'],
-    libraries['maven.com_google_api_api_common'])
+    libraries['maven.com_google_protobuf_java_util'])
 
   compileOnly libraries['maven.com_google_auto_value_auto_value']
 
-  testImplementation( project(':gax').sourceSets.test.output,
+  testImplementation(project(':gax').sourceSets.test.output,
     libraries['maven.junit_junit'],
     libraries['maven.org_mockito_mockito_core'],
     libraries['maven.com_google_truth_truth'])

--- a/gax/build.gradle
+++ b/gax/build.gradle
@@ -4,19 +4,21 @@ archivesBaseName = "gax"
 project.version = "2.6.1-SNAPSHOT" // {x-version-update:gax:current}
 
 dependencies {
-  implementation (libraries['maven.com_google_guava_guava'],
+  api(libraries['maven.com_google_api_api_common'],
+    libraries['maven.com_google_auth_google_auth_library_credentials'],
+    libraries['maven.org_threeten_threetenbp'])
+
+  implementation(libraries['maven.com_google_auth_google_auth_library_oauth2_http'],
     libraries['maven.com_google_code_findbugs_jsr305'],
-    libraries['maven.org_threeten_threetenbp'],
-    libraries['maven.com_google_auth_google_auth_library_oauth2_http'],
-    libraries['maven.com_google_api_api_common'],
+    libraries['maven.com_google_guava_guava'],
     libraries['maven.io_opencensus_opencensus_api'])
 
   compileOnly libraries['maven.com_google_auto_value_auto_value']
 
-  testImplementation( libraries['maven.junit_junit'],
+  testImplementation(libraries['maven.junit_junit'],
     libraries['maven.org_mockito_mockito_core'],
     libraries['maven.com_google_truth_truth'],
-    libraries['maven.com_google_auto_value_auto_value'] )
+    libraries['maven.com_google_auto_value_auto_value'])
 
   annotationProcessor libraries['maven.com_google_auto_value_auto_value']
   testAnnotationProcessor libraries['maven.com_google_auto_value_auto_value']


### PR DESCRIPTION
This is cherry-pick of https://github.com/googleapis/gax-java/pull/1535 to the 2.6.x branch.