### PR TITLE
chore: disable requiresStrictStatusChecks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -6,7 +6,7 @@ branchProtectionRules:
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
     requiresCodeOwnerReviews: true
-    requiresStrictStatusChecks: true
+    requiresStrictStatusChecks: false
     requiredStatusCheckContexts:
       - bazel
       - units (8)


### PR DESCRIPTION
We don't want to require branches to be up to date before merging into main.