### PR TITLE
fix: call ResponseMetadataHanlder#onTrailers before calling onClose

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcMetadataHandlerInterceptor.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcMetadataHandlerInterceptor.java
@@ -73,8 +73,8 @@ class GrpcMetadataHandlerInterceptor implements ClientInterceptor {
 
               @Override
               public void onClose(Status status, Metadata trailers) {
-                super.onClose(status, trailers);
                 metadataHandler.onTrailers(trailers);
+                super.onClose(status, trailers);
               }
             };
         super.start(forwardingResponseListener, headers);


### PR DESCRIPTION
`metadataHandler.onTrailers(..)` should be called before `onClose(..)`. With the current implementation, I don't think it's possible for ServerStreamingCallables or UnaryCallable#futureCalls() to get the trailers because the trailers are set after the call is closed?

The [comment in the code](https://github.com/googleapis/gax-java/blob/main/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcResponseMetadata.java#L49-L52) and [test case](https://github.com/googleapis/gax-java/blob/main/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcResponseMetadataTest.java#L168) also only showed synchronized calls for UnaryCallables.

Use a server stream call as an example, the way I'm trying to access the trailer is:
```java
class MyStreamingCallable<RequestT, ResponseT> extends ServerStreamingCallable  {
  @Override
  public void call(RequestT request, ResponseObserver<ResponseT> responseObserver, ApiCallContext context) {
      final GrpcResponseMetadata responseMetadata = new GrpcResponseMetadata();
      MyResponseObserver<ResponseT> innerObserver = new MyResponseObserver<>(responseObserver, responseMetadata);
      ApiCallContext withResponseMetadata = responseMetadata.addHandlers(context);
      innerCallable.call(request, innerObserver, withResponseMetadata);
  }

  // Response observer class
  private class MyResponseObserver<ResponseT> implements ResponseObserver<ResponseT> {
    @Override
    public void onComplete() {
      // With the current implementation, trailers will be null because we're still calling #onClose()
      Metadata trailers = responseMetadata.getTrailingMetadata();
      ...
      outerObserver.onComplete();
    }

    // onError will be similar to onComplete
  }
}
```
Unless `GrpcResponseMetadata` is not intended to be used this way? 