### PR TITLE
deps: upgrade protobuf to 3.19.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,10 @@ jobs:
           echo "The old one will disappear after 7 days."
 
       - name: Run bazel tests
-        run: bazel --batch test //... --noshow_progress --test_output=errors
+        run: |
+          which bazel
+          bazel --version
+          bazel --batch test //... --noshow_progress --test_output=errors
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,7 +12,30 @@ load("//:repositories.bzl", "com_google_api_gax_java_repositories")
 
 com_google_api_gax_java_repositories()
 
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load("@com_google_protobuf//:protobuf_deps.bzl",
+    "PROTOBUF_MAVEN_ARTIFACTS", "protobuf_deps")
+
+# From protobuf 3.19, protobuf project started to provide
+# PROTOBUF_MAVEN_ARTIFACTS variable so that the Bazel users can resolve their
+# dependencies through maven_install.
+# https://github.com/protocolbuffers/protobuf/issues/9132
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+RULES_JVM_EXTERNAL_TAG = "4.2"
+RULES_JVM_EXTERNAL_SHA = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea15e9e5ba1ca"
+http_archive(
+    name = "rules_jvm_external",
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+    sha256 = RULES_JVM_EXTERNAL_SHA,
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
+)
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+maven_install(
+    artifacts = PROTOBUF_MAVEN_ARTIFACTS,
+    generate_compat_repositories = True,
+    repositories = [
+        "https://repo.maven.apache.org/maven2/",
+    ],
+)
 
 protobuf_deps()
 

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -23,7 +23,7 @@ version.gax_httpjson=0.92.1-SNAPSHOT
 # Versions for dependencies which actual artifacts differ between Bazel and Gradle.
 # Gradle build depends on prebuilt maven artifacts, while Bazel build depends on Bazel workspaces
 # with the sources.
-version.com_google_protobuf=3.18.1
+version.com_google_protobuf=3.19.1
 version.google_java_format=1.1
 version.io_grpc=1.41.0
 


### PR DESCRIPTION
Upgrading the protobuf version to 3.19.1.

Reference:

> In protobuf_deps.bzl we now define a constant PROTOBUF_MAVEN_ARTIFACTS that you can use with maven_install() in your WORKSPACE file to make sure all protobuf's Java dependencies are available.

https://github.com/protocolbuffers/protobuf/issues/9132#issuecomment-954058223

