### PR TITLE
feat: relocate ApiClientSubstitutions from java-core to gax

### DIFF
--- a/gax/src/main/java/com/google/api/gax/nativeimage/substitutions/ApiClientVersionSubstitutions.java
+++ b/gax/src/main/java/com/google/api/gax/nativeimage/substitutions/ApiClientVersionSubstitutions.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.api.gax.nativeimage.substitutions;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import java.util.function.BooleanSupplier;
+
+/** Substitution for setting Java version correctly in the Google Java Http Client. */
+@TargetClass(
+    className =
+        "com.google.api.client.googleapis.services.AbstractGoogleClientRequest$ApiClientVersion",
+    onlyWith = ApiClientVersionSubstitutions.OnlyIfInClassPath.class)
+final class ApiClientVersionSubstitutions {
+
+  @Alias private String versionString;
+
+  @Substitute
+  public String toString() {
+    String[] tokens = versionString.split(" ");
+
+    if (tokens.length > 0 && tokens[0].startsWith("gl-java")) {
+      tokens[0] += "-graalvm";
+      return String.join(" ", tokens);
+    } else {
+      return versionString;
+    }
+  }
+
+  private ApiClientVersionSubstitutions() {}
+
+  static class OnlyIfInClassPath implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+      try {
+        // Note: Set initialize = false to avoid initializing the class when looking it up.
+        Class.forName(
+            "com.google.api.client.googleapis.services."
+                + "AbstractGoogleClientRequest$ApiClientVersion",
+            false,
+            Thread.currentThread().getContextClassLoader());
+        return true;
+      } catch (ClassNotFoundException e) {
+        return false;
+      }
+    }
+  }
+}

--- a/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
+++ b/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
@@ -2,4 +2,5 @@ Args = --allow-incomplete-classpath \
 --enable-url-protocols=https,http \
 --initialize-at-build-time=org.conscrypt,\
   org.slf4j.LoggerFactory,\
-  org.junit.platform.engine.TestTag
+  org.junit.platform.engine.TestTag \
+--initialize-at-run-time=com.google.api.client.googleapis.services.AbstractGoogleClientRequest$ApiClientVersion


### PR DESCRIPTION
https://github.com/googleapis/google-api-java-client doesn't support java 8 so moving ApiClientSubstitutions to GAX instead. 