### PR TITLE
fix: remove runtime initialization of logger classes

### DIFF
--- a/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/native-image.properties
+++ b/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/native-image.properties
@@ -3,8 +3,6 @@ Args = --initialize-at-run-time=io.grpc.netty.shaded.io.netty.handler.ssl.OpenSs
     io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateVerifier,\
     io.grpc.netty.shaded.io.netty.internal.tcnative.SSLPrivateKeyMethod,\
     io.grpc.netty.shaded.io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod,\
-    io.grpc.netty.shaded.io.netty.util.internal.logging.Slf4JLoggerFactory,\
-    io.grpc.netty.shaded.io.netty.util.internal.logging.Log4JLogger,\
     io.grpc.netty.shaded.io.grpc.netty,\
     io.grpc.netty.shaded.io.netty.channel.epoll,\
     io.grpc.netty.shaded.io.netty.channel.unix,\


### PR DESCRIPTION
Fixes #1696

gax-grpc transitively invokes the `io.netty.util.internal.PlatformDependent` class which leads to InternalLoggerFactory being initialized. `InternalLoggerFactory` . As described [here](https://github.com/netty/netty/blob/c08beb543a6b8db0c7f3cee225042361b4025e4c/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java#L36), `InternalLoggerFactory` first chooses `Slf4jLoggerFactory` as the default logger factory and if slf4j is not present then it chooses `Log4JLoggerFactory` and so on. This results in `io.grpc.netty.shaded.io.netty.util.internal.logging.Slf4JLoggerFactory` and `io.grpc.netty.shaded.io.netty.util.internal.logging.Log4JLogger` being initialized and can sometimes lead to the following warning by graal during native image compilation (when slf4j is not present on the classpath):

```
Warning: class initialization of class io.grpc.netty.shaded.io.netty.util.internal.logging.Slf4JLoggerFactory failed with exception java.lang.NoClassDefFoundError: Could not initialize class io.grpc.netty.shaded.io.netty.util.internal.logging.Slf4JLoggerFactory. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.grpc.netty.shaded.io.netty.util.internal.logging.Slf4JLoggerFactory to explicitly request delayed initialization of this class.
```


To avoid this warning, we initially followed the instructions to initialize these classes at runtime. While this behaves fine when there is no slf4j or log4j dependency on the classpath, this breaks behavior when these logging dependencies are actually added. 

Reproducer: https://github.com/mpeddada1/simple-netty-test/blob/main/README.md 
