### PR TITLE
ci: maven options to suppress unnecessary outputs

### DIFF
--- a/.kokoro/maven-build.sh
+++ b/.kokoro/maven-build.sh
@@ -37,7 +37,7 @@ fi
 echo "Compiling using Java:"
 java -version
 echo
-mvn clean install
+mvn -V -B -ntp clean install
 
 # We ensure the generated class files are compatible with Java 8
 if [ ! -z "${JAVA8_HOME}" ]; then
@@ -58,4 +58,4 @@ fi
 
 echo
 # run tests in Java 8 with the source compiled in Java 11
-mvn surefire:test
+mvn -V -B -ntp surefire:test


### PR DESCRIPTION
The Maven options to suppress unnecessary outputs. These options are standard in googleapis/java-* builds.

![image](https://user-images.githubusercontent.com/28604/174103157-28ce65c4-755c-45ad-a25b-c758a75a801b.png)
