### PR TITLE
fix: use graal-sdk 21.3.2 

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -71,7 +71,7 @@ maven.com_google_http_client_google_http_client_gson=com.google.http-client:goog
 maven.org_codehaus_mojo_animal_sniffer_annotations=org.codehaus.mojo:animal-sniffer-annotations:1.18
 maven.javax_annotation_javax_annotation_api=javax.annotation:javax.annotation-api:1.3.2
 maven.org_graalvm_nativeimage_svm=org.graalvm.nativeimage:svm:22.0.0.2
-maven.org_graalvm_sdk=org.graalvm.sdk:graal-sdk:22.0.0.2
+maven.org_graalvm_sdk=org.graalvm.sdk:graal-sdk:21.3.2
 
 # Testing maven artifacts
 maven.junit_junit=junit:junit:4.13.2


### PR DESCRIPTION
Downgrading to graal-sdk 21.3.2 to address CVE https://security.snyk.io/vuln/SNYK-JAVA-ORGGRAALVMSDK-2769618. We're unable to use graal-sdk 22.1 at the moment because of https://github.com/googleapis/gax-java/pull/1669.