### PR TITLE
ci: re-enable native image downstream check

### DIFF
--- a/.kokoro/downstream-client-library-check.sh
+++ b/.kokoro/downstream-client-library-check.sh
@@ -93,5 +93,7 @@ echo "Modification on the shared dependencies BOM:"
 git diff
 echo
 
+export INTEGRATION_TEST_ARGS="-Denforcer.skip=true"
+
 # This reads the JOB_TYPE environmental variable ("test" or "graalvm")
 .kokoro/build.sh

--- a/.kokoro/downstream-client-library-check.sh
+++ b/.kokoro/downstream-client-library-check.sh
@@ -94,10 +94,4 @@ git diff
 echo
 
 # This reads the JOB_TYPE environmental variable ("test" or "graalvm")
-mvn install -B -V -ntp \
-    -DskipTests=true \
-    -Dclirr.skip=true \
-    -Denforcer.skip=true \
-    -Dmaven.javadoc.skip=true \
-    -Dgcloud.download.skip=true \
-    -T 1C
+.kokoro/build.sh


### PR DESCRIPTION
The native image downstream checks are currently not running in gax (for example: https://github.com/googleapis/gax-java/runs/7621662093?check_suite_focus=true).  This PR restores the original change from https://github.com/googleapis/gax-java/pull/1681 to address this. 

Fixes #1686