### PR TITLE
chore: remove AutomaticFeature annotation

### DIFF
--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/nativeimage/GrpcNettyFeature.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/nativeimage/GrpcNettyFeature.java
@@ -35,11 +35,9 @@ import static com.google.api.gax.nativeimage.NativeImageUtils.registerClassHiera
 import static com.google.api.gax.nativeimage.NativeImageUtils.registerForReflectiveInstantiation;
 import static com.google.api.gax.nativeimage.NativeImageUtils.registerForUnsafeFieldAccess;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
 import org.graalvm.nativeimage.hosted.Feature;
 
 /** Configures Native Image settings for the grpc-netty-shaded dependency. */
-@AutomaticFeature
 final class GrpcNettyFeature implements Feature {
 
   private static final String GRPC_NETTY_SHADED_CLASS =

--- a/gax-grpc/src/main/java/com/google/api/gax/grpc/nativeimage/ProtobufMessageFeature.java
+++ b/gax-grpc/src/main/java/com/google/api/gax/grpc/nativeimage/ProtobufMessageFeature.java
@@ -31,7 +31,6 @@
 package com.google.api.gax.grpc.nativeimage;
 
 import com.google.api.gax.nativeimage.NativeImageUtils;
-import com.oracle.svm.core.annotate.AutomaticFeature;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
@@ -44,7 +43,6 @@ import org.graalvm.nativeimage.hosted.RuntimeReflection;
  * <p>This feature is only needed if you need to access proto objects reflectively (such as
  * printing/logging proto objects).
  */
-@AutomaticFeature
 final class ProtobufMessageFeature implements Feature {
 
   // Proto classes to check on the classpath.

--- a/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/native-image.properties
+++ b/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/native-image.properties
@@ -7,4 +7,6 @@ Args = --initialize-at-run-time=io.grpc.netty.shaded.io.netty.handler.ssl.OpenSs
     io.grpc.netty.shaded.io.netty.channel.epoll,\
     io.grpc.netty.shaded.io.netty.channel.unix,\
     io.grpc.netty.shaded.io.netty.handler.ssl,\
-    io.grpc.internal.RetriableStream
+    io.grpc.internal.RetriableStream \
+  --features=com.google.api.gax.grpc.nativeimage.ProtobufMessageFeature,\
+  com.google.api.gax.grpc.nativeimage.GrpcNettyFeature

--- a/gax/src/main/java/com/google/api/gax/nativeimage/GoogleJsonClientFeature.java
+++ b/gax/src/main/java/com/google/api/gax/nativeimage/GoogleJsonClientFeature.java
@@ -32,14 +32,12 @@ package com.google.api.gax.nativeimage;
 
 import static com.google.api.gax.nativeimage.NativeImageUtils.registerClassForReflection;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
 import com.oracle.svm.core.configure.ResourcesRegistry;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.impl.ConfigurationCondition;
 
 /** Configures Native Image settings for the Google JSON Client. */
-@AutomaticFeature
 final class GoogleJsonClientFeature implements Feature {
 
   private static final String GOOGLE_API_CLIENT_CLASS =

--- a/gax/src/main/java/com/google/api/gax/nativeimage/OpenCensusFeature.java
+++ b/gax/src/main/java/com/google/api/gax/nativeimage/OpenCensusFeature.java
@@ -32,11 +32,9 @@ package com.google.api.gax.nativeimage;
 
 import static com.google.api.gax.nativeimage.NativeImageUtils.registerForReflectiveInstantiation;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
 import org.graalvm.nativeimage.hosted.Feature;
 
 /** Registers reflection usage in OpenCensus libraries. */
-@AutomaticFeature
 final class OpenCensusFeature implements Feature {
 
   private static final String TAGS_COMPONENT_CLASS = "io.opencensus.impl.tags.TagsComponentImpl";

--- a/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
+++ b/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
@@ -3,4 +3,6 @@ Args = --allow-incomplete-classpath \
 --initialize-at-build-time=org.conscrypt,\
   org.slf4j.LoggerFactory,\
   org.junit.platform.engine.TestTag \
---initialize-at-run-time=com.google.api.client.googleapis.services.AbstractGoogleClientRequest$ApiClientVersion
+--initialize-at-run-time=com.google.api.client.googleapis.services.AbstractGoogleClientRequest$ApiClientVersion \
+  --features=com.google.api.gax.nativeimage.OpenCensusFeature,\
+  com.google.api.gax.nativeimage.GoogleJsonClientFeature


### PR DESCRIPTION
This work contributes towards removing SVM as a dependency.
Testing:
Conducted small experiment with java-bigquery where AutomaticFeature in `GrpcNettyFeature` and `ProtobufMessageFeature` was replaced with `--features`. The resulting build showed the following features still being included (as expected):
```
 6 user-provided feature(s)
  - com.google.api.gax.grpc.nativeimage.GrpcNettyFeature
  - com.google.api.gax.grpc.nativeimage.ProtobufMessageFeature
  - com.google.api.gax.nativeimage.GoogleJsonClientFeature
  - com.google.api.gax.nativeimage.OpenCensusFeature
  - com.oracle.svm.thirdparty.gson.GsonFeature
  - org.graalvm.junit.platform.JUnitPlatformFeature
``` 
