### PR TITLE
fix: update exception mapping on HTTP error responses

### DIFF
--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonExceptionCallable.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonExceptionCallable.java
@@ -95,7 +95,7 @@ class HttpJsonExceptionCallable<RequestT, ResponseT> extends UnaryCallable<Reque
     public void onFailure(Throwable throwable) {
       if (throwable instanceof HttpResponseException) {
         HttpResponseException e = (HttpResponseException) throwable;
-        StatusCode statusCode = HttpJsonStatusCode.of(e.getStatusCode(), e.getMessage());
+        StatusCode statusCode = HttpJsonStatusCode.of(e.getStatusCode());
         boolean canRetry = retryableCodes.contains(statusCode.getCode());
         String message = e.getStatusMessage();
         ApiException newException =

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonOperationSnapshot.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonOperationSnapshot.java
@@ -138,9 +138,9 @@ public class HttpJsonOperationSnapshot implements OperationSnapshot {
       return this;
     }
 
-    public Builder setError(int errorCode, String errorMessage) {
+    public Builder setError(int httpStatus, String errorMessage) {
       this.errorCode =
-          errorCode == 0 ? HttpJsonStatusCode.of(Code.OK) : HttpJsonStatusCode.of(errorCode);
+          httpStatus == 0 ? HttpJsonStatusCode.of(Code.OK) : HttpJsonStatusCode.of(httpStatus);
       this.errorMessage = errorMessage;
       return this;
     }

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonOperationSnapshot.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonOperationSnapshot.java
@@ -140,8 +140,7 @@ public class HttpJsonOperationSnapshot implements OperationSnapshot {
 
     public Builder setError(int errorCode, String errorMessage) {
       this.errorCode =
-          HttpJsonStatusCode.of(
-              errorCode == 0 ? Code.OK.getHttpStatusCode() : errorCode, errorMessage);
+          errorCode == 0 ? HttpJsonStatusCode.of(Code.OK) : HttpJsonStatusCode.of(errorCode);
       this.errorMessage = errorMessage;
       return this;
     }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonOperationSnapshotTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonOperationSnapshotTest.java
@@ -67,7 +67,7 @@ public class HttpJsonOperationSnapshotTest {
             .build();
 
     assertEquals(testOperationSnapshot.getErrorMessage(), "Forbidden");
-    assertEquals(testOperationSnapshot.getErrorCode(), HttpJsonStatusCode.of(403, "Forbidden"));
+    assertEquals(testOperationSnapshot.getErrorCode(), HttpJsonStatusCode.of(403));
     assertTrue(testOperationSnapshot.isDone());
   }
 

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonStatusCodeTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonStatusCodeTest.java
@@ -29,12 +29,10 @@
  */
 package com.google.api.gax.httpjson;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.api.gax.rpc.StatusCode.Code;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
@@ -55,34 +53,39 @@ public class HttpJsonStatusCodeTest {
         continue;
       }
 
-      assertNotNull(statusCode);
+      assertThat(statusCode).isNotNull();
       allCodes.add(statusCode);
     }
 
-    assertEquals(allCodes, new HashSet<>(Arrays.asList(Code.values())));
+    assertThat(Code.values()).asList().containsExactlyElementsIn(allCodes);
   }
 
   @Test
   public void httpStatusToStatusCodeTest() {
-    assertEquals(Code.OK, HttpJsonStatusCode.httpStatusToStatusCode(200));
-    assertEquals(Code.OK, HttpJsonStatusCode.httpStatusToStatusCode(201));
-    assertEquals(Code.INVALID_ARGUMENT, HttpJsonStatusCode.httpStatusToStatusCode(400));
-    assertEquals(Code.UNAUTHENTICATED, HttpJsonStatusCode.httpStatusToStatusCode(401));
-    assertEquals(Code.PERMISSION_DENIED, HttpJsonStatusCode.httpStatusToStatusCode(403));
-    assertEquals(Code.NOT_FOUND, HttpJsonStatusCode.httpStatusToStatusCode(404));
-    assertEquals(Code.ABORTED, HttpJsonStatusCode.httpStatusToStatusCode(409));
-    assertEquals(Code.OUT_OF_RANGE, HttpJsonStatusCode.httpStatusToStatusCode(416));
-    assertEquals(Code.RESOURCE_EXHAUSTED, HttpJsonStatusCode.httpStatusToStatusCode(429));
-    assertEquals(Code.CANCELLED, HttpJsonStatusCode.httpStatusToStatusCode(499));
-    assertEquals(Code.INTERNAL, HttpJsonStatusCode.httpStatusToStatusCode(500));
-    assertEquals(Code.UNIMPLEMENTED, HttpJsonStatusCode.httpStatusToStatusCode(501));
-    assertEquals(Code.INTERNAL, HttpJsonStatusCode.httpStatusToStatusCode(502));
-    assertEquals(Code.UNAVAILABLE, HttpJsonStatusCode.httpStatusToStatusCode(503));
-    assertEquals(Code.DEADLINE_EXCEEDED, HttpJsonStatusCode.httpStatusToStatusCode(504));
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(200)).isEqualTo(Code.OK);
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(201)).isEqualTo(Code.OK);
 
-    assertEquals(Code.UNKNOWN, HttpJsonStatusCode.httpStatusToStatusCode(100));
-    assertEquals(Code.UNKNOWN, HttpJsonStatusCode.httpStatusToStatusCode(300));
-    assertEquals(Code.UNKNOWN, HttpJsonStatusCode.httpStatusToStatusCode(302));
-    assertEquals(Code.UNKNOWN, HttpJsonStatusCode.httpStatusToStatusCode(600));
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(400)).isEqualTo(Code.INVALID_ARGUMENT);
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(401)).isEqualTo(Code.UNAUTHENTICATED);
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(403)).isEqualTo(Code.PERMISSION_DENIED);
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(404)).isEqualTo(Code.NOT_FOUND);
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(409)).isEqualTo(Code.ABORTED);
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(416)).isEqualTo(Code.OUT_OF_RANGE);
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(429)).isEqualTo(Code.RESOURCE_EXHAUSTED);
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(499)).isEqualTo(Code.CANCELLED);
+
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(405)).isEqualTo(Code.FAILED_PRECONDITION);
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(408)).isEqualTo(Code.FAILED_PRECONDITION);
+
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(500)).isEqualTo(Code.INTERNAL);
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(501)).isEqualTo(Code.UNIMPLEMENTED);
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(502)).isEqualTo(Code.INTERNAL);
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(503)).isEqualTo(Code.UNAVAILABLE);
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(504)).isEqualTo(Code.DEADLINE_EXCEEDED);
+
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(100)).isEqualTo(Code.UNKNOWN);
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(300)).isEqualTo(Code.UNKNOWN);
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(302)).isEqualTo(Code.UNKNOWN);
+    assertThat(HttpJsonStatusCode.httpStatusToStatusCode(600)).isEqualTo(Code.UNKNOWN);
   }
 }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonStatusCodeTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonStatusCodeTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
-import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.StatusCode.Code;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -43,9 +43,9 @@ public class HttpJsonStatusCodeTest {
 
   @Test
   public void rpcCodeToStatusCodeTest() {
-    Set<StatusCode.Code> allCodes = new HashSet<>();
+    Set<Code> allCodes = new HashSet<>();
     for (com.google.rpc.Code rpcCode : com.google.rpc.Code.values()) {
-      StatusCode.Code statusCode;
+      Code statusCode;
       try {
         statusCode = HttpJsonStatusCode.rpcCodeToStatusCode(rpcCode);
       } catch (IllegalArgumentException e) {
@@ -59,73 +59,30 @@ public class HttpJsonStatusCodeTest {
       allCodes.add(statusCode);
     }
 
-    assertEquals(allCodes, new HashSet<>(Arrays.asList(StatusCode.Code.values())));
+    assertEquals(allCodes, new HashSet<>(Arrays.asList(Code.values())));
   }
 
   @Test
   public void httpStatusToStatusCodeTest() {
-    // The HTTP status code conversion logic is currently in the process of being standardized,
-    // the tested logic may change in nearest future.
-    final String defaultMessage = "anything";
-    assertEquals(
-        StatusCode.Code.OK, HttpJsonStatusCode.httpStatusToStatusCode(200, defaultMessage));
-    assertEquals(
-        StatusCode.Code.OUT_OF_RANGE,
-        HttpJsonStatusCode.httpStatusToStatusCode(400, HttpJsonStatusCode.OUT_OF_RANGE));
-    assertEquals(
-        StatusCode.Code.FAILED_PRECONDITION,
-        HttpJsonStatusCode.httpStatusToStatusCode(400, HttpJsonStatusCode.FAILED_PRECONDITION));
-    assertEquals(
-        StatusCode.Code.INVALID_ARGUMENT,
-        HttpJsonStatusCode.httpStatusToStatusCode(400, defaultMessage));
-    assertEquals(
-        StatusCode.Code.UNAUTHENTICATED,
-        HttpJsonStatusCode.httpStatusToStatusCode(401, defaultMessage));
-    assertEquals(
-        StatusCode.Code.PERMISSION_DENIED,
-        HttpJsonStatusCode.httpStatusToStatusCode(403, defaultMessage));
-    assertEquals(
-        StatusCode.Code.NOT_FOUND, HttpJsonStatusCode.httpStatusToStatusCode(404, defaultMessage));
-    assertEquals(
-        StatusCode.Code.ALREADY_EXISTS,
-        HttpJsonStatusCode.httpStatusToStatusCode(409, HttpJsonStatusCode.ALREADY_EXISTS));
-    assertEquals(
-        StatusCode.Code.ABORTED, HttpJsonStatusCode.httpStatusToStatusCode(409, defaultMessage));
-    assertEquals(
-        StatusCode.Code.RESOURCE_EXHAUSTED,
-        HttpJsonStatusCode.httpStatusToStatusCode(429, defaultMessage));
-    assertEquals(
-        StatusCode.Code.CANCELLED, HttpJsonStatusCode.httpStatusToStatusCode(499, defaultMessage));
-    assertEquals(
-        StatusCode.Code.DATA_LOSS,
-        HttpJsonStatusCode.httpStatusToStatusCode(500, HttpJsonStatusCode.DATA_LOSS));
-    assertEquals(
-        StatusCode.Code.UNKNOWN,
-        HttpJsonStatusCode.httpStatusToStatusCode(500, HttpJsonStatusCode.UNKNOWN));
-    assertEquals(
-        StatusCode.Code.INTERNAL, HttpJsonStatusCode.httpStatusToStatusCode(500, defaultMessage));
-    assertEquals(
-        StatusCode.Code.UNIMPLEMENTED,
-        HttpJsonStatusCode.httpStatusToStatusCode(501, defaultMessage));
-    assertEquals(
-        StatusCode.Code.UNAVAILABLE,
-        HttpJsonStatusCode.httpStatusToStatusCode(503, defaultMessage));
-    assertEquals(
-        StatusCode.Code.DEADLINE_EXCEEDED,
-        HttpJsonStatusCode.httpStatusToStatusCode(504, defaultMessage));
+    assertEquals(Code.OK, HttpJsonStatusCode.httpStatusToStatusCode(200));
+    assertEquals(Code.OK, HttpJsonStatusCode.httpStatusToStatusCode(201));
+    assertEquals(Code.INVALID_ARGUMENT, HttpJsonStatusCode.httpStatusToStatusCode(400));
+    assertEquals(Code.UNAUTHENTICATED, HttpJsonStatusCode.httpStatusToStatusCode(401));
+    assertEquals(Code.PERMISSION_DENIED, HttpJsonStatusCode.httpStatusToStatusCode(403));
+    assertEquals(Code.NOT_FOUND, HttpJsonStatusCode.httpStatusToStatusCode(404));
+    assertEquals(Code.ABORTED, HttpJsonStatusCode.httpStatusToStatusCode(409));
+    assertEquals(Code.OUT_OF_RANGE, HttpJsonStatusCode.httpStatusToStatusCode(416));
+    assertEquals(Code.RESOURCE_EXHAUSTED, HttpJsonStatusCode.httpStatusToStatusCode(429));
+    assertEquals(Code.CANCELLED, HttpJsonStatusCode.httpStatusToStatusCode(499));
+    assertEquals(Code.INTERNAL, HttpJsonStatusCode.httpStatusToStatusCode(500));
+    assertEquals(Code.UNIMPLEMENTED, HttpJsonStatusCode.httpStatusToStatusCode(501));
+    assertEquals(Code.INTERNAL, HttpJsonStatusCode.httpStatusToStatusCode(502));
+    assertEquals(Code.UNAVAILABLE, HttpJsonStatusCode.httpStatusToStatusCode(503));
+    assertEquals(Code.DEADLINE_EXCEEDED, HttpJsonStatusCode.httpStatusToStatusCode(504));
 
-    try {
-      HttpJsonStatusCode.httpStatusToStatusCode(411, defaultMessage);
-      fail();
-    } catch (IllegalStateException e) {
-      // expected
-    }
-
-    try {
-      HttpJsonStatusCode.httpStatusToStatusCode(666, defaultMessage);
-      fail();
-    } catch (IllegalArgumentException e) {
-      // expected
-    }
+    assertEquals(Code.UNKNOWN, HttpJsonStatusCode.httpStatusToStatusCode(100));
+    assertEquals(Code.UNKNOWN, HttpJsonStatusCode.httpStatusToStatusCode(300));
+    assertEquals(Code.UNKNOWN, HttpJsonStatusCode.httpStatusToStatusCode(302));
+    assertEquals(Code.UNKNOWN, HttpJsonStatusCode.httpStatusToStatusCode(600));
   }
 }


### PR DESCRIPTION
The HTTP-to-Canonical code conversion (`HttpJsonStatusCode.httpStatusToStatusCode()`) is used only for error situations where a server returns a non-2xx HTTP status code. gax-java surfaces errors in terms of `ApiException`s, which are modeled precisely following the canonical status codes (go/canonical-codes). (That is, there's a one-to-one correspondence between the canonical error codes and the Java exceptions.) That's why and the only reason we need to interpret HTTP codes  as canonical codes.

The previous implementation wasn't following the standardized mapping (go/http-canonical-mapping). Now we are trying to make this consistent across all languages. Therefore, this does introduce a breaking change in terms of which HTTP server response code is surfaced as which Java exception.

However, for the conventional commit message and the PR title, I'm not marking as a breaking change, as gax-httpjson hasn't GA'ed.

b/205195666

---

### Appendix

The locations where the HTTP-to-canonical conversion takes place:
- [`HttpJsonExceptionCallable.onFailure()`](https://github.com/googleapis/gax-java/blob/e3c844c0e49e7e00db89495536ee57cf8f85b3c1/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonExceptionCallable.java#L96-L98): HTTP error status is interpreted as canonical error status (via exception).
```java
    public void onFailure(Throwable throwable) {
      if (throwable instanceof HttpResponseException) {
        HttpResponseException e = (HttpResponseException) throwable;
        // HttpResponseException.getStatusCode() returns HTTP code
        StatusCode statusCode = HttpJsonStatusCode.of(e.getStatusCode());
        boolean canRetry = retryableCodes.contains(statusCode.getCode());
        String message = e.getStatusMessage();
        ApiException newException =
            message == null
                ? ApiExceptionFactory.createException(throwable, statusCode, canRetry)
                : ApiExceptionFactory.createException(message, throwable, statusCode, canRetry);
        super.setException(newException);
```
- `HttpJsonOperationSnapshot.Builder.setError()`: the builder takes an HTTP code. Note there's no usage of `setError()` within gax-java. It is supposed to take HTTP code, but for some legacy reason, it treats 0 as a special case to indicate success (which is not ideal).
```java
    public Builder setError(int httpStatus, String errorMessage) {
      this.errorCode =
          httpStatus == 0 ? HttpJsonStatusCode.of(Code.OK) : HttpJsonStatusCode.of(httpStatus);
      this.errorMessage = errorMessage;
      return this;
    }
```