### PR TITLE
fix(java): initialize CertificateCompressionAlgo netty class at run-time

### DIFF
--- a/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/native-image.properties
+++ b/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/native-image.properties
@@ -3,6 +3,7 @@ Args = --initialize-at-run-time=io.grpc.netty.shaded.io.netty.handler.ssl.OpenSs
     io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateVerifier,\
     io.grpc.netty.shaded.io.netty.internal.tcnative.SSLPrivateKeyMethod,\
     io.grpc.netty.shaded.io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod,\
+    io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateCompressionAlgo,\
     io.grpc.netty.shaded.io.grpc.netty,\
     io.grpc.netty.shaded.io.netty.channel.epoll,\
     io.grpc.netty.shaded.io.netty.channel.unix,\


### PR DESCRIPTION
Related to #1740. 