### PR TITLE
feat: relocate netty and gax substitutions from java-core

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/nativeimage/substitutions/NettyInternalLoggerFactorySubstitutions.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/nativeimage/substitutions/NettyInternalLoggerFactorySubstitutions.java
@@ -45,6 +45,8 @@ import java.util.function.BooleanSupplier;
     onlyWith = NettyInternalLoggerFactorySubstitutions.OnlyIfInClassPath.class)
 final class NettyInternalLoggerFactorySubstitutions {
 
+  private NettyInternalLoggerFactorySubstitutions(){}
+
   @Substitute
   private static InternalLoggerFactory newDefaultFactory(String name) {
     return JdkLoggerFactory.INSTANCE;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/nativeimage/substitutions/NettyInternalLoggerFactorySubstitutions.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/nativeimage/substitutions/NettyInternalLoggerFactorySubstitutions.java
@@ -45,7 +45,7 @@ import java.util.function.BooleanSupplier;
     onlyWith = NettyInternalLoggerFactorySubstitutions.OnlyIfInClassPath.class)
 final class NettyInternalLoggerFactorySubstitutions {
 
-  private NettyInternalLoggerFactorySubstitutions(){}
+  private NettyInternalLoggerFactorySubstitutions() {}
 
   @Substitute
   private static InternalLoggerFactory newDefaultFactory(String name) {

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/nativeimage/substitutions/NettyInternalLoggerFactorySubstitutions.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/nativeimage/substitutions/NettyInternalLoggerFactorySubstitutions.java
@@ -1,17 +1,31 @@
 /*
  * Copyright 2022 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 package com.google.api.gax.grpc.nativeimage.substitutions;

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/nativeimage/substitutions/NettyInternalLoggerFactorySubstitutions.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/nativeimage/substitutions/NettyInternalLoggerFactorySubstitutions.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.api.gax.grpc.nativeimage.substitutions;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLoggerFactory;
+import io.grpc.netty.shaded.io.netty.util.internal.logging.JdkLoggerFactory;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Substitutions for {@link InternalLoggerFactory} which are needed to avoid dynamic loading of
+ * logging library.
+ */
+@TargetClass(
+    className = "io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLoggerFactory",
+    onlyWith = NettyInternalLoggerFactorySubstitutions.OnlyIfInClassPath.class)
+final class NettyInternalLoggerFactorySubstitutions {
+
+  @Substitute
+  private static InternalLoggerFactory newDefaultFactory(String name) {
+    return JdkLoggerFactory.INSTANCE;
+  }
+
+  static class OnlyIfInClassPath implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+      try {
+        // Note: Set initialize = false to avoid initializing the class when looking it up.
+        Class.forName(
+            "io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLoggerFactory",
+            false,
+            Thread.currentThread().getContextClassLoader());
+        return true;
+      } catch (ClassNotFoundException e) {
+        return false;
+      }
+    }
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/nativeimage/substitutions/GaxPropertiesSubstitutions.java
+++ b/gax/src/main/java/com/google/api/gax/nativeimage/substitutions/GaxPropertiesSubstitutions.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.api.gax.nativeimage.substitutions;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.RecomputeFieldValue.Kind;
+import com.oracle.svm.core.annotate.TargetClass;
+import java.util.function.BooleanSupplier;
+
+/**
+ * This file contains the GaxProperties substitution to correctly set the Java language string in
+ * API call headers for Native Image users.
+ */
+@TargetClass(
+    className = "com.google.api.gax.core.GaxProperties",
+    onlyWith = GaxPropertiesSubstitutions.OnlyIfInClassPath.class)
+final class GaxPropertiesSubstitutions {
+
+  @Alias
+  @RecomputeFieldValue(kind = Kind.FromAlias)
+  private static String JAVA_VERSION = System.getProperty("java.version") + "-graalvm";
+
+  private GaxPropertiesSubstitutions() {}
+
+  static class OnlyIfInClassPath implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+      try {
+        // Note: Set initialize = false to avoid initializing the class when looking it up.
+        Class.forName(
+            "com.google.api.gax.core.GaxProperties",
+            false,
+            Thread.currentThread().getContextClassLoader());
+        return true;
+      } catch (ClassNotFoundException e) {
+        return false;
+      }
+    }
+  }
+}

--- a/gax/src/main/java/com/google/api/gax/nativeimage/substitutions/GaxPropertiesSubstitutions.java
+++ b/gax/src/main/java/com/google/api/gax/nativeimage/substitutions/GaxPropertiesSubstitutions.java
@@ -1,17 +1,31 @@
 /*
  * Copyright 2022 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 package com.google.api.gax.nativeimage.substitutions;


### PR DESCRIPTION
Substitutions is a mechanism that allow us to modify native code without actually touching the source code. As described [here](https://medium.com/graalvm/instant-netty-startup-using-graalvm-native-image-generation-ed6f14ff7692#4271), during the build process, Substrate VM compiles bytecode into native code using the Graal compiler which then lets us make use of the substitutions. 