### PR TITLE
deps: update dependency io_grpc to 1.44.0

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -23,17 +23,17 @@ version.gax_httpjson=0.95.1-SNAPSHOT
 # Versions for dependencies which actual artifacts differ between Bazel and Gradle.
 # Gradle build depends on prebuilt maven artifacts, while Bazel build depends on Bazel workspaces
 # with the sources.
-version.com_google_protobuf=3.19.2
+version.com_google_protobuf=3.19.3
 version.google_java_format=1.1
-version.io_grpc=1.43.2
+version.io_grpc=1.44.0
 
 # Maven artifacts.
 # Note, the actual name of each property matters (bazel build scripts depend on it).
 # It should be constructed the following way:
 #   1) Take full artifact id (including the group and classifier (if any) portions) and remove version portion.
 #   2) Replace all characters which are neither alphabetic nor digits with the underscore ('_') character
-maven.com_google_api_grpc_proto_google_common_protos=com.google.api.grpc:proto-google-common-protos:2.7.1
-maven.com_google_api_grpc_grpc_google_common_protos=com.google.api.grpc:grpc-google-common-protos:2.7.1
+maven.com_google_api_grpc_proto_google_common_protos=com.google.api.grpc:proto-google-common-protos:2.7.2
+maven.com_google_api_grpc_grpc_google_common_protos=com.google.api.grpc:grpc-google-common-protos:2.7.2
 maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:1.2.1
 maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:1.2.1
 maven.io_opencensus_opencensus_api=io.opencensus:opencensus-api:0.28.0
@@ -58,16 +58,16 @@ maven.com_google_guava_failureaccess=com.google.guava:failureaccess:1.0.1
 maven.org_apache_commons_commons_lang3=org.apache.commons:commons-lang3:3.8.1
 maven.com_google_android_annotations=com.google.android:annotations:4.1.1.4
 maven.com_google_code_findbugs_jsr305=com.google.code.findbugs:jsr305:3.0.2
-maven.com_google_errorprone_error_prone_annotations=com.google.errorprone:error_prone_annotations:2.9.0
+maven.com_google_errorprone_error_prone_annotations=com.google.errorprone:error_prone_annotations:2.11.0
 maven.com_google_j2objc_j2objc_annotations=com.google.j2objc:j2objc-annotations:1.3
 maven.com_google_auto_value_auto_value=com.google.auto.value:auto-value:1.9
 maven.com_google_auto_value_auto_value_annotations=com.google.auto.value:auto-value-annotations:1.9
-maven.com_google_api_api_common=com.google.api:api-common:2.1.2
+maven.com_google_api_api_common=com.google.api:api-common:2.1.3
 maven.org_threeten_threetenbp=org.threeten:threetenbp:1.5.0
 maven.com_google_api_grpc_grpc_google_iam_v1=com.google.api.grpc:grpc-google-iam-v1:1.0.9
 maven.com_google_api_grpc_proto_google_iam_v1=com.google.api.grpc:proto-google-iam-v1:1.0.9
-maven.com_google_http_client_google_http_client=com.google.http-client:google-http-client:1.41.0
-maven.com_google_http_client_google_http_client_gson=com.google.http-client:google-http-client-gson:1.41.0
+maven.com_google_http_client_google_http_client=com.google.http-client:google-http-client:1.41.2
+maven.com_google_http_client_google_http_client_gson=com.google.http-client:google-http-client-gson:1.41.2
 maven.org_codehaus_mojo_animal_sniffer_annotations=org.codehaus.mojo:animal-sniffer-annotations:1.18
 maven.javax_annotation_javax_annotation_api=javax.annotation:javax.annotation-api:1.3.2
 


### PR DESCRIPTION
deps: update dependency com.google.errorprone:error_prone_annotations to v2.11.0
deps: update dependency com.google.api.grpc:proto-google-common-protos to 2.7.2
deps: update dependency com.google.api.grpc:grpc-google-common-protos to 2.7.2
deps: update dependency com.google.api:api-common to 2.1.3
deps: update dependency com_google_protobuf to 3.19.3
deps: update dependency com.google.http-client:google-http-client to 1.41.2
deps: update dependency com.google.http-client:google-http-client-gson to 1.41.2