### PR TITLE
chore: fix duplicate sourcesJar source entries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ configure(javaProjects) {
   task sourcesJar(type: Jar, dependsOn: classes) {
     archiveClassifier = 'sources'
 
-    from sourceSets.main.allSource, sourceSets.test.allSource, sourceSets.main.resources.srcDirs
+    from sourceSets.main.allSource, sourceSets.test.allSource
     exclude('**/*Test.java')
   }
 


### PR DESCRIPTION
All the context is at https://github.com/googleapis/gax-java/pull/1562#discussion_r753483746, but TL;DR is that `sourceSets.main.allSource` by default contains `sourceSets.main.resources`, so no need to duplicate it. If any file is added to `src/main/resources`, Gradle will fail warning that there are duplicate files.

The change is also in PR #1562. However,it's unclear when it will be merged, so I'm doing it now here.