### PR TITLE
fix: update the runtime dependency grpc-java xds to googleapis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ ext {
     'maven.io_grpc_grpc_protobuf': "io.grpc:grpc-protobuf:${libraries['version.io_grpc']}",
     'maven.io_grpc_grpc_netty_shaded': "io.grpc:grpc-netty-shaded:${libraries['version.io_grpc']}",
     'maven.io_grpc_grpc_alts': "io.grpc:grpc-alts:${libraries['version.io_grpc']}",
-    'maven.io_grpc_grpc_xds': "io.grpc:grpc-xds:${libraries['version.io_grpc']}",
+    'maven.io_grpc_grpc_googleapis': "io.grpc:grpc-googleapis:${libraries['version.io_grpc']}",
     'maven.com_google_protobuf': "com.google.protobuf:protobuf-java:${libraries['version.com_google_protobuf']}",
     'maven.com_google_protobuf_java_util': "com.google.protobuf:protobuf-java-util:${libraries['version.com_google_protobuf']}")
 }

--- a/gax-grpc/build.gradle
+++ b/gax-grpc/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     libraries['maven.io_grpc_grpc_protobuf'],
     libraries['maven.io_grpc_grpc_stub'])
 
-  runtimeOnly libraries['maven.io_grpc_grpc_xds']
+  runtimeOnly libraries['maven.io_grpc_grpc_googleapis']
 
   compileOnly libraries['maven.com_google_auto_value_auto_value']
 


### PR DESCRIPTION
In https://github.com/grpc/grpc-java/pull/8963, the `google-c2p-experimental` name resolver is moved from xds package to googleapis package in grpc java, so we need to update the runtime dependency accordingly.

cc @ejona86