### PR TITLE
chore: Remove `@BetaApi` annotations for the de-facto GA features

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -423,7 +423,6 @@ public final class GrpcCallContext implements ApiCallContext {
    * @see ApiCallContext#withStreamWaitTimeout(Duration)
    */
   @Override
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nullable
   public Duration getStreamWaitTimeout() {
     return streamWaitTimeout;
@@ -435,14 +434,12 @@ public final class GrpcCallContext implements ApiCallContext {
    * @see ApiCallContext#withStreamIdleTimeout(Duration)
    */
   @Override
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nullable
   public Duration getStreamIdleTimeout() {
     return streamIdleTimeout;
   }
 
   /** The channel affinity for this context. */
-  @BetaApi("The surface for channel affinity is not stable yet and may change in the future.")
   @Nullable
   public Integer getChannelAffinity() {
     return channelAffinity;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallSettings.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallSettings.java
@@ -34,7 +34,6 @@ import com.google.api.gax.rpc.RequestParamsExtractor;
 import io.grpc.MethodDescriptor;
 
 /** Grpc-specific settings for creating callables. */
-@BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
 public class GrpcCallSettings<RequestT, ResponseT> {
   private final MethodDescriptor<RequestT, ResponseT> methodDescriptor;
   private final RequestParamsExtractor<RequestT> paramsExtractor;
@@ -50,7 +49,6 @@ public class GrpcCallSettings<RequestT, ResponseT> {
     return methodDescriptor;
   }
 
-  @BetaApi
   public RequestParamsExtractor<RequestT> getParamsExtractor() {
     return paramsExtractor;
   }
@@ -94,7 +92,6 @@ public class GrpcCallSettings<RequestT, ResponseT> {
       return this;
     }
 
-    @BetaApi
     public Builder<RequestT, ResponseT> setParamsExtractor(
         RequestParamsExtractor<RequestT> paramsExtractor) {
       this.paramsExtractor = paramsExtractor;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallableFactory.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.grpc;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.BatchingCallSettings;
@@ -65,7 +64,6 @@ import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 
 /** Class with utility methods to create grpc-based direct callables. */
-@BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
 public class GrpcCallableFactory {
   // Used to extract service and method name from a grpc MethodDescriptor.
   private static final Pattern FULL_METHOD_NAME_REGEX = Pattern.compile("^.*?([^./]+)/([^./]+)$");
@@ -144,7 +142,6 @@ public class GrpcCallableFactory {
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link UnaryCallable} callable object.
    */
-  @BetaApi("The surface for batching is not stable yet and may change in the future.")
   public static <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createBatchingCallable(
       GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
       BatchingCallSettings<RequestT, ResponseT> batchingCallSettings,
@@ -177,8 +174,6 @@ public class GrpcCallableFactory {
    * @param operationsStub {@link OperationsStub} to use to poll for updates on the Operation.
    * @return {@link com.google.api.gax.rpc.OperationCallable} callable object.
    */
-  @BetaApi(
-      "The surface for long-running operations is not stable yet and may change in the future.")
   public static <RequestT, ResponseT, MetadataT>
       OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
           GrpcCallSettings<RequestT, Operation> grpcCallSettings,
@@ -223,7 +218,6 @@ public class GrpcCallableFactory {
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link BidiStreamingCallable} callable object.
    */
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   public static <RequestT, ResponseT>
       BidiStreamingCallable<RequestT, ResponseT> createBidiStreamingCallable(
           GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
@@ -253,7 +247,6 @@ public class GrpcCallableFactory {
    * @deprecated Please use ServerStreamingCallSettings
    */
   @Deprecated
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   public static <RequestT, ResponseT>
       ServerStreamingCallable<RequestT, ResponseT> createServerStreamingCallable(
           GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
@@ -277,7 +270,6 @@ public class GrpcCallableFactory {
    *     settings with.
    * @param clientContext {@link ClientContext} to use to connect to the service.
    */
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   public static <RequestT, ResponseT>
       ServerStreamingCallable<RequestT, ResponseT> createServerStreamingCallable(
           GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
@@ -312,7 +304,6 @@ public class GrpcCallableFactory {
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link ClientStreamingCallable} callable object.
    */
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   public static <RequestT, ResponseT>
       ClientStreamingCallable<RequestT, ResponseT> createClientStreamingCallable(
           GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcInterceptorProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcInterceptorProvider.java
@@ -29,13 +29,10 @@
  */
 package com.google.api.gax.grpc;
 
-import com.google.api.core.BetaApi;
 import io.grpc.ClientInterceptor;
 import java.util.List;
 
 /** Provider of custom gRPC ClientInterceptors. */
-@BetaApi(
-    "The surface for adding custom interceptors is not stable yet and may change in the future.")
 public interface GrpcInterceptorProvider {
 
   /**

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcRawCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcRawCallableFactory.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.grpc;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.ClientStreamingCallable;
@@ -70,7 +69,6 @@ public class GrpcRawCallableFactory {
    * @param retryableCodes the {@link StatusCode.Code} that should be marked as retryable
    * @return {@link BidiStreamingCallable} callable object.
    */
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   public static <RequestT, ResponseT>
       BidiStreamingCallable<RequestT, ResponseT> createBidiStreamingCallable(
           GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
@@ -88,7 +86,6 @@ public class GrpcRawCallableFactory {
    * @param grpcCallSettings the gRPC call settings
    * @param retryableCodes the {@link StatusCode.Code} that should be marked as retryable
    */
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   public static <RequestT, ResponseT>
       ServerStreamingCallable<RequestT, ResponseT> createServerStreamingCallable(
           GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
@@ -109,7 +106,6 @@ public class GrpcRawCallableFactory {
    * @param grpcCallSettings the gRPC call settings
    * @param retryableCodes the {@link StatusCode.Code} that should be marked as retryable
    */
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   public static <RequestT, ResponseT>
       ClientStreamingCallable<RequestT, ResponseT> createClientStreamingCallable(
           GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcResponseMetadata.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcResponseMetadata.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.grpc;
 
-import com.google.api.core.BetaApi;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.common.base.Preconditions;
 import io.grpc.Metadata;
@@ -53,7 +52,6 @@ import io.grpc.Metadata;
  * </code>
  * </pre>
  */
-@BetaApi("The surface for response metadata is not stable yet and may change in the future.")
 public class GrpcResponseMetadata implements ResponseMetadataHandler {
 
   private volatile Metadata responseMetadata;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcStubCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcStubCallableFactory.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.grpc;
 
-import com.google.api.core.BetaApi;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.ClientContext;
@@ -45,7 +44,6 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 
-@BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
 public interface GrpcStubCallableFactory {
 
   /**
@@ -53,7 +51,7 @@ public interface GrpcStubCallableFactory {
    *
    * @param grpcCallSettings the gRPC call settings
    */
-  public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createUnaryCallable(
+  <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createUnaryCallable(
       GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
       UnaryCallSettings<RequestT, ResponseT> callSettings,
       ClientContext clientContext);
@@ -67,7 +65,7 @@ public interface GrpcStubCallableFactory {
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link UnaryCallable} callable object.
    */
-  public <RequestT, ResponseT, PagedListResponseT>
+  <RequestT, ResponseT, PagedListResponseT>
       UnaryCallable<RequestT, PagedListResponseT> createPagedCallable(
           GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
           PagedCallSettings<RequestT, ResponseT, PagedListResponseT> pagedCallSettings,
@@ -83,8 +81,7 @@ public interface GrpcStubCallableFactory {
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link UnaryCallable} callable object.
    */
-  @BetaApi("The surface for batching is not stable yet and may change in the future.")
-  public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createBatchingCallable(
+  <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createBatchingCallable(
       GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
       BatchingCallSettings<RequestT, ResponseT> batchingCallSettings,
       ClientContext clientContext);
@@ -100,9 +97,7 @@ public interface GrpcStubCallableFactory {
    * @param operationsStub {@link OperationsStub} to use to poll for updates on the Operation.
    * @return {@link OperationCallable} callable object.
    */
-  @BetaApi(
-      "The surface for long-running operations is not stable yet and may change in the future.")
-  public <RequestT, ResponseT, MetadataT>
+  <RequestT, ResponseT, MetadataT>
       OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
           GrpcCallSettings<RequestT, Operation> grpcCallSettings,
           OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings,
@@ -119,12 +114,10 @@ public interface GrpcStubCallableFactory {
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link BidiStreamingCallable} callable object.
    */
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
-  public <RequestT, ResponseT>
-      BidiStreamingCallable<RequestT, ResponseT> createBidiStreamingCallable(
-          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
-          StreamingCallSettings<RequestT, ResponseT> streamingCallSettings,
-          ClientContext clientContext);
+  <RequestT, ResponseT> BidiStreamingCallable<RequestT, ResponseT> createBidiStreamingCallable(
+      GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+      StreamingCallSettings<RequestT, ResponseT> streamingCallSettings,
+      ClientContext clientContext);
 
   /**
    * Create a server-streaming callable with grpc-specific functionality. Designed for use by
@@ -135,12 +128,10 @@ public interface GrpcStubCallableFactory {
    *     settings with.
    * @param clientContext {@link ClientContext} to use to connect to the service.
    */
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
-  public <RequestT, ResponseT>
-      ServerStreamingCallable<RequestT, ResponseT> createServerStreamingCallable(
-          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
-          ServerStreamingCallSettings<RequestT, ResponseT> streamingCallSettings,
-          ClientContext clientContext);
+  <RequestT, ResponseT> ServerStreamingCallable<RequestT, ResponseT> createServerStreamingCallable(
+      GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+      ServerStreamingCallSettings<RequestT, ResponseT> streamingCallSettings,
+      ClientContext clientContext);
 
   /**
    * Create a client-streaming callable object with grpc-specific functionality. Designed for use by
@@ -152,10 +143,8 @@ public interface GrpcStubCallableFactory {
    * @param clientContext {@link ClientContext} to use to connect to the service.
    * @return {@link ClientStreamingCallable} callable object.
    */
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
-  public <RequestT, ResponseT>
-      ClientStreamingCallable<RequestT, ResponseT> createClientStreamingCallable(
-          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
-          StreamingCallSettings<RequestT, ResponseT> streamingCallSettings,
-          ClientContext clientContext);
+  <RequestT, ResponseT> ClientStreamingCallable<RequestT, ResponseT> createClientStreamingCallable(
+      GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+      StreamingCallSettings<RequestT, ResponseT> streamingCallSettings,
+      ClientContext clientContext);
 }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -166,13 +166,11 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
   }
 
   @Override
-  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public boolean needsHeaders() {
     return headerProvider == null;
   }
 
   @Override
-  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public TransportChannelProvider withHeaders(Map<String, String> headers) {
     return toBuilder().setHeaderProvider(FixedHeaderProvider.create(headers)).build();
   }

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ProtoOperationTransformers.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ProtoOperationTransformers.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.grpc;
 
 import com.google.api.core.ApiFunction;
-import com.google.api.core.BetaApi;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.ApiExceptionFactory;
 import com.google.api.gax.rpc.StatusCode.Code;
@@ -39,7 +38,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 
 /** Public for technical reasons; intended for use by generated code. */
-@BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
 public class ProtoOperationTransformers {
   private ProtoOperationTransformers() {}
 

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/ResponseMetadataHandler.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/ResponseMetadataHandler.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.grpc;
 
-import com.google.api.core.BetaApi;
 import io.grpc.Metadata;
 
 /**
@@ -37,7 +36,6 @@ import io.grpc.Metadata;
  * GrpcMetadataHandlerInterceptor class to provide custom handling of the returned headers and
  * trailers.
  */
-@BetaApi("The surface for response metadata is not stable yet and may change in the future.")
 public interface ResponseMetadataHandler {
 
   /** Handle the headers returned by an RPC. */

--- a/gax-grpc/src/main/java/com/google/longrunning/OperationsClient.java
+++ b/gax-grpc/src/main/java/com/google/longrunning/OperationsClient.java
@@ -34,7 +34,6 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
-import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.paging.AbstractFixedSizeCollection;
 import com.google.api.gax.paging.AbstractPage;
@@ -125,7 +124,6 @@ public class OperationsClient implements BackgroundResource {
    * Constructs an instance of OperationsClient, using the given stub for making calls. This is for
    * advanced usage - prefer to use OperationsSettings}.
    */
-  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
   public static final OperationsClient create(OperationsStub stub) {
     return new OperationsClient(stub);
   }
@@ -139,7 +137,6 @@ public class OperationsClient implements BackgroundResource {
     this.stub = ((OperationsStubSettings) settings.getStubSettings()).createStub();
   }
 
-  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
   protected OperationsClient(OperationsStub stub) {
     this.settings = null;
     this.stub = stub;
@@ -149,7 +146,6 @@ public class OperationsClient implements BackgroundResource {
     return settings;
   }
 
-  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
   public OperationsStub getStub() {
     return stub;
   }

--- a/gax-grpc/src/main/java/com/google/longrunning/OperationsSettings.java
+++ b/gax-grpc/src/main/java/com/google/longrunning/OperationsSettings.java
@@ -30,7 +30,6 @@
 package com.google.longrunning;
 
 import com.google.api.core.ApiFunction;
-import com.google.api.core.BetaApi;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
 import com.google.api.gax.rpc.ApiClientHeaderProvider;
@@ -86,7 +85,6 @@ public class OperationsSettings extends ClientSettings<OperationsSettings> {
     return OperationsStubSettings.defaultCredentialsProviderBuilder();
   }
 
-  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
     return OperationsStubSettings.defaultApiClientHeaderProviderBuilder();
   }

--- a/gax-grpc/src/main/java/com/google/longrunning/stub/GrpcOperationsCallableFactory.java
+++ b/gax-grpc/src/main/java/com/google/longrunning/stub/GrpcOperationsCallableFactory.java
@@ -29,7 +29,6 @@
  */
 package com.google.longrunning.stub;
 
-import com.google.api.core.BetaApi;
 import com.google.api.gax.grpc.GrpcCallSettings;
 import com.google.api.gax.grpc.GrpcCallableFactory;
 import com.google.api.gax.grpc.GrpcStubCallableFactory;
@@ -52,7 +51,6 @@ import com.google.longrunning.Operation;
  *
  * <p>This class is for advanced usage.
  */
-@BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
 public class GrpcOperationsCallableFactory implements GrpcStubCallableFactory {
   @Override
   public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createUnaryCallable(

--- a/gax-grpc/src/main/java/com/google/longrunning/stub/GrpcOperationsStub.java
+++ b/gax-grpc/src/main/java/com/google/longrunning/stub/GrpcOperationsStub.java
@@ -31,7 +31,6 @@ package com.google.longrunning.stub;
 
 import static com.google.longrunning.OperationsClient.ListOperationsPagedResponse;
 
-import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.BackgroundResourceAggregation;
 import com.google.api.gax.grpc.GrpcCallSettings;
@@ -59,7 +58,6 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
-@BetaApi("A restructuring of stub classes is planned, so this may break in the future")
 public class GrpcOperationsStub extends OperationsStub {
 
   private static final MethodDescriptor<GetOperationRequest, Operation>

--- a/gax-grpc/src/main/java/com/google/longrunning/stub/OperationsStub.java
+++ b/gax-grpc/src/main/java/com/google/longrunning/stub/OperationsStub.java
@@ -31,7 +31,6 @@ package com.google.longrunning.stub;
 
 import static com.google.longrunning.OperationsClient.ListOperationsPagedResponse;
 
-import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.CancelOperationRequest;
@@ -48,7 +47,6 @@ import com.google.protobuf.Empty;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
-@BetaApi("A restructuring of stub classes is planned, so this may break in the future")
 public abstract class OperationsStub implements BackgroundResource {
 
   public UnaryCallable<GetOperationRequest, Operation> getOperationCallable() {

--- a/gax-grpc/src/main/java/com/google/longrunning/stub/OperationsStubSettings.java
+++ b/gax-grpc/src/main/java/com/google/longrunning/stub/OperationsStubSettings.java
@@ -33,7 +33,6 @@ import static com.google.longrunning.OperationsClient.ListOperationsPagedRespons
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
-import com.google.api.core.BetaApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -67,7 +66,6 @@ import java.io.IOException;
 import org.threeten.bp.Duration;
 
 /** Settings class to configure an instance of {@link OperationsStub}. */
-@BetaApi
 public class OperationsStubSettings extends StubSettings<OperationsStubSettings> {
 
   private final UnaryCallSettings<GetOperationRequest, Operation> getOperationSettings;
@@ -105,7 +103,6 @@ public class OperationsStubSettings extends StubSettings<OperationsStubSettings>
     return waitOperationSettings;
   }
 
-  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
   public OperationsStub createStub() throws IOException {
     if (getTransportChannelProvider()
         .getTransportName()
@@ -127,7 +124,6 @@ public class OperationsStubSettings extends StubSettings<OperationsStubSettings>
     return GoogleCredentialsProvider.newBuilder();
   }
 
-  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
     return ApiClientHeaderProvider.newBuilder()
         .setGeneratedLibToken(

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/FieldsExtractor.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/FieldsExtractor.java
@@ -29,13 +29,10 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
-
 /**
  * A functional interface to be implemented for each request message to extract specific fields from
  * it. For advanced usage only.
  */
-@BetaApi
 public interface FieldsExtractor<RequestT, ParamsT> {
   ParamsT extract(RequestT request);
 }

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallContext.java
@@ -59,7 +59,7 @@ import org.threeten.bp.Instant;
  * copies of the object, but with one field changed. The immutability and thread safety of the
  * arguments solely depends on the arguments themselves.
  */
-@BetaApi
+@BetaApi("Reference ApiCallContext instead - this class is likely to experience breaking changes")
 public final class HttpJsonCallContext implements ApiCallContext {
   private final HttpJsonChannel channel;
   private final HttpJsonCallOptions callOptions;

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonCallableFactory.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.BatchingCallSettings;
@@ -51,7 +50,6 @@ import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 
 /** Class with utility methods to create http/json-based direct callables. */
-@BetaApi
 public class HttpJsonCallableFactory {
   // Used to extract service and method name from a grpc MethodDescriptor.
   // fullMethodName has the format: service.resource.action
@@ -161,8 +159,6 @@ public class HttpJsonCallableFactory {
     return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
   }
 
-  @BetaApi(
-      "The surface for long-running operations is not stable yet and may change in the future.")
   public static <RequestT, ResponseT, MetadataT>
       OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
           OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings,
@@ -175,7 +171,6 @@ public class HttpJsonCallableFactory {
     return operationCallable.withDefaultCallContext(clientContext.getDefaultCallContext());
   }
 
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   public static <RequestT, ResponseT>
       ServerStreamingCallable<RequestT, ResponseT> createServerStreamingCallable(
           HttpJsonCallSettings<RequestT, ResponseT> httpJsoncallSettings,

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonLongRunningClient.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonLongRunningClient.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.httpjson;
 
 import com.google.api.core.ApiFunction;
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.LongRunningClient;
@@ -42,7 +41,6 @@ import com.google.api.gax.rpc.UnaryCallable;
  *
  * <p>Public for technical reasons. For internal use only.
  */
-@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 @InternalApi
 public class HttpJsonLongRunningClient<RequestT, OperationT> implements LongRunningClient {
 

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonOperationSnapshot.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonOperationSnapshot.java
@@ -41,7 +41,7 @@ import com.google.longrunning.Operation;
  *
  * <p>Public for technical reasons. For internal use only.
  */
-@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+@BetaApi
 @InternalApi
 public class HttpJsonOperationSnapshot implements OperationSnapshot {
   private final String name;

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonOperationSnapshotCallable.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonOperationSnapshotCallable.java
@@ -46,7 +46,7 @@ import com.google.api.gax.rpc.UnaryCallable;
  *
  * <p>Public for technical reasons. For internal use only.
  */
-@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+@BetaApi
 @InternalApi
 public class HttpJsonOperationSnapshotCallable<RequestT, OperationT>
     extends UnaryCallable<RequestT, OperationSnapshot> {

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStubCallableFactory.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStubCallableFactory.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.ClientContext;
@@ -42,7 +41,6 @@ import com.google.api.gax.rpc.StreamingCallSettings;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 
-@BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
 public interface HttpJsonStubCallableFactory<
     OperationT, OperationsStub extends BackgroundResource> {
 

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonTransportChannel.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonTransportChannel.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.auto.value.AutoValue;
@@ -37,7 +36,6 @@ import java.util.concurrent.TimeUnit;
 
 /** Implementation of TransportChannel based on http/json. */
 @AutoValue
-@BetaApi
 @InternalExtensionOnly
 public abstract class HttpJsonTransportChannel implements TransportChannel {
 

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpRequestFormatter.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpRequestFormatter.java
@@ -29,13 +29,11 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import com.google.api.pathtemplate.PathTemplate;
 import java.util.List;
 import java.util.Map;
 
 /** Interface for classes that create parts of HTTP requests from a parameterized message. */
-@BetaApi
 public interface HttpRequestFormatter<MessageFormatT> {
   /**
    * Return a map where each entry is the name of a query param mapped to the values of the param.

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/OperationSnapshotFactory.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/OperationSnapshotFactory.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import com.google.api.gax.longrunning.OperationSnapshot;
 
 /**
@@ -42,7 +41,6 @@ import com.google.api.gax.longrunning.OperationSnapshot;
  * @param <RequestT> initial request message type
  * @param <OperationT> initial or polling response type
  */
-@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public interface OperationSnapshotFactory<RequestT, OperationT> {
   OperationSnapshot create(RequestT request, OperationT response);
 }

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/PollingRequestFactory.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/PollingRequestFactory.java
@@ -29,14 +29,11 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
-
 /**
  * A factory which creates a subsequent polling request from a compund operation id.
  *
  * @param <RequestT> polling request type
  */
-@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public interface PollingRequestFactory<RequestT> {
   /**
    * Creates a polling request message from a {@code compoundOperationId}.

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoMessageRequestFormatter.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoMessageRequestFormatter.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.protobuf.Message;
@@ -37,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 
 /** Creates parts of a HTTP request from a protobuf message. */
-@BetaApi
 public class ProtoMessageRequestFormatter<RequestT extends Message>
     implements HttpRequestFormatter<RequestT> {
 

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoMessageResponseParser.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoMessageResponseParser.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.httpjson;
 
-import com.google.api.core.BetaApi;
 import com.google.protobuf.Message;
 import com.google.protobuf.TypeRegistry;
 import java.io.IOException;
@@ -39,7 +38,6 @@ import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 
 /** The implementation of {@link HttpResponseParser} which works with protobuf messages. */
-@BetaApi
 public class ProtoMessageResponseParser<ResponseT extends Message>
     implements HttpResponseParser<ResponseT> {
 

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoOperationTransformers.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoOperationTransformers.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.httpjson;
 
 import com.google.api.core.ApiFunction;
-import com.google.api.core.BetaApi;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.ApiExceptionFactory;
 import com.google.api.gax.rpc.StatusCode.Code;
@@ -39,7 +38,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 
 /** Public for technical reasons; intended for use by generated code. */
-@BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
 public class ProtoOperationTransformers {
   private ProtoOperationTransformers() {}
 

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/OperationsClient.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/OperationsClient.java
@@ -142,7 +142,6 @@ public class OperationsClient implements BackgroundResource {
    * Constructs an instance of OperationsClient, using the given stub for making calls. This is for
    * advanced usage - prefer using create(OperationsSettings).
    */
-  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
   public static final OperationsClient create(OperationsStub stub) {
     return new OperationsClient(stub);
   }
@@ -151,7 +150,6 @@ public class OperationsClient implements BackgroundResource {
    * Constructs an instance of OperationsClient, using the given stub for making calls. This is for
    * advanced usage - prefer using create(OperationsSettings).
    */
-  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
   public static final OperationsClient create(BackgroundResource stub) {
     return new OperationsClient((OperationsStub) stub);
   }

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/OperationsSettings.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/OperationsSettings.java
@@ -143,7 +143,6 @@ public class OperationsSettings extends ClientSettings<OperationsSettings> {
     return OperationsStubSettings.defaultTransportChannelProvider();
   }
 
-  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
     return OperationsStubSettings.defaultApiClientHeaderProviderBuilder();
   }

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/stub/HttpJsonOperationsCallableFactory.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/stub/HttpJsonOperationsCallableFactory.java
@@ -81,8 +81,6 @@ public class HttpJsonOperationsCallableFactory
         httpJsonCallSettings, callSettings, clientContext);
   }
 
-  @BetaApi(
-      "The surface for long-running operations is not stable yet and may change in the future.")
   @Override
   public <RequestT, ResponseT, MetadataT>
       OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/stub/HttpJsonOperationsStub.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/stub/HttpJsonOperationsStub.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.httpjson.longrunning.stub;
 
 import com.google.api.client.http.HttpMethods;
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.BackgroundResourceAggregation;
@@ -70,7 +69,6 @@ import java.util.regex.Pattern;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
-@BetaApi("A restructuring of stub classes is planned, so this may break in the future")
 public class HttpJsonOperationsStub extends OperationsStub {
   private static final Pattern CLIENT_PACKAGE_VERSION_PATTERN =
       Pattern.compile("\\.(?<version>v\\d+[a-zA-Z]*\\d*[a-zA-Z]*\\d*)\\.[\\w.]*stub");

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/stub/OperationsStub.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/stub/OperationsStub.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.httpjson.longrunning.stub;
 
-import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.httpjson.longrunning.OperationsClient.ListOperationsPagedResponse;
 import com.google.api.gax.rpc.LongRunningClient;
@@ -48,7 +47,6 @@ import com.google.protobuf.Empty;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
-@BetaApi
 public abstract class OperationsStub implements BackgroundResource {
 
   public UnaryCallable<ListOperationsRequest, ListOperationsPagedResponse>

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/stub/OperationsStubSettings.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/longrunning/stub/OperationsStubSettings.java
@@ -33,7 +33,6 @@ import static com.google.api.gax.httpjson.longrunning.OperationsClient.ListOpera
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
-import com.google.api.core.BetaApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -99,7 +98,6 @@ import org.threeten.bp.Duration;
  * OperationsStubSettings operationsSettings = operationsSettingsBuilder.build();
  * }</pre>
  */
-@BetaApi
 public class OperationsStubSettings extends StubSettings<OperationsStubSettings> {
   /** The default scopes of the service. */
   private static final ImmutableList<String> DEFAULT_SERVICE_SCOPES =
@@ -188,7 +186,6 @@ public class OperationsStubSettings extends StubSettings<OperationsStubSettings>
     return cancelOperationSettings;
   }
 
-  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
   public OperationsStub createStub() throws IOException {
     if (getTransportChannelProvider()
         .getTransportName()
@@ -235,7 +232,6 @@ public class OperationsStubSettings extends StubSettings<OperationsStubSettings>
     return defaultHttpJsonTransportProviderBuilder().build();
   }
 
-  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
     return ApiClientHeaderProvider.newBuilder()
         .setGeneratedLibToken(

--- a/gax/src/main/java/com/google/api/gax/batching/AccumulatingBatchReceiver.java
+++ b/gax/src/main/java/com/google/api/gax/batching/AccumulatingBatchReceiver.java
@@ -30,13 +30,11 @@
 package com.google.api.gax.batching;
 
 import com.google.api.core.ApiFuture;
-import com.google.api.core.BetaApi;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /** A simple ThresholdBatchReceiver that just accumulates batches. */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public final class AccumulatingBatchReceiver<T> implements ThresholdBatchReceiver<T> {
   private final ConcurrentLinkedQueue<T> batches = new ConcurrentLinkedQueue<>();
   private final ApiFuture<?> retFuture;

--- a/gax/src/main/java/com/google/api/gax/batching/BatchEntry.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchEntry.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.batching;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.core.SettableApiFuture;
 import com.google.auto.value.AutoValue;
@@ -43,7 +42,6 @@ import javax.annotation.Nullable;
  * @param <ElementT> The type of each individual element to be batched.
  * @param <ElementResultT> The type of the result for each individual element.
  */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 @InternalApi("For google-cloud-java client use only.")
 @AutoValue
 public abstract class BatchEntry<ElementT, ElementResultT> {

--- a/gax/src/main/java/com/google/api/gax/batching/BatchMerger.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchMerger.java
@@ -29,9 +29,6 @@
  */
 package com.google.api.gax.batching;
 
-import com.google.api.core.BetaApi;
-
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public interface BatchMerger<B> {
   void merge(B batch, B newBatch);
 }

--- a/gax/src/main/java/com/google/api/gax/batching/Batcher.java
+++ b/gax/src/main/java/com/google/api/gax/batching/Batcher.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.batching;
 
 import com.google.api.core.ApiFuture;
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.ApiCallContext;
 
@@ -46,7 +45,6 @@ import com.google.api.gax.rpc.ApiCallContext;
  * @param <ElementT> The type of each individual element to be batched.
  * @param <ElementResultT> The type of the result for each individual element.
  */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 @InternalExtensionOnly
 public interface Batcher<ElementT, ElementResultT> extends AutoCloseable {
 

--- a/gax/src/main/java/com/google/api/gax/batching/BatcherImpl.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatcherImpl.java
@@ -34,7 +34,6 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.batching.FlowController.FlowControlException;
@@ -74,7 +73,6 @@ import javax.annotation.Nullable;
  * @param <RequestT> The type of the request that will contain the accumulated elements.
  * @param <ResponseT> The type of the response that will unpack into individual element results.
  */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 @InternalApi("For google-cloud-java client use only")
 public class BatcherImpl<ElementT, ElementResultT, RequestT, ResponseT>
     implements Batcher<ElementT, ElementResultT> {

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingCallSettings.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.batching;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.StatusCode;
@@ -64,7 +63,6 @@ import java.util.Set;
  * @param <RequestT> The type of the request that will contain the accumulated elements.
  * @param <ResponseT> The type of the response that will unpack into individual element results.
  */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public final class BatchingCallSettings<ElementT, ElementResultT, RequestT, ResponseT>
     extends UnaryCallSettings<RequestT, ResponseT> {
   private final BatchingDescriptor<ElementT, ElementResultT, RequestT, ResponseT>

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingDescriptor.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingDescriptor.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.batching;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import java.util.List;
 
@@ -80,7 +79,6 @@ import java.util.List;
  * @param <RequestT> The type of the request that will contain the accumulated elements
  * @param <ResponseT> The type of the response that will be unpacked into individual element results
  */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 @InternalApi("For google-cloud-java client use only.")
 public interface BatchingDescriptor<ElementT, ElementResultT, RequestT, ResponseT> {
 

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingException.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingException.java
@@ -29,10 +29,7 @@
  */
 package com.google.api.gax.batching;
 
-import com.google.api.core.BetaApi;
-
 /** Represents exception occurred during batching. */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public final class BatchingException extends RuntimeException {
 
   BatchingException(String message) {

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingFlowController.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingFlowController.java
@@ -29,13 +29,11 @@
  */
 package com.google.api.gax.batching;
 
-import com.google.api.core.BetaApi;
 import com.google.api.gax.batching.FlowController.FlowControlException;
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
 
 /** Wraps a {@link FlowController} for use by batching. */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public class BatchingFlowController<T> {
 
   private final FlowController flowController;

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingRequestBuilder.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingRequestBuilder.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.batching;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 
 /**
@@ -41,7 +40,6 @@ import com.google.api.core.InternalApi;
  * @param <ElementT> The type of each individual element to be batched.
  * @param <RequestT> The type of the request that will contain the accumulated elements.
  */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 @InternalApi("For google-cloud-java client use only.")
 public interface BatchingRequestBuilder<ElementT, RequestT> {
 

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingThreshold.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingThreshold.java
@@ -29,13 +29,10 @@
  */
 package com.google.api.gax.batching;
 
-import com.google.api.core.BetaApi;
-
 /**
  * The interface representing a threshold to be used in ThresholdBatcher. Thresholds do not need to
  * be thread-safe if they are only used inside ThresholdBatcher.
  */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public interface BatchingThreshold<E> {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/batching/BatchingThresholds.java
+++ b/gax/src/main/java/com/google/api/gax/batching/BatchingThresholds.java
@@ -29,12 +29,10 @@
  */
 package com.google.api.gax.batching;
 
-import com.google.api.core.BetaApi;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 /** Factory methods for general-purpose batching thresholds. */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public final class BatchingThresholds {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/batching/ElementCounter.java
+++ b/gax/src/main/java/com/google/api/gax/batching/ElementCounter.java
@@ -29,14 +29,11 @@
  */
 package com.google.api.gax.batching;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Interface representing an object that provides a numerical count given an object of the
  * parameterized type.
  */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public interface ElementCounter<E> {
   /** Provides the numerical count associated with the given object. */
-  public long count(E element);
+  long count(E element);
 }

--- a/gax/src/main/java/com/google/api/gax/batching/FlowController.java
+++ b/gax/src/main/java/com/google/api/gax/batching/FlowController.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.batching;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.batching.FlowControlEventStats.FlowControlEvent;
 import com.google.common.base.Preconditions;
@@ -38,7 +37,6 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /** Provides flow control capability. */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public class FlowController {
   /** Base exception that signals a flow control state. */
   public abstract static class FlowControlException extends Exception {
@@ -49,7 +47,6 @@ public class FlowController {
    * Runtime exception that can be used in place of FlowControlException when an unchecked exception
    * is required.
    */
-  @BetaApi
   public static class FlowControlRuntimeException extends RuntimeException {
     private FlowControlRuntimeException(FlowControlException e) {
       super(e);
@@ -64,7 +61,6 @@ public class FlowController {
    * Exception thrown when client-side flow control is enforced based on the maximum number of
    * outstanding in-memory elements.
    */
-  @BetaApi
   public static final class MaxOutstandingElementCountReachedException
       extends FlowControlException {
     private final long currentMaxElementCount;
@@ -88,7 +84,6 @@ public class FlowController {
    * Exception thrown when client-side flow control is enforced based on the maximum number of
    * unacknowledged in-memory bytes.
    */
-  @BetaApi
   public static final class MaxOutstandingRequestBytesReachedException
       extends FlowControlException {
     private final long currentMaxBytes;
@@ -112,7 +107,6 @@ public class FlowController {
    * Enumeration of behaviors that FlowController can use in case the flow control limits are
    * exceeded.
    */
-  @BetaApi
   public enum LimitExceededBehavior {
     /**
      * Throws {@link MaxOutstandingElementCountReachedException} or {@link

--- a/gax/src/main/java/com/google/api/gax/batching/NumericThreshold.java
+++ b/gax/src/main/java/com/google/api/gax/batching/NumericThreshold.java
@@ -29,11 +29,9 @@
  */
 package com.google.api.gax.batching;
 
-import com.google.api.core.BetaApi;
 import com.google.common.base.Preconditions;
 
 /** A threshold which accumulates a count based on the provided ElementCounter. */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public final class NumericThreshold<E> implements BatchingThreshold<E> {
   private final long threshold;
   private final ElementCounter<E> extractor;

--- a/gax/src/main/java/com/google/api/gax/batching/PartitionKey.java
+++ b/gax/src/main/java/com/google/api/gax/batching/PartitionKey.java
@@ -30,10 +30,8 @@
 
 package com.google.api.gax.batching;
 
-import com.google.api.core.BetaApi;
 import com.google.common.collect.ImmutableList;
 
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public final class PartitionKey {
   private final ImmutableList<Object> keys;
   private final int hash;

--- a/gax/src/main/java/com/google/api/gax/batching/RequestBuilder.java
+++ b/gax/src/main/java/com/google/api/gax/batching/RequestBuilder.java
@@ -29,9 +29,6 @@
  */
 package com.google.api.gax.batching;
 
-import com.google.api.core.BetaApi;
-
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public interface RequestBuilder<RequestT> {
   void appendRequest(RequestT request);
 

--- a/gax/src/main/java/com/google/api/gax/batching/ThresholdBatchReceiver.java
+++ b/gax/src/main/java/com/google/api/gax/batching/ThresholdBatchReceiver.java
@@ -30,13 +30,11 @@
 package com.google.api.gax.batching;
 
 import com.google.api.core.ApiFuture;
-import com.google.api.core.BetaApi;
 
 /**
  * Interface representing an object that receives batches from a ThresholdBatcher and takes action
  * on them. Implementations of ThresholdBatchReceiver should be thread-safe.
  */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public interface ThresholdBatchReceiver<BatchT> {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/batching/ThresholdBatcher.java
+++ b/gax/src/main/java/com/google/api/gax/batching/ThresholdBatcher.java
@@ -35,7 +35,6 @@ import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
-import com.google.api.core.BetaApi;
 import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.batching.FlowController.FlowControlException;
 import com.google.common.annotations.VisibleForTesting;
@@ -52,7 +51,6 @@ import org.threeten.bp.Duration;
  * Queues up elements until either a duration of time has passed or any threshold in a given set of
  * thresholds is breached, and then delivers the elements in a batch to the consumer.
  */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public final class ThresholdBatcher<E> {
 
   private class ReleaseResourcesFunction<T> implements ApiFunction<T, Void> {

--- a/gax/src/main/java/com/google/api/gax/core/Distribution.java
+++ b/gax/src/main/java/com/google/api/gax/core/Distribution.java
@@ -40,7 +40,6 @@ import java.util.concurrent.atomic.AtomicLongArray;
  *
  * <p>Methods may be called concurrently.
  */
-@Deprecated
 public class Distribution {
 
   private final AtomicLongArray buckets;

--- a/gax/src/main/java/com/google/api/gax/core/Distribution.java
+++ b/gax/src/main/java/com/google/api/gax/core/Distribution.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.core;
 
-import com.google.api.core.BetaApi;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -41,7 +40,7 @@ import java.util.concurrent.atomic.AtomicLongArray;
  *
  * <p>Methods may be called concurrently.
  */
-@BetaApi
+@Deprecated
 public class Distribution {
 
   private final AtomicLongArray buckets;

--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationFuture.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationFuture.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.longrunning;
 
 import com.google.api.core.ApiFuture;
-import com.google.api.core.BetaApi;
 import com.google.api.gax.retrying.RetryingFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -40,7 +39,6 @@ import java.util.concurrent.ExecutionException;
  *
  * <p>Implementations are expected to be thread-safe.
  */
-@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public interface OperationFuture<ResponseT, MetadataT> extends ApiFuture<ResponseT> {
   /**
    * Returns the value of the name of the operation from the initial operation object returned from

--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationFutureImpl.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationFutureImpl.java
@@ -35,7 +35,6 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.retrying.RetryingFuture;
 import java.util.concurrent.ExecutionException;
@@ -51,7 +50,6 @@ import java.util.concurrent.TimeoutException;
  *
  * <p>This is public only for technical reasons, for advanced usage.
  */
-@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 @InternalApi
 public final class OperationFutureImpl<ResponseT, MetadataT>
     implements OperationFuture<ResponseT, MetadataT> {

--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationFutures.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationFutures.java
@@ -31,7 +31,6 @@ package com.google.api.gax.longrunning;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
-import com.google.api.core.BetaApi;
 import com.google.api.gax.retrying.RetryingFuture;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.StatusCode;
@@ -40,7 +39,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
-@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public class OperationFutures {
   private OperationFutures() {
     // Utility class

--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationResponsePollAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationResponsePollAlgorithm.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.longrunning;
 
-import com.google.api.core.BetaApi;
 import com.google.api.gax.retrying.ResultRetryAlgorithm;
 import com.google.api.gax.retrying.TimedAttemptSettings;
 
@@ -37,7 +36,6 @@ import com.google.api.gax.retrying.TimedAttemptSettings;
  * Operation polling algorithm, which keeps retrying until {@link OperationSnapshot#isDone()} is
  * true.
  */
-@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public class OperationResponsePollAlgorithm implements ResultRetryAlgorithm<OperationSnapshot> {
   @Override
   public TimedAttemptSettings createNextAttempt(

--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationSnapshot.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationSnapshot.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.longrunning;
 
-import com.google.api.core.BetaApi;
 import com.google.api.gax.rpc.StatusCode;
 
 /**
@@ -38,7 +37,6 @@ import com.google.api.gax.rpc.StatusCode;
  * <p>The metadata and response will have a structure defined by the particular long-running
  * operation that was initiated.
  */
-@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public interface OperationSnapshot {
 
   /** The name of the operation. This is used for identifying the operation on the server. */

--- a/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
+++ b/gax/src/main/java/com/google/api/gax/longrunning/OperationTimedPollAlgorithm.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.longrunning;
 
 import com.google.api.core.ApiClock;
-import com.google.api.core.BetaApi;
 import com.google.api.core.NanoClock;
 import com.google.api.gax.retrying.ExponentialRetryAlgorithm;
 import com.google.api.gax.retrying.RetrySettings;
@@ -42,7 +41,6 @@ import java.util.concurrent.CancellationException;
  * next polling operation should be executed. If the polling exceeds the total timeout this
  * algorithm cancels polling.
  */
-@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public class OperationTimedPollAlgorithm extends ExponentialRetryAlgorithm {
   /**
    * Creates the polling algorithm, using the default {@code NanoClock} for time computations.

--- a/gax/src/main/java/com/google/api/gax/paging/Pages.java
+++ b/gax/src/main/java/com/google/api/gax/paging/Pages.java
@@ -32,7 +32,6 @@ package com.google.api.gax.paging;
 import java.util.Collections;
 
 /** Utility class for {@link Page}s. */
-@Deprecated
 public class Pages {
   private Pages() {}
 

--- a/gax/src/main/java/com/google/api/gax/paging/Pages.java
+++ b/gax/src/main/java/com/google/api/gax/paging/Pages.java
@@ -29,11 +29,10 @@
  */
 package com.google.api.gax.paging;
 
-import com.google.api.core.BetaApi;
 import java.util.Collections;
 
 /** Utility class for {@link Page}s. */
-@BetaApi
+@Deprecated
 public class Pages {
   private Pages() {}
 

--- a/gax/src/main/java/com/google/api/gax/retrying/DirectRetryingExecutor.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/DirectRetryingExecutor.java
@@ -33,7 +33,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
-import com.google.api.core.BetaApi;
 import java.io.InterruptedIOException;
 import java.nio.channels.ClosedByInterruptException;
 import java.util.concurrent.Callable;
@@ -81,7 +80,6 @@ public class DirectRetryingExecutor<ResponseT> implements RetryingExecutorWithCo
    * @param callable the actual callable, which should be executed in a retriable context
    * @return retrying future facade
    */
-  @BetaApi("The surface for passing per operation state is not yet stable")
   @Override
   public RetryingFuture<ResponseT> createFuture(
       Callable<ResponseT> callable, RetryingContext context) {

--- a/gax/src/main/java/com/google/api/gax/retrying/SimpleStreamResumptionStrategy.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/SimpleStreamResumptionStrategy.java
@@ -29,14 +29,12 @@
  */
 package com.google.api.gax.retrying;
 
-import com.google.api.core.BetaApi;
 import com.google.common.base.Preconditions;
 
 /**
  * Simplest implementation of a {@link StreamResumptionStrategy} which returns the initial request
  * for unstarted streams.
  */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public final class SimpleStreamResumptionStrategy<RequestT, ResponseT>
     implements StreamResumptionStrategy<RequestT, ResponseT> {
   private boolean seenFirstResponse;

--- a/gax/src/main/java/com/google/api/gax/retrying/StreamResumptionStrategy.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/StreamResumptionStrategy.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.retrying;
 
-import com.google.api.core.BetaApi;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -39,7 +38,6 @@ import javax.annotation.Nullable;
  *
  * <p>Implementations don't have to be threadsafe because all of the calls will be serialized.
  */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public interface StreamResumptionStrategy<RequestT, ResponseT> {
 
   /** Creates a new instance of this StreamResumptionStrategy without accumulated state */

--- a/gax/src/main/java/com/google/api/gax/retrying/TimedAttemptSettings.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/TimedAttemptSettings.java
@@ -30,13 +30,10 @@
 package com.google.api.gax.retrying;
 
 import com.google.api.core.ApiClock;
-import com.google.api.core.BetaApi;
 import com.google.auto.value.AutoValue;
-import com.google.auto.value.AutoValue.Builder;
 import org.threeten.bp.Duration;
 
 /** Timed attempt execution settings. Defines time-specific properties of a retry attempt. */
-@BetaApi
 @AutoValue
 public abstract class TimedAttemptSettings {
 

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -98,7 +98,6 @@ public interface ApiCallContext extends RetryingContext {
    * <p>Please note that this timeout is best effort and the maximum resolution is configured in
    * {@link StubSettings#getStreamWatchdogCheckInterval()}.
    */
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   ApiCallContext withStreamWaitTimeout(@Nullable Duration streamWaitTimeout);
 
   /**
@@ -106,7 +105,6 @@ public interface ApiCallContext extends RetryingContext {
    *
    * @see #withStreamWaitTimeout(Duration)
    */
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nullable
   Duration getStreamWaitTimeout();
 
@@ -128,7 +126,6 @@ public interface ApiCallContext extends RetryingContext {
    * <p>Please note that this timeout is best effort and the maximum resolution is configured in
    * {@link StubSettings#getStreamWatchdogCheckInterval()}.
    */
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   ApiCallContext withStreamIdleTimeout(@Nullable Duration streamIdleTimeout);
 
   /**
@@ -136,7 +133,6 @@ public interface ApiCallContext extends RetryingContext {
    *
    * @see #withStreamIdleTimeout(Duration)
    */
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nullable
   Duration getStreamIdleTimeout();
 

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiClientHeaderProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiClientHeaderProvider.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
@@ -39,7 +38,6 @@ import java.util.Map;
  * Implementation of HeaderProvider that provides headers describing the API client library making
  * API calls.
  */
-@BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
 public class ApiClientHeaderProvider implements HeaderProvider, Serializable {
   private static final long serialVersionUID = -8876627296793342119L;
   static final String QUOTA_PROJECT_ID_HEADER_KEY = "x-goog-user-project";

--- a/gax/src/main/java/com/google/api/gax/rpc/ApiStreamObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ApiStreamObserver.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Receives notifications from an observable stream of messages.
  *
@@ -52,7 +50,6 @@ import com.google.api.core.BetaApi;
  * <p>This interface is a fork of io.grpc.stub.StreamObserver to enable shadowing of Guava, and also
  * to allow for a transport-agnostic interface that doesn't depend on gRPC.
  */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public interface ApiStreamObserver<V> {
   /**
    * Receives a value from the stream.

--- a/gax/src/main/java/com/google/api/gax/rpc/BatchedRequestIssuer.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/BatchedRequestIssuer.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import com.google.common.base.Preconditions;
 
 /**
@@ -38,7 +37,6 @@ import com.google.common.base.Preconditions;
  *
  * <p>This class is designed to be used by generated code.
  */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public final class BatchedRequestIssuer<ResponseT> {
   private final BatchedFuture<ResponseT> batchedFuture;
   private final long messageCount;

--- a/gax/src/main/java/com/google/api/gax/rpc/BatchingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/BatchingCallSettings.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowController;
@@ -42,7 +41,6 @@ import java.util.Set;
  * A settings class to configure a {@link UnaryCallable} for calls to an API method that supports
  * batching. The settings are provided using an instance of {@link BatchingSettings}.
  */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 @InternalExtensionOnly
 public final class BatchingCallSettings<RequestT, ResponseT>
     extends UnaryCallSettings<RequestT, ResponseT> {

--- a/gax/src/main/java/com/google/api/gax/rpc/BatchingDescriptor.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/BatchingDescriptor.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import com.google.api.gax.batching.PartitionKey;
 import com.google.api.gax.batching.RequestBuilder;
 import java.util.Collection;
@@ -43,7 +42,6 @@ import java.util.Collection;
  *
  * <p>This class is designed to be used by generated code.
  */
-@BetaApi("The surface for batching is not stable yet and may change in the future.")
 public interface BatchingDescriptor<RequestT, ResponseT> {
 
   /** Returns the value of the partition key for the given request. */

--- a/gax/src/main/java/com/google/api/gax/rpc/BidiStream.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/BidiStream.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 
 /**
@@ -69,7 +68,6 @@ import com.google.api.core.InternalApi;
  * @param <RequestT> The type of each request.
  * @param <ResponseT> The type of each response.
  */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public class BidiStream<RequestT, ResponseT> extends ServerStream<ResponseT>
     implements ClientStream<RequestT> {
 

--- a/gax/src/main/java/com/google/api/gax/rpc/BidiStreamObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/BidiStreamObserver.java
@@ -29,8 +29,5 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public interface BidiStreamObserver<RequestT, ResponseT>
     extends ResponseObserver<ResponseT>, ClientStreamReadyObserver<RequestT> {}

--- a/gax/src/main/java/com/google/api/gax/rpc/BidiStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/BidiStreamingCallable.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * A BidiStreamingCallable is an immutable object which is capable of making RPC calls to
  * bidirectional streaming API methods. Not all transports support streaming.
@@ -39,7 +37,6 @@ import com.google.api.core.BetaApi;
  * class is intended to be created by a generated client class, and configured by instances of
  * StreamingCallSettings.Builder which are exposed through the client settings class.
  */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public abstract class BidiStreamingCallable<RequestT, ResponseT> {
 
   protected BidiStreamingCallable() {}

--- a/gax/src/main/java/com/google/api/gax/rpc/Callables.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Callables.java
@@ -77,7 +77,6 @@ public class Callables {
         clientContext.getDefaultCallContext(), innerCallable, retryingExecutor);
   }
 
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   public static <RequestT, ResponseT> ServerStreamingCallable<RequestT, ResponseT> retrying(
       ServerStreamingCallable<RequestT, ResponseT> innerCallable,
       ServerStreamingCallSettings<RequestT, ResponseT> callSettings,
@@ -105,7 +104,6 @@ public class Callables {
         innerCallable, retryingExecutor, settings.getResumptionStrategy());
   }
 
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   public static <RequestT, ResponseT> ServerStreamingCallable<RequestT, ResponseT> watched(
       ServerStreamingCallable<RequestT, ResponseT> callable,
       ServerStreamingCallSettings<RequestT, ResponseT> callSettings,
@@ -132,7 +130,6 @@ public class Callables {
    * @param context {@link ClientContext} to use to connect to the service.
    * @return {@link UnaryCallable} callable object.
    */
-  @BetaApi("The surface for batching is not stable yet and may change in the future.")
   public static <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> batching(
       UnaryCallable<RequestT, ResponseT> innerCallable,
       BatchingCallSettings<RequestT, ResponseT> batchingCallSettings,

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java
@@ -84,21 +84,17 @@ public abstract class ClientContext {
   @Nullable
   public abstract TransportChannel getTransportChannel();
 
-  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public abstract Map<String, String> getHeaders();
 
-  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   protected abstract Map<String, String> getInternalHeaders();
 
   public abstract ApiClock getClock();
 
   public abstract ApiCallContext getDefaultCallContext();
 
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nullable
   public abstract Watchdog getStreamWatchdog();
 
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nonnull
   public abstract Duration getStreamWatchdogCheckInterval();
 
@@ -305,10 +301,8 @@ public abstract class ClientContext {
 
     public abstract Builder setTransportChannel(TransportChannel transportChannel);
 
-    @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
     public abstract Builder setHeaders(Map<String, String> headers);
 
-    @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
     protected abstract Builder setInternalHeaders(Map<String, String> headers);
 
     public abstract Builder setClock(ApiClock clock);
@@ -319,10 +313,8 @@ public abstract class ClientContext {
 
     public abstract Builder setQuotaProjectId(String QuotaProjectId);
 
-    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     public abstract Builder setStreamWatchdog(Watchdog watchdog);
 
-    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     public abstract Builder setStreamWatchdogCheckInterval(Duration duration);
 
     /**

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientSettings.java
@@ -31,7 +31,6 @@ package com.google.api.gax.rpc;
 
 import com.google.api.core.ApiClock;
 import com.google.api.core.ApiFunction;
-import com.google.api.core.BetaApi;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.ExecutorProvider;
 import com.google.common.base.MoreObjects;
@@ -82,12 +81,10 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
     return stubSettings.getCredentialsProvider();
   }
 
-  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public final HeaderProvider getHeaderProvider() {
     return stubSettings.getHeaderProvider();
   }
 
-  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   protected final HeaderProvider getInternalHeaderProvider() {
     return stubSettings.getInternalHeaderProvider();
   }
@@ -104,13 +101,11 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
     return stubSettings.getQuotaProjectId();
   }
 
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nullable
   public final WatchdogProvider getWatchdogProvider() {
     return stubSettings.getStreamWatchdogProvider();
   }
 
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nonnull
   public final Duration getWatchdogCheckInterval() {
     return stubSettings.getStreamWatchdogCheckInterval();
@@ -204,7 +199,6 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
      * Some reserved headers can be overridden (e.g. Content-Type) or merged with the default value
      * (e.g. User-Agent) by the underlying transport layer.
      */
-    @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
     public B setHeaderProvider(HeaderProvider headerProvider) {
       stubSettings.setHeaderProvider(headerProvider);
       return self();
@@ -217,7 +211,6 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
      * the constructed client. Some reserved headers can be overridden (e.g. Content-Type) or merged
      * with the default value (e.g. User-Agent) by the underlying transport layer.
      */
-    @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
     protected B setInternalHeaderProvider(HeaderProvider internalHeaderProvider) {
       stubSettings.setInternalHeaderProvider(internalHeaderProvider);
       return self();
@@ -252,13 +245,11 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
       return self();
     }
 
-    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     public B setWatchdogProvider(@Nullable WatchdogProvider watchdogProvider) {
       stubSettings.setStreamWatchdogProvider(watchdogProvider);
       return self();
     }
 
-    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     public B setWatchdogCheckInterval(@Nullable Duration checkInterval) {
       stubSettings.setStreamWatchdogCheckInterval(checkInterval);
       return self();
@@ -298,13 +289,11 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
     }
 
     /** Gets the custom HeaderProvider that was previously set on this Builder. */
-    @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
     public HeaderProvider getHeaderProvider() {
       return stubSettings.getHeaderProvider();
     }
 
     /** Gets the internal HeaderProvider that was previously set on this Builder. */
-    @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
     protected HeaderProvider getInternalHeaderProvider() {
       return stubSettings.getInternalHeaderProvider();
     }
@@ -323,13 +312,11 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
       return stubSettings.getQuotaProjectId();
     }
 
-    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     @Nullable
     public WatchdogProvider getWatchdogProvider() {
       return stubSettings.getStreamWatchdogProvider();
     }
 
-    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     @Nullable
     public Duration getWatchdogCheckInterval() {
       return stubSettings.getStreamWatchdogCheckInterval();

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientStream.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientStream.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * A wrapper used to send requests to the server.
  *
@@ -51,7 +49,6 @@ import com.google.api.core.BetaApi;
  *
  * @param <RequestT> The type of each request.
  */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public interface ClientStream<RequestT> {
   /** Sends a request to the server. It is an error to call this if the stream is already closed. */
   void send(RequestT request);

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientStreamReadyObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientStreamReadyObserver.java
@@ -29,10 +29,7 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /** A callback used to report that the {@link ClientStream} is ready to send more messages. */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public interface ClientStreamReadyObserver<V> {
   void onReady(ClientStream<V> stream);
 }

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientStreamingCallable.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * A ClientStreamingCallable is an immutable object which is capable of making RPC calls to client
  * streaming API methods. Not all transports support streaming.
@@ -39,7 +37,6 @@ import com.google.api.core.BetaApi;
  * This class is intended to be created by a generated client class, and configured by instances of
  * StreamingCallSettings.Builder which are exposed through the client settings class.
  */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public abstract class ClientStreamingCallable<RequestT, ResponseT> {
 
   protected ClientStreamingCallable() {}

--- a/gax/src/main/java/com/google/api/gax/rpc/FixedHeaderProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FixedHeaderProvider.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
@@ -41,7 +40,6 @@ import javax.annotation.Nullable;
 
 /** An instance of HeaderProvider that always provides the same headers. */
 @AutoValue
-@BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
 public abstract class FixedHeaderProvider implements HeaderProvider, Serializable {
 
   private static final long serialVersionUID = -4881534091594970538L;

--- a/gax/src/main/java/com/google/api/gax/rpc/FixedTransportChannelProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FixedTransportChannelProvider.java
@@ -70,13 +70,11 @@ public class FixedTransportChannelProvider implements TransportChannelProvider {
   }
 
   @Override
-  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public boolean needsHeaders() {
     return false;
   }
 
   @Override
-  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public FixedTransportChannelProvider withHeaders(Map<String, String> headers) {
     throw new UnsupportedOperationException("FixedTransportChannelProvider doesn't need headers");
   }

--- a/gax/src/main/java/com/google/api/gax/rpc/FixedWatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/FixedWatchdogProvider.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.ApiClock;
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nonnull;
@@ -44,7 +43,6 @@ import org.threeten.bp.Duration;
  * <p>This is the internal class and is public only for technical reasons. It may change any time
  * without notice, please do not depend on it explicitly.
  */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 @InternalApi
 public final class FixedWatchdogProvider implements WatchdogProvider {
   @Nullable private final Watchdog watchdog;

--- a/gax/src/main/java/com/google/api/gax/rpc/HeaderProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/HeaderProvider.java
@@ -29,11 +29,9 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import java.util.Map;
 
 /** Provider of headers to put on http requests. */
-@BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
 public interface HeaderProvider {
 
   /** Get the headers to put on http requests. */

--- a/gax/src/main/java/com/google/api/gax/rpc/InstantiatingWatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/InstantiatingWatchdogProvider.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.ApiClock;
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.common.base.Preconditions;
 import java.util.concurrent.ScheduledExecutorService;
@@ -44,7 +43,6 @@ import org.threeten.bp.Duration;
  * <p>This is the internal class and is public only for technical reasons. It may change any time
  * without notice, please do not depend on it explicitly.
  */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 @InternalApi
 public final class InstantiatingWatchdogProvider implements WatchdogProvider {
   @Nullable private final ApiClock clock;

--- a/gax/src/main/java/com/google/api/gax/rpc/LongRunningClient.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/LongRunningClient.java
@@ -29,11 +29,9 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import com.google.api.gax.longrunning.OperationSnapshot;
 
 /** Implementation-agnostic interface for managing long-running operations. */
-@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public interface LongRunningClient {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/rpc/NoHeaderProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/NoHeaderProvider.java
@@ -29,13 +29,11 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 
 /** Implementation of HeaderProvider that provides empty headers. */
-@BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
 public class NoHeaderProvider implements HeaderProvider, Serializable {
   private static final long serialVersionUID = 7323717933589691233L;
 

--- a/gax/src/main/java/com/google/api/gax/rpc/OperationCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/OperationCallSettings.java
@@ -32,7 +32,6 @@ package com.google.api.gax.rpc;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.core.ApiFunction;
-import com.google.api.core.BetaApi;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.retrying.TimedRetryAlgorithm;
 
@@ -40,7 +39,6 @@ import com.google.api.gax.retrying.TimedRetryAlgorithm;
  * A settings class to configure an {@link OperationCallable} for calls to initiate, resume, and
  * cancel a long-running operation.
  */
-@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public final class OperationCallSettings<RequestT, ResponseT, MetadataT> {
   private final UnaryCallSettings<RequestT, OperationSnapshot> initialCallSettings;
   private final TimedRetryAlgorithm pollingAlgorithm;

--- a/gax/src/main/java/com/google/api/gax/rpc/OperationCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/OperationCallable.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.ApiFuture;
-import com.google.api.core.BetaApi;
 import com.google.api.gax.longrunning.OperationFuture;
 
 /**
@@ -42,7 +41,6 @@ import com.google.api.gax.longrunning.OperationFuture;
  * class is intended to be created by a generated client class, and configured by instances of
  * OperationCallSettings.Builder which are exposed through the client settings class.
  */
-@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
 public abstract class OperationCallable<RequestT, ResponseT, MetadataT> {
 
   protected OperationCallable() {}

--- a/gax/src/main/java/com/google/api/gax/rpc/ResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ResponseObserver.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * Receives notifications from server-streaming calls.
  *
@@ -50,7 +48,6 @@ import com.google.api.core.BetaApi;
  * control by calling {@code disableAutoInboundFlowControl()} in {@code onStart}. After this, the
  * consumer must request responses by calling {@code request()}.
  */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public interface ResponseObserver<V> {
 
   /**

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStream.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStream.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import java.util.Iterator;
 import javax.annotation.Nonnull;
@@ -65,7 +64,6 @@ import javax.annotation.Nonnull;
  *
  * @param <V> The type of each response.
  */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public class ServerStream<V> implements Iterable<V> {
   private final QueuingResponseObserver<V> observer = new QueuingResponseObserver<>();
   private final ServerStreamIterator<V> iterator = new ServerStreamIterator<>(observer);

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.retrying.SimpleStreamResumptionStrategy;
 import com.google.api.gax.retrying.StreamResumptionStrategy;
@@ -72,7 +71,6 @@ import org.threeten.bp.Duration;
  *   <li>totalTimeout still applies to the entire stream.
  * </ul>
  */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public final class ServerStreamingCallSettings<RequestT, ResponseT>
     extends StreamingCallSettings<RequestT, ResponseT> {
 

--- a/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallable.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import java.util.Iterator;
 import java.util.List;
 
@@ -41,7 +40,6 @@ import java.util.List;
  * This class is intended to be created by a generated client class, and configured by instances of
  * StreamingCallSettings.Builder which are exposed through the client settings class.
  */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public abstract class ServerStreamingCallable<RequestT, ResponseT> {
   private final FirstElementCallable<RequestT, ResponseT> firstCallable;
   private final SpoolingCallable<RequestT, ResponseT> spoolingCallable;

--- a/gax/src/main/java/com/google/api/gax/rpc/StateCheckingResponseObserver.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StateCheckingResponseObserver.java
@@ -29,11 +29,9 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import com.google.common.base.Preconditions;
 
 /** Base implementation of {@link ResponseObserver} that performs state sanity checks. */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public abstract class StateCheckingResponseObserver<V> implements ResponseObserver<V> {
   private boolean isStarted;
   private boolean isClosed;

--- a/gax/src/main/java/com/google/api/gax/rpc/StreamController.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StreamController.java
@@ -29,7 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import java.util.concurrent.CancellationException;
 
 /**
@@ -40,7 +39,6 @@ import java.util.concurrent.CancellationException;
  * flow control. The receiver can also save a reference to the instance and terminate the stream
  * early using {@code cancel()}.
  */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public interface StreamController {
   /**
    * Cancel the stream early.

--- a/gax/src/main/java/com/google/api/gax/rpc/StreamingCallSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StreamingCallSettings.java
@@ -29,13 +29,11 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
 
 /**
  * A settings class to configure a streaming callable object for calls to a streaming API method.
  */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 @InternalExtensionOnly
 public class StreamingCallSettings<RequestT, ResponseT> {
 

--- a/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -123,12 +123,10 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     return credentialsProvider;
   }
 
-  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public final HeaderProvider getHeaderProvider() {
     return headerProvider;
   }
 
-  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   protected final HeaderProvider getInternalHeaderProvider() {
     return internalHeaderProvider;
   }
@@ -154,13 +152,11 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     return quotaProjectId;
   }
 
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nullable
   public final WatchdogProvider getStreamWatchdogProvider() {
     return streamWatchdogProvider;
   }
 
-  @BetaApi("The surface for streaming is not stable yet and may change in the future.")
   @Nonnull
   public final Duration getStreamWatchdogCheckInterval() {
     return streamWatchdogCheckInterval;
@@ -351,7 +347,6 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
      * Some reserved headers can be overridden (e.g. Content-Type) or merged with the default value
      * (e.g. User-Agent) by the underlying transport layer.
      */
-    @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
     public B setHeaderProvider(HeaderProvider headerProvider) {
       this.headerProvider = headerProvider;
       if (this.quotaProjectId == null
@@ -368,7 +363,6 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
      * the constructed client. Some reserved headers can be overridden (e.g. Content-Type) or merged
      * with the default value (e.g. User-Agent) by the underlying transport layer.
      */
-    @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
     protected B setInternalHeaderProvider(HeaderProvider internalHeaderProvider) {
       this.internalHeaderProvider = internalHeaderProvider;
       if (this.quotaProjectId == null
@@ -392,7 +386,6 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
      *
      * <p>This will default to a {@link InstantiatingWatchdogProvider} if it is not set.
      */
-    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     public B setStreamWatchdogProvider(@Nullable WatchdogProvider streamWatchdogProvider) {
       this.streamWatchdogProvider = streamWatchdogProvider;
       return self();
@@ -436,7 +429,6 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
      * Sets how often the {@link Watchdog} will check ongoing streaming RPCs. Defaults to 10 secs.
      * Use {@link Duration#ZERO} to disable.
      */
-    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     public B setStreamWatchdogCheckInterval(@Nonnull Duration checkInterval) {
       Preconditions.checkNotNull(checkInterval);
       this.streamWatchdogCheckInterval = checkInterval;
@@ -477,19 +469,16 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     }
 
     /** Gets the custom HeaderProvider that was previously set on this Builder. */
-    @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
     public HeaderProvider getHeaderProvider() {
       return headerProvider;
     }
 
     /** Gets the internal HeaderProvider that was previously set on this Builder. */
-    @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
     protected HeaderProvider getInternalHeaderProvider() {
       return internalHeaderProvider;
     }
 
     /** Gets the {@link WatchdogProvider }that was previously set on this Builder. */
-    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     @Nullable
     public WatchdogProvider getStreamWatchdogProvider() {
       return streamWatchdogProvider;
@@ -513,7 +502,6 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       return quotaProjectId;
     }
 
-    @BetaApi("The surface for streaming is not stable yet and may change in the future.")
     @Nonnull
     public Duration getStreamWatchdogCheckInterval() {
       return streamWatchdogCheckInterval;

--- a/gax/src/main/java/com/google/api/gax/rpc/TransportChannelProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/TransportChannelProvider.java
@@ -78,7 +78,6 @@ public interface TransportChannelProvider {
   TransportChannelProvider withExecutor(ScheduledExecutorService executor);
 
   /** True if the TransportProvider has no headers provided. */
-  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   boolean needsHeaders();
 
   /**
@@ -86,7 +85,6 @@ public interface TransportChannelProvider {
    *
    * <p>This method should only be called if {@link #needsHeaders()} returns true.
    */
-  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   TransportChannelProvider withHeaders(Map<String, String> headers);
 
   /** True if the TransportProvider has no endpoint set. */

--- a/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.ApiClock;
-import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.common.base.Preconditions;
 import java.util.Iterator;
@@ -61,7 +60,6 @@ import org.threeten.bp.Duration;
  *       had no outstanding demand. Duration.ZERO disables the timeout.
  * </ul>
  */
-@BetaApi
 public final class Watchdog implements Runnable, BackgroundResource {
   private static final Logger LOG = Logger.getLogger(Watchdog.class.getName());
 

--- a/gax/src/main/java/com/google/api/gax/rpc/WatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/WatchdogProvider.java
@@ -30,12 +30,10 @@
 package com.google.api.gax.rpc;
 
 import com.google.api.core.ApiClock;
-import com.google.api.core.BetaApi;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nonnull;
 import org.threeten.bp.Duration;
 
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public interface WatchdogProvider {
   boolean needsClock();
 

--- a/gax/src/main/java/com/google/api/gax/rpc/WatchdogTimeoutException.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/WatchdogTimeoutException.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.api.core.BetaApi;
-
 /**
  * The marker exception thrown when a timeout is exceeded.
  *
@@ -44,7 +42,6 @@ import com.google.api.core.BetaApi;
  *       or next on {@link ServerStream#iterator()} (in case of blocking api).
  * </ul>
  */
-@BetaApi("The surface for streaming is not stable yet and may change in the future.")
 public class WatchdogTimeoutException extends ApiException {
   private static final long serialVersionUID = -777463630112442086L;
 


### PR DESCRIPTION
Those features have been under `BetaApi` annotation for 2-3+ years.

They are:
- Long running operations logic
- Streaming logic
- Fields extractor logic
- Interceptors logic
- Response metadata logic
- Custom headers logic

Many of the classes under gax-httpjson module remain `BetaApi` as those are much younger than grpc and shared classes, and will be cleaned up with httpjson module GA (which whill hopefully happen in H1).

Not all `BetaApi` annotations were removed. For example channel pool configuration and recent explicit headers logic kept Beta, as those are much newer.

This also addresses a couple old issues: https://github.com/googleapis/gax-java/issues/1095 and https://github.com/googleapis/gax-java/issues/702