### PR TITLE
feat: relocate native image properties from java-core to gax

### DIFF
--- a/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/native-image.properties
+++ b/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/native-image.properties
@@ -1,0 +1,10 @@
+Args = --initialize-at-run-time=io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl,\
+    io.grpc.netty.shaded.io.netty.internal.tcnative.SSL,\
+    io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateVerifier,\
+    io.grpc.netty.shaded.io.netty.internal.tcnative.SSLPrivateKeyMethod,\
+    io.grpc.netty.shaded.io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod,\
+    io.grpc.netty.shaded.io.grpc.netty,\
+    io.grpc.netty.shaded.io.netty.channel.epoll,\
+    io.grpc.netty.shaded.io.netty.channel.unix,\
+    io.grpc.netty.shaded.io.netty.handler.ssl,\
+    io.grpc.internal.RetriableStream

--- a/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
+++ b/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
@@ -1,0 +1,5 @@
+Args = --allow-incomplete-classpath \
+--enable-url-protocols=https,http \
+--initialize-at-build-time=org.conscrypt,\
+  org.slf4j.LoggerFactory,\
+  org.junit.platform.engine.TestTag


### PR DESCRIPTION
Tested this out locally with java-pubsub and java-firestore. Following this [naming convention](https://docs.oracle.com/en/graalvm/enterprise/21/docs/reference-manual/native-image/BuildConfiguration/) allows us to aggregate configurations in separate native-image.properties files. 

TODO:
- Remove these configurations from java-core/native-image-support. 
 