### PR TITLE
fix: revert generics syntax change in MockHttpService test utility

### DIFF
--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/stub/HttpJsonOperationsStub.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/stub/HttpJsonOperationsStub.java
@@ -297,8 +297,8 @@ public class HttpJsonOperationsStub extends OperationsStub {
   }
 
   @InternalApi
-  public static List<ApiMethodDescriptor<?, ?>> getMethodDescriptors() {
-    List<ApiMethodDescriptor<?, ?>> methodDescriptors = new ArrayList<>();
+  public static List<ApiMethodDescriptor> getMethodDescriptors() {
+    List<ApiMethodDescriptor> methodDescriptors = new ArrayList<>();
     methodDescriptors.add(listOperationsMethodDescriptor);
     methodDescriptors.add(getOperationMethodDescriptor);
     methodDescriptors.add(deleteOperationMethodDescriptor);

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/MockHttpServiceTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/MockHttpServiceTest.java
@@ -143,7 +143,7 @@ public class MockHttpServiceTest {
           .setResponseParser(PET_RESPONSE_PARSER)
           .build();
 
-  private static final List<ApiMethodDescriptor<?, ?>> SERVER_METHOD_DESCRIPTORS =
+  private static final List<ApiMethodDescriptor> SERVER_METHOD_DESCRIPTORS =
       Lists.newArrayList(methodDescriptor);
 
   private static MockHttpService testService =

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/testing/MockHttpService.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/testing/MockHttpService.java
@@ -55,7 +55,7 @@ public final class MockHttpService extends MockHttpTransport {
   private final Multimap<String, String> requestHeaders = LinkedListMultimap.create();
   private final List<String> requestPaths = new LinkedList<>();
   private final Queue<HttpResponseFactory> responseHandlers = new LinkedList<>();
-  private List<ApiMethodDescriptor<?, ?>> serviceMethodDescriptors;
+  private List<ApiMethodDescriptor> serviceMethodDescriptors;
   private String endpoint;
 
   /**

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/testing/MockHttpService.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/testing/MockHttpService.java
@@ -66,8 +66,7 @@ public final class MockHttpService extends MockHttpTransport {
    * @param pathPrefix - the fixed portion of the endpoint URL that prefixes the methods' path
    *     template substring.
    */
-  public MockHttpService(
-      List<ApiMethodDescriptor> serviceMethodDescriptors, String pathPrefix) {
+  public MockHttpService(List<ApiMethodDescriptor> serviceMethodDescriptors, String pathPrefix) {
     this.serviceMethodDescriptors = ImmutableList.copyOf(serviceMethodDescriptors);
     endpoint = pathPrefix;
   }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/testing/MockHttpService.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/testing/MockHttpService.java
@@ -67,7 +67,7 @@ public final class MockHttpService extends MockHttpTransport {
    *     template substring.
    */
   public MockHttpService(
-      List<ApiMethodDescriptor<?, ?>> serviceMethodDescriptors, String pathPrefix) {
+      List<ApiMethodDescriptor> serviceMethodDescriptors, String pathPrefix) {
     this.serviceMethodDescriptors = ImmutableList.copyOf(serviceMethodDescriptors);
     endpoint = pathPrefix;
   }


### PR DESCRIPTION
In the cleanup PR #1554, I added the generics syntax for parameterized types in some cases. When I was doing it, I was careful to not change anything publicly visible (e.g., only change files user `src/test/...`, local method code, `private` method signature, etc.).

However, it turns out `MockHttpService` under`src/test/...` is published to Maven Central (as a test utility as `testlib`) and being used in units test in library repos.