### PR TITLE
fix: Exclude error_prone_annotations from guava.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,12 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>31.1-jre</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.opencensus</groupId>


### PR DESCRIPTION
Outdated error_prone_annotations version in guava is causing the maven enforcer plugin to fail, remove it to pass the check. 