### PR TITLE
feat: Add numeric enum support.

### DIFF
--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoMessageResponseParser.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoMessageResponseParser.java
@@ -79,7 +79,7 @@ public class ProtoMessageResponseParser<ResponseT extends Message>
   /* {@inheritDoc} */
   @Override
   public String serialize(ResponseT response) {
-    return ProtoRestSerializer.create(defaultRegistry).toJson(response);
+    return ProtoRestSerializer.create(defaultRegistry).toJson(response, false);
   }
 
   // Convert to @AutoValue if this class gets more complicated

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoRestSerializer.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoRestSerializer.java
@@ -35,6 +35,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.TypeRegistry;
 import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.JsonFormat.Printer;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.List;
@@ -69,12 +70,19 @@ public class ProtoRestSerializer<RequestT extends Message> {
    * protobuf native JSON formatter.
    *
    * @param message a message to serialize
+   * @param numericEnum a boolean flag that determine if enum values should be serialized to number
+   *     or not
    * @throws InvalidProtocolBufferException if failed to serialize the protobuf message to JSON
    *     format
    */
-  String toJson(RequestT message) {
+  String toJson(RequestT message, boolean numericEnum) {
     try {
-      return JsonFormat.printer().usingTypeRegistry(registry).print(message);
+      Printer printer = JsonFormat.printer().usingTypeRegistry(registry);
+      if (numericEnum) {
+        return printer.printingEnumsAsInts().print(message);
+      } else {
+        return printer.print(message);
+      }
     } catch (InvalidProtocolBufferException e) {
       throw new RestSerializationException("Failed to serialize message to JSON", e);
     }
@@ -134,10 +142,11 @@ public class ProtoRestSerializer<RequestT extends Message> {
   /**
    * Serializes a message to a request body in a form of JSON-encoded string.
    *
-   * @param fieldName a name of a request message field this message belongs to
    * @param fieldValue a field value to serialize
+   * @param numericEnum a boolean flag that determine if enum values should be serialized to number
+   *     or not
    */
-  public String toBody(String fieldName, RequestT fieldValue) {
-    return toJson(fieldValue);
+  public String toBody(RequestT fieldValue, boolean numericEnum) {
+    return toJson(fieldValue, numericEnum);
   }
 }

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoRestSerializer.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoRestSerializer.java
@@ -142,6 +142,16 @@ public class ProtoRestSerializer<RequestT extends Message> {
   /**
    * Serializes a message to a request body in a form of JSON-encoded string.
    *
+   * @param fieldName a name of a request message field this message belongs to
+   * @param fieldValue a field value to serialize
+   */
+  public String toBody(String fieldName, RequestT fieldValue) {
+    return toJson(fieldValue, false);
+  }
+
+  /**
+   * Serializes a message to a request body in a form of JSON-encoded string.
+   *
    * @param fieldValue a field value to serialize
    * @param numericEnum a boolean flag that determine if enum values should be serialized to number
    *     or not

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoRestSerializer.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoRestSerializer.java
@@ -152,11 +152,11 @@ public class ProtoRestSerializer<RequestT extends Message> {
   /**
    * Serializes a message to a request body in a form of JSON-encoded string.
    *
+   * @param fieldName a name of a request message field this message belongs to
    * @param fieldValue a field value to serialize
    * @param numericEnum a boolean flag that determine if enum values should be serialized to number
-   *     or not
    */
-  public String toBody(RequestT fieldValue, boolean numericEnum) {
+  public String toBody(String fieldName, RequestT fieldValue, boolean numericEnum) {
     return toJson(fieldValue, numericEnum);
   }
 }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonClientInterceptorTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonClientInterceptorTest.java
@@ -123,7 +123,7 @@ public class HttpJsonClientInterceptorTest {
                   .setRequestBodyExtractor(
                       request ->
                           ProtoRestSerializer.create()
-                              .toBody("*", request.toBuilder().clearName().build()))
+                              .toBody(request.toBuilder().clearName().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Field>newBuilder()

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonClientInterceptorTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonClientInterceptorTest.java
@@ -123,7 +123,7 @@ public class HttpJsonClientInterceptorTest {
                   .setRequestBodyExtractor(
                       request ->
                           ProtoRestSerializer.create()
-                              .toBody(request.toBuilder().clearName().build(), false))
+                              .toBody("*", request.toBuilder().clearName().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Field>newBuilder()

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonDirectCallableTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonDirectCallableTest.java
@@ -83,7 +83,7 @@ public class HttpJsonDirectCallableTest {
                   .setRequestBodyExtractor(
                       request ->
                           ProtoRestSerializer.create()
-                              .toBody(request.toBuilder().clearName().build(), false))
+                              .toBody("*", request.toBuilder().clearName().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Field>newBuilder()

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonDirectCallableTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonDirectCallableTest.java
@@ -83,7 +83,7 @@ public class HttpJsonDirectCallableTest {
                   .setRequestBodyExtractor(
                       request ->
                           ProtoRestSerializer.create()
-                              .toBody("*", request.toBuilder().clearName().build()))
+                              .toBody(request.toBuilder().clearName().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Field>newBuilder()

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonDirectServerStreamingCallableTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonDirectServerStreamingCallableTest.java
@@ -92,7 +92,7 @@ public class HttpJsonDirectServerStreamingCallableTest {
                   .setRequestBodyExtractor(
                       request ->
                           ProtoRestSerializer.create()
-                              .toBody("*", request.toBuilder().clearBlue().clearRed().build()))
+                              .toBody(request.toBuilder().clearBlue().clearRed().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Money>newBuilder()

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonDirectServerStreamingCallableTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonDirectServerStreamingCallableTest.java
@@ -92,7 +92,8 @@ public class HttpJsonDirectServerStreamingCallableTest {
                   .setRequestBodyExtractor(
                       request ->
                           ProtoRestSerializer.create()
-                              .toBody(request.toBuilder().clearBlue().clearRed().build(), false))
+                              .toBody(
+                                  "*", request.toBuilder().clearBlue().clearRed().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Money>newBuilder()

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoMessageRequestFormatterTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoMessageRequestFormatterTest.java
@@ -79,7 +79,7 @@ public class ProtoMessageRequestFormatterTest {
             .setRequestBodyExtractor(
                 request -> {
                   ProtoRestSerializer<Field> serializer = ProtoRestSerializer.create();
-                  return serializer.toBody(request, false);
+                  return serializer.toBody("field", request, false);
                 })
             .setAdditionalPaths("/api/v1/names/{name=field_name1/**}/hello")
             .build();

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoMessageRequestFormatterTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoMessageRequestFormatterTest.java
@@ -79,7 +79,7 @@ public class ProtoMessageRequestFormatterTest {
             .setRequestBodyExtractor(
                 request -> {
                   ProtoRestSerializer<Field> serializer = ProtoRestSerializer.create();
-                  return serializer.toBody("field", request);
+                  return serializer.toBody(request, false);
                 })
             .setAdditionalPaths("/api/v1/names/{name=field_name1/**}/hello")
             .build();

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
@@ -183,7 +183,7 @@ public class ProtoRestSerializerTest {
 
   @Test
   public void toBody() {
-    String body = requestSerializer.toBody(field, false);
+    String body = requestSerializer.toBody("bodyField1", field, false);
     Truth.assertThat(body).isEqualTo(fieldJson);
   }
 }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
@@ -49,6 +49,7 @@ public class ProtoRestSerializerTest {
   private Field field;
   private String fieldJson;
   private String fieldJsonNumericEnum;
+  private String fieldJsonUnknownNumericEnum;
 
   @Before
   public void setUp() {
@@ -85,6 +86,18 @@ public class ProtoRestSerializerTest {
             + "    \"name\": \"opt_name2\"\n"
             + "  }]\n"
             + "}";
+
+    fieldJsonUnknownNumericEnum =
+        "{\n"
+            + "  \"cardinality\": 7,\n"
+            + "  \"number\": 2,\n"
+            + "  \"name\": \"field_name1\",\n"
+            + "  \"options\": [{\n"
+            + "    \"name\": \"opt_name1\"\n"
+            + "  }, {\n"
+            + "    \"name\": \"opt_name2\"\n"
+            + "  }]\n"
+            + "}";
   }
 
   @Test
@@ -102,15 +115,24 @@ public class ProtoRestSerializerTest {
   @Test
   public void fromJson_numericEnumTrue() {
     Field fieldFromJson =
-        requestSerializer.fromJson(new StringReader(fieldJson), Field.newBuilder());
+        requestSerializer.fromJson(new StringReader(fieldJsonNumericEnum), Field.newBuilder());
     Truth.assertThat(fieldFromJson).isEqualTo(field);
   }
 
   @Test
   public void fromJson_numericEnumFalse() {
     Field fieldFromJson =
-        requestSerializer.fromJson(new StringReader(fieldJsonNumericEnum), Field.newBuilder());
+        requestSerializer.fromJson(new StringReader(fieldJson), Field.newBuilder());
     Truth.assertThat(fieldFromJson).isEqualTo(field);
+  }
+
+  @Test
+  public void fromJson_numericEnumTrueAndUnknownEnum() {
+    Field expected = field.toBuilder().setCardinalityValue(7).build();
+    Field fieldFromJson =
+        requestSerializer.fromJson(
+            new StringReader(fieldJsonUnknownNumericEnum), Field.newBuilder());
+    Truth.assertThat(fieldFromJson).isEqualTo(expected);
   }
 
   @Test

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
@@ -48,6 +48,7 @@ public class ProtoRestSerializerTest {
   private ProtoRestSerializer<Field> requestSerializer;
   private Field field;
   private String fieldJson;
+  private String fieldJsonNumericEnum;
 
   @Before
   public void setUp() {
@@ -72,18 +73,43 @@ public class ProtoRestSerializerTest {
             + "    \"name\": \"opt_name2\"\n"
             + "  }]\n"
             + "}";
+
+    fieldJsonNumericEnum =
+        "{\n"
+            + "  \"cardinality\": 1,\n"
+            + "  \"number\": 2,\n"
+            + "  \"name\": \"field_name1\",\n"
+            + "  \"options\": [{\n"
+            + "    \"name\": \"opt_name1\"\n"
+            + "  }, {\n"
+            + "    \"name\": \"opt_name2\"\n"
+            + "  }]\n"
+            + "}";
   }
 
   @Test
-  public void toJson() {
-    String fieldToJson = requestSerializer.toJson(field);
+  public void toJson_numericEnumTrue() {
+    String fieldToJson = requestSerializer.toJson(field, true);
+    Truth.assertThat(fieldToJson).isEqualTo(fieldJsonNumericEnum);
+  }
+
+  @Test
+  public void toJson_numericEnumFalse() {
+    String fieldToJson = requestSerializer.toJson(field, false);
     Truth.assertThat(fieldToJson).isEqualTo(fieldJson);
   }
 
   @Test
-  public void fromJson() {
+  public void fromJson_numericEnumTrue() {
     Field fieldFromJson =
         requestSerializer.fromJson(new StringReader(fieldJson), Field.newBuilder());
+    Truth.assertThat(fieldFromJson).isEqualTo(field);
+  }
+
+  @Test
+  public void fromJson_numericEnumFalse() {
+    Field fieldFromJson =
+        requestSerializer.fromJson(new StringReader(fieldJsonNumericEnum), Field.newBuilder());
     Truth.assertThat(fieldFromJson).isEqualTo(field);
   }
 
@@ -135,7 +161,7 @@ public class ProtoRestSerializerTest {
 
   @Test
   public void toBody() {
-    String body = requestSerializer.toBody("bodyField1", field);
+    String body = requestSerializer.toBody(field, false);
     Truth.assertThat(body).isEqualTo(fieldJson);
   }
 }


### PR DESCRIPTION
Add numeric enum support based on go/actools-numeric-enum-impl.
Add a new overloaded `toBody` method that support serializing request object to Json with numeric enums.