### PR TITLE
deps: trying perfmark 0.23.0. DO NOT MERGE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,14 @@ configure(javaProjects) {
   // Dependencies
   // ------------
 
+  dependencies {
+    implementation('io.perfmark:perfmark-api') {
+      version {
+        strictly '0.23.0'
+      }
+    }
+  }
+
   repositories {
     mavenLocal()
     mavenCentral()


### PR DESCRIPTION
Trying to see the impact of perfmark 0.23.0 in dependencies.

https://github.com/googleapis/java-cloud-bom/pull/4463#issuecomment-1144348779

```
~/gax-java $ ./gradlew -p gax-grpc dependencies

> Task :gax-grpc:dependencies

...

compileClasspath - Compile classpath for source set 'main'.
...
+--- io.grpc:grpc-api:1.46.0
|    +--- io.grpc:grpc-context:1.46.0
|    +--- com.google.code.findbugs:jsr305:3.0.2
|    \--- com.google.errorprone:error_prone_annotations:2.10.0 -> 2.11.0
+--- org.threeten:threetenbp:1.5.0
+--- com.google.auto.value:auto-value:1.9
+--- org.graalvm.sdk:graal-sdk:22.1.0
+--- io.perfmark:perfmark-api:{strictly 0.23.0} -> 0.23.0
...
```