### PR TITLE
fix: fix gRPC code conversion

### DIFF
--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonExceptionCallable.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonExceptionCallable.java
@@ -95,16 +95,13 @@ class HttpJsonExceptionCallable<RequestT, ResponseT> extends UnaryCallable<Reque
     public void onFailure(Throwable throwable) {
       if (throwable instanceof HttpResponseException) {
         HttpResponseException e = (HttpResponseException) throwable;
-        StatusCode.Code statusCode =
-            HttpJsonStatusCode.httpStatusToStatusCode(e.getStatusCode(), e.getMessage());
-        boolean canRetry = retryableCodes.contains(statusCode);
+        StatusCode statusCode = HttpJsonStatusCode.of(e.getStatusCode(), e.getMessage());
+        boolean canRetry = retryableCodes.contains(statusCode.getCode());
         String message = e.getStatusMessage();
         ApiException newException =
             message == null
-                ? ApiExceptionFactory.createException(
-                    throwable, HttpJsonStatusCode.of(statusCode), canRetry)
-                : ApiExceptionFactory.createException(
-                    message, throwable, HttpJsonStatusCode.of(statusCode), canRetry);
+                ? ApiExceptionFactory.createException(throwable, statusCode, canRetry)
+                : ApiExceptionFactory.createException(message, throwable, statusCode, canRetry);
         super.setException(newException);
       } else if (throwable instanceof CancellationException && cancelled) {
         // this just circled around, so ignore.

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStatusCode.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStatusCode.java
@@ -32,6 +32,7 @@ package com.google.api.gax.httpjson;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.common.base.Strings;
 import java.util.Objects;
 
@@ -46,22 +47,22 @@ public class HttpJsonStatusCode implements StatusCode {
   static final String UNKNOWN = "UNKNOWN";
 
   private final int httpStatus;
-  private final StatusCode.Code statusCode;
+  private final Code statusCode;
 
   /** Creates a new instance with the given status code. */
   public static HttpJsonStatusCode of(int httpStatus, String errorMessage) {
     return new HttpJsonStatusCode(httpStatus, httpStatusToStatusCode(httpStatus, errorMessage));
   }
 
-  public static HttpJsonStatusCode of(StatusCode.Code statusCode) {
+  public static HttpJsonStatusCode of(Code statusCode) {
     return new HttpJsonStatusCode(statusCode.getHttpStatusCode(), statusCode);
   }
 
   public static HttpJsonStatusCode of(com.google.rpc.Code rpcCode) {
-    return new HttpJsonStatusCode(rpcCode.getNumber(), rpcCodeToStatusCode(rpcCode));
+    return HttpJsonStatusCode.of(rpcCodeToStatusCode(rpcCode));
   }
 
-  static StatusCode.Code rpcCodeToStatusCode(com.google.rpc.Code rpcCode) {
+  static Code rpcCodeToStatusCode(com.google.rpc.Code rpcCode) {
     switch (rpcCode) {
       case OK:
         return Code.OK;
@@ -102,7 +103,7 @@ public class HttpJsonStatusCode implements StatusCode {
     }
   }
 
-  static StatusCode.Code httpStatusToStatusCode(int httpStatus, String errorMessage) {
+  static Code httpStatusToStatusCode(int httpStatus, String errorMessage) {
     String causeMessage = Strings.nullToEmpty(errorMessage).toUpperCase();
     switch (httpStatus) {
       case 200:
@@ -155,7 +156,7 @@ public class HttpJsonStatusCode implements StatusCode {
   }
 
   @Override
-  public StatusCode.Code getCode() {
+  public Code getCode() {
     return statusCode;
   }
 
@@ -165,8 +166,8 @@ public class HttpJsonStatusCode implements StatusCode {
     return httpStatus;
   }
 
-  private HttpJsonStatusCode(int code, StatusCode.Code statusCode) {
-    this.httpStatus = code;
+  private HttpJsonStatusCode(int httpStatus, Code statusCode) {
+    this.httpStatus = httpStatus;
     this.statusCode = statusCode;
   }
 


### PR DESCRIPTION
- `HttpJsonExceptionCallable`: HTTP response code is first converted to `Code` (the actual HTTP code value is lost here during conversion), and later, `StatusCode` (which is designed to hold an HTTP response code value) is constructed from the converted `Code`. The mapping back to HTTP codes is by the canned default values of `Code`, so precision is lost due to the double conversion.

- `HttpJsonStatusCode.of(com.google.rpc.Code rpcCode)` is passing `rpcCode.getNumber()` (which returns integer values 0, 1, 2, 3 ...) as an argument that accepts the HTTP response code, which is wrong. As the best effort, give the canned default HTTP codes.

---

Unrelated, I don't think there is a reason in our codebase to hold and carry an HTTP response code inside `HttpJsonStatusCode`, which is not going to be used anywhere and only there to cause this sort of maintenance trouble.