### PR TITLE
feat: relocate Opencensus configurations from java-core to gax

### DIFF
--- a/gax/src/main/java/com/google/api/gax/nativeimage/OpenCensusFeature.java
+++ b/gax/src/main/java/com/google/api/gax/nativeimage/OpenCensusFeature.java
@@ -49,7 +49,7 @@ final class OpenCensusFeature implements Feature {
     }
     if (access.findClassByName(TAGS_COMPONENT_CLASS) != null) {
       registerForReflectiveInstantiation(access, "io.opencensus.impl.metrics.MetricsComponentImpl");
-      registerForReflectiveInstantiation(access, "io.opencensus.impl.tags.TagsComponentImpl");
+      registerForReflectiveInstantiation(access, TAGS_COMPONENT_CLASS);
       registerForReflectiveInstantiation(access, "io.opencensus.impl.trace.TraceComponentImpl");
     }
   }

--- a/gax/src/main/java/com/google/api/gax/nativeimage/OpenCensusFeature.java
+++ b/gax/src/main/java/com/google/api/gax/nativeimage/OpenCensusFeature.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.api.gax.nativeimage;
+
+import static com.google.api.gax.nativeimage.NativeImageUtils.registerForReflectiveInstantiation;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import org.graalvm.nativeimage.hosted.Feature;
+
+/** Registers reflection usage in OpenCensus libraries. */
+@AutomaticFeature
+final class OpenCensusFeature implements Feature {
+
+  private static final String TAGS_COMPONENT_CLASS = "io.opencensus.impl.tags.TagsComponentImpl";
+  private static final String STATS_COMPONENT_CLASS = "io.opencensus.impl.stats.StatsComponentImpl";
+
+  @Override
+  public void beforeAnalysis(BeforeAnalysisAccess access) {
+    if (access.findClassByName(STATS_COMPONENT_CLASS) != null) {
+      registerForReflectiveInstantiation(access, STATS_COMPONENT_CLASS);
+    }
+    if (access.findClassByName(TAGS_COMPONENT_CLASS) != null) {
+      registerForReflectiveInstantiation(access, "io.opencensus.impl.metrics.MetricsComponentImpl");
+      registerForReflectiveInstantiation(access, "io.opencensus.impl.tags.TagsComponentImpl");
+      registerForReflectiveInstantiation(access, "io.opencensus.impl.trace.TraceComponentImpl");
+    }
+  }
+}


### PR DESCRIPTION
Opencensus is used by libraries like Pub/Sub and Spanner. 
Tested this out manually with Pub/Sub and Spanner. Without this feature, Pub/Sub results in:
```
   Caused by: io.grpc.StatusRuntimeException: UNAUTHENTICATED: Failed computing credential metadata
       io.grpc.Status.asRuntimeException(Status.java:535)
       [...]
     Caused by: java.util.ServiceConfigurationError: Provider io.opencensus.impl.trace.TraceComponentImpl could not be instantiated.
       io.opencensus.internal.Provider.createInstance(Provider.java:46)
       io.opencensus.trace.Tracing.loadTraceComponent(Tracing.java:110)
       io.opencensus.trace.Tracing.<clinit>(Tracing.java:38)
       com.google.api.client.http.OpenCensusUtils.<clinit>(OpenCensusUtils.java:56)
       com.google.api.client.http.HttpRequest.<init>(HttpRequest.java:203)
       [...]
     Caused by: java.lang.NoSuchMethodException: io.opencensus.impl.trace.TraceComponentImpl.<init>()
       java.lang.Class.getConstructor0(DynamicHub.java:3349)
       java.lang.Class.getConstructor(DynamicHub.java:2151)
       io.opencensus.internal.Provider.createInstance(Provider.java:43)
       [...]
```
Spanner results in:
```
JUnit Vintage:InstanceAdminClientTest:testIAMPermissions
    MethodSource [className = 'com.google.cloud.spanner.InstanceAdminClientTest', methodName = 'testIAMPermissions', methodParameterTypes = '']
    => org.opentest4j.MultipleFailuresError: Multiple Failures (2 failures)
        java.util.ServiceConfigurationError: Provider io.opencensus.impl.trace.TraceComponentImpl could not be instantiated.
        java.lang.NullPointerException: <no message>
       org.junit.vintage.engine.execution.TestRun.getStoredResultOrSuccessful(TestRun.java:196)
       org.junit.vintage.engine.execution.RunListenerAdapter.fireExecutionFinished(RunListenerAdapter.java:226)
       org.junit.vintage.engine.execution.RunListenerAdapter.testFinished(RunListenerAdapter.java:192)
       org.junit.vintage.engine.execution.RunListenerAdapter.testFinished(RunListenerAdapter.java:79)
       org.junit.runner.notification.SynchronizedRunListener.testFinished(SynchronizedRunListener.java:87)
       [...]
       Suppressed: java.util.ServiceConfigurationError: Provider io.opencensus.impl.trace.TraceComponentImpl could not be instantiated.
         io.opencensus.internal.Provider.createInstance(Provider.java:46)
         io.opencensus.trace.Tracing.loadTraceComponent(Tracing.java:110)
         io.opencensus.trace.Tracing.<clinit>(Tracing.java:38)
         com.google.cloud.spanner.SpannerImpl.<clinit>(SpannerImpl.java:58)
```

TODO:
- Remove Opencensus feature from java-core once this PR is merged and released. 