### PR TITLE
feat: relocate resource-config from java-core to gax

### DIFF
--- a/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/resource-config.json
+++ b/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/resource-config.json
@@ -1,0 +1,9 @@
+{
+  "resources":[
+    {"pattern":"\\QMETA-INF/native/libio_grpc_netty_shaded_netty_tcnative_linux_x86_64.so\\E"},
+    {"pattern":"\\QMETA-INF/native/libio_grpc_netty_shaded_netty_transport_native_epoll_x86_64.so\\E"},
+    {"pattern":"\\QMETA-INF/services/io.grpc.LoadBalancerProvider\\E"},
+    {"pattern":"\\QMETA-INF/services/io.grpc.ManagedChannelProvider\\E"},
+    {"pattern":"\\QMETA-INF/services/io.grpc.NameResolverProvider\\E"}],
+  "bundles":[]
+}

--- a/gax/src/main/resources/META-INF/native-image/com.google.api/gax/resource-config.json
+++ b/gax/src/main/resources/META-INF/native-image/com.google.api/gax/resource-config.json
@@ -1,0 +1,6 @@
+{
+  "resources":[
+    {"pattern":"\\QMETA-INF/services/jdk.vm.ci.services.JVMCIServiceLocator\\E"},
+    {"pattern":"\\Qdependencies.properties\\E"}],
+  "bundles":[]
+}


### PR DESCRIPTION
These resource configurations were initially all in the same config file. This PR splits them up according to grpc-related and general config.
TODO:
- Remove the[ resource-config.json file from java-core](https://github.com/googleapis/java-core/blob/main/native-image-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-core/resource-config.json) once this PR is merged and released.  

