### PR TITLE
fix(httpjson): handle message derived query params

### DIFF
--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/JsonSerializableMessages.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/JsonSerializableMessages.java
@@ -1,0 +1,5 @@
+package com.google.api.gax.httpjson;
+
+public class JsonSerializableMessages {
+
+}

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/JsonSerializableMessages.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/JsonSerializableMessages.java
@@ -1,5 +1,0 @@
-package com.google.api.gax.httpjson;
-
-public class JsonSerializableMessages {
-
-}

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoRestSerializer.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoRestSerializer.java
@@ -63,6 +63,9 @@ import java.util.Set;
 @BetaApi
 public class ProtoRestSerializer<RequestT extends Message> {
   private final TypeRegistry registry;
+
+  // well-known types obtained from
+  // https://github.com/googleapis/gapic-showcase/blob/fe414784c18878d704b884348d84c68fd6b87466/util/genrest/resttools/populatefield.go#L27
   private static final Set<Class<GeneratedMessageV3>> jsonSerializableMessages = new HashSet(
       Arrays.asList(
           com.google.protobuf.BoolValue.class,
@@ -227,7 +230,8 @@ public class ProtoRestSerializer<RequestT extends Message> {
    * @param fieldValue a field value to serialize
    */
   public String toQueryParamValue(Object fieldValue) {
-    if (fieldValue instanceof GeneratedMessageV3) {
+    // This will match with message types that are serializable (e.g. FieldMask)
+    if (fieldValue instanceof GeneratedMessageV3 && !isNonSerializableMessageValue(fieldValue)) {
       return toJson(((GeneratedMessageV3) fieldValue).toBuilder(), false)
           .replaceAll("^\"", "")
           .replaceAll("\"$", "");

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoRestSerializer.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoRestSerializer.java
@@ -30,19 +30,13 @@
 package com.google.api.gax.httpjson;
 
 import com.google.api.core.BetaApi;
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.FieldDescriptor;
-import com.google.protobuf.DoubleValue;
-import com.google.protobuf.FloatValue;
 import com.google.protobuf.GeneratedMessageV3;
-import com.google.protobuf.Int64Value;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageOrBuilder;
 import com.google.protobuf.TypeRegistry;
-import com.google.protobuf.UInt32Value;
-import com.google.protobuf.UInt64Value;
 import com.google.protobuf.util.JsonFormat;
 import com.google.protobuf.util.JsonFormat.Printer;
 import java.io.IOException;
@@ -66,24 +60,25 @@ public class ProtoRestSerializer<RequestT extends Message> {
 
   // well-known types obtained from
   // https://github.com/googleapis/gapic-showcase/blob/fe414784c18878d704b884348d84c68fd6b87466/util/genrest/resttools/populatefield.go#L27
-  private static final Set<Class<GeneratedMessageV3>> jsonSerializableMessages = new HashSet(
-      Arrays.asList(
-          com.google.protobuf.BoolValue.class,
-          com.google.protobuf.BytesValue.class,
-          com.google.protobuf.DoubleValue.class,
-          com.google.protobuf.Duration.class,
-          com.google.protobuf.FieldMask.class,
-          com.google.protobuf.FloatValue.class,
-          com.google.protobuf.Int32Value.class,
-          com.google.protobuf.Int64Value.class,
-          com.google.protobuf.StringValue.class,
-          com.google.protobuf.Timestamp.class,
-          com.google.protobuf.UInt32Value.class,
-          com.google.protobuf.UInt64Value.class
-      ));
+  private static final Set<Class<GeneratedMessageV3>> jsonSerializableMessages =
+      new HashSet(
+          Arrays.asList(
+              com.google.protobuf.BoolValue.class,
+              com.google.protobuf.BytesValue.class,
+              com.google.protobuf.DoubleValue.class,
+              com.google.protobuf.Duration.class,
+              com.google.protobuf.FieldMask.class,
+              com.google.protobuf.FloatValue.class,
+              com.google.protobuf.Int32Value.class,
+              com.google.protobuf.Int64Value.class,
+              com.google.protobuf.StringValue.class,
+              com.google.protobuf.Timestamp.class,
+              com.google.protobuf.UInt32Value.class,
+              com.google.protobuf.UInt64Value.class));
 
   private boolean isNonSerializableMessageValue(Object value) {
-    return value instanceof GeneratedMessageV3 && !jsonSerializableMessages.contains(value.getClass());
+    return value instanceof GeneratedMessageV3
+        && !jsonSerializableMessages.contains(value.getClass());
   }
 
   private ProtoRestSerializer(TypeRegistry registry) {
@@ -154,12 +149,14 @@ public class ProtoRestSerializer<RequestT extends Message> {
   }
 
   private void putDecomposedMessageQueryParam(
-      Map<String, List<String>> fields, String fieldName, Object fieldValue
-  ) {
-    for (Map.Entry<FieldDescriptor, Object> fieldEntry : ((GeneratedMessageV3) fieldValue)
-        .getAllFields().entrySet()) {
+      Map<String, List<String>> fields, String fieldName, Object fieldValue) {
+    for (Map.Entry<FieldDescriptor, Object> fieldEntry :
+        ((GeneratedMessageV3) fieldValue).getAllFields().entrySet()) {
       Object value = fieldEntry.getValue();
-      putQueryParam(fields, String.format("%s.%s",fieldName, fieldEntry.getKey().toProto().getName()), fieldEntry.getValue());
+      putQueryParam(
+          fields,
+          String.format("%s.%s", fieldName, fieldEntry.getKey().toProto().getName()),
+          fieldEntry.getValue());
     }
   }
 

--- a/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoRestSerializer.java
+++ b/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ProtoRestSerializer.java
@@ -36,6 +36,7 @@ import com.google.gson.JsonParser;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageOrBuilder;
+import com.google.protobuf.ProtocolMessageEnum;
 import com.google.protobuf.TypeRegistry;
 import com.google.protobuf.util.JsonFormat;
 import com.google.protobuf.util.JsonFormat.Printer;
@@ -157,6 +158,8 @@ public class ProtoRestSerializer<RequestT extends Message> {
         String json = toJson(((Message) fieldValueItem).toBuilder(), true);
         JsonElement parsed = JsonParser.parseString(json);
         putDecomposedMessageQueryParam(fields, fieldName, parsed);
+      } else if (fieldValueItem instanceof ProtocolMessageEnum) {
+        paramValueList.add(String.valueOf(((ProtocolMessageEnum) fieldValueItem).getNumber()));
       } else {
         paramValueList.add(String.valueOf(fieldValueItem));
       }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
@@ -31,9 +31,6 @@
 package com.google.api.gax.httpjson;
 
 import com.google.common.truth.Truth;
-import com.google.longrunning.Operation;
-import com.google.protobuf.Any;
-import com.google.protobuf.ByteString;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Field;
 import com.google.protobuf.Field.Cardinality;
@@ -42,10 +39,8 @@ import com.google.protobuf.FloatValue;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.Option;
 import com.google.protobuf.Timestamp;
-import com.google.rpc.Status;
 import java.io.IOException;
 import java.io.StringReader;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -188,22 +183,7 @@ public class ProtoRestSerializerTest {
         fields, "optName8", FieldMask.newBuilder().addPaths("a.b").addPaths("c.d").build());
     requestSerializer.putQueryParam(fields, "optName9", Int32Value.of(1));
     requestSerializer.putQueryParam(fields, "optName10", FloatValue.of(1.1f));
-    com.google.longrunning.Operation operation =
-        Operation.newBuilder()
-            .setDone(true)
-            .setError(
-                Status.newBuilder()
-                    .addDetails(
-                        Any.newBuilder()
-                            .setValue(ByteString.copyFrom("error-1", Charset.defaultCharset()))
-                            .build())
-                    .addDetails(
-                        Any.newBuilder()
-                            .setValue(ByteString.copyFrom("error-2", Charset.defaultCharset()))
-                            .build()))
-            .setName("test")
-            .build();
-    requestSerializer.putQueryParam(fields, "optName11", operation);
+    requestSerializer.putQueryParam(fields, "optName11", field);
 
     Map<String, List<String>> expectedFields = new HashMap<>();
     expectedFields.put("optName1", Arrays.asList("1"));
@@ -216,9 +196,10 @@ public class ProtoRestSerializerTest {
     expectedFields.put("optName8", Arrays.asList("a.b,c.d"));
     expectedFields.put("optName9", Arrays.asList("1"));
     expectedFields.put("optName10", Arrays.asList("1.1"));
-    expectedFields.put("optName11.name", Arrays.asList("test"));
-    expectedFields.put("optName11.done", Arrays.asList("true"));
-    expectedFields.put("optName11.error.details.value", Arrays.asList("error-1", "error-2"));
+    expectedFields.put("optName11.name", Arrays.asList("field_name1"));
+    expectedFields.put("optName11.number", Arrays.asList("2"));
+    expectedFields.put("optName11.options.name", Arrays.asList("opt_name1", "opt_name2"));
+    expectedFields.put("optName11.cardinality", Arrays.asList("1"));
 
     Truth.assertThat(fields).isEqualTo(expectedFields);
   }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
@@ -31,6 +31,9 @@
 package com.google.api.gax.httpjson;
 
 import com.google.common.truth.Truth;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Field;
 import com.google.protobuf.Field.Cardinality;
@@ -39,8 +42,10 @@ import com.google.protobuf.FloatValue;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.Option;
 import com.google.protobuf.Timestamp;
+import com.google.rpc.Status;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -183,6 +188,16 @@ public class ProtoRestSerializerTest {
         fields, "optName8", FieldMask.newBuilder().addPaths("a.b").addPaths("c.d").build());
     requestSerializer.putQueryParam(fields, "optName9", Int32Value.of(1));
     requestSerializer.putQueryParam(fields, "optName10", FloatValue.of(1.1f));
+    com.google.longrunning.Operation operation = Operation.newBuilder()
+        .setDone(true)
+        .setError(Status.newBuilder()
+            .addDetails(Any.newBuilder().setValue(ByteString.copyFrom("error-1",
+              Charset.defaultCharset())).build())
+            .addDetails(Any.newBuilder().setValue(ByteString.copyFrom("error-2",
+              Charset.defaultCharset())).build()))
+        .setName("test")
+        .build();
+    requestSerializer.putQueryParam(fields, "optName11", operation);
 
     Map<String, List<String>> expectedFields = new HashMap<>();
     expectedFields.put("optName1", Arrays.asList("1"));
@@ -195,6 +210,9 @@ public class ProtoRestSerializerTest {
     expectedFields.put("optName8", Arrays.asList("a.b,c.d"));
     expectedFields.put("optName9", Arrays.asList("1"));
     expectedFields.put("optName10", Arrays.asList("1.1"));
+    expectedFields.put("optName11.name", Arrays.asList("test"));
+    expectedFields.put("optName11.done", Arrays.asList("true"));
+    expectedFields.put("optName11.error.details.value", Arrays.asList("error-1", "error-2"));
 
     Truth.assertThat(fields).isEqualTo(expectedFields);
   }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
@@ -168,22 +168,13 @@ public class ProtoRestSerializerTest {
   }
 
   @Test
-  public void putQueryParam() {
+  public void putQueryParamPrimitive() {
     Map<String, List<String>> fields = new HashMap<>();
     requestSerializer.putQueryParam(fields, "optName1", 1);
     requestSerializer.putQueryParam(fields, "optName2", 0);
     requestSerializer.putQueryParam(fields, "optName3", "three");
     requestSerializer.putQueryParam(fields, "optName4", "");
     requestSerializer.putQueryParam(fields, "optName5", Arrays.asList("four", "five"));
-    requestSerializer.putQueryParam(
-        fields, "optName6", Duration.newBuilder().setSeconds(1).setNanos(1).build());
-    requestSerializer.putQueryParam(
-        fields, "optName7", Timestamp.newBuilder().setSeconds(1).setNanos(1).build());
-    requestSerializer.putQueryParam(
-        fields, "optName8", FieldMask.newBuilder().addPaths("a.b").addPaths("c.d").build());
-    requestSerializer.putQueryParam(fields, "optName9", Int32Value.of(1));
-    requestSerializer.putQueryParam(fields, "optName10", FloatValue.of(1.1f));
-    requestSerializer.putQueryParam(fields, "optName11", field);
 
     Map<String, List<String>> expectedFields = new HashMap<>();
     expectedFields.put("optName1", Arrays.asList("1"));
@@ -191,15 +182,36 @@ public class ProtoRestSerializerTest {
     expectedFields.put("optName3", Arrays.asList("three"));
     expectedFields.put("optName4", Arrays.asList(""));
     expectedFields.put("optName5", Arrays.asList("four", "five"));
-    expectedFields.put("optName6", Arrays.asList("1.000000001s"));
-    expectedFields.put("optName7", Arrays.asList("1970-01-01T00:00:01.000000001Z"));
-    expectedFields.put("optName8", Arrays.asList("a.b,c.d"));
-    expectedFields.put("optName9", Arrays.asList("1"));
-    expectedFields.put("optName10", Arrays.asList("1.1"));
-    expectedFields.put("optName11.name", Arrays.asList("field_name1"));
-    expectedFields.put("optName11.number", Arrays.asList("2"));
-    expectedFields.put("optName11.options.name", Arrays.asList("opt_name1", "opt_name2"));
-    expectedFields.put("optName11.cardinality", Arrays.asList("1"));
+
+    Truth.assertThat(fields).isEqualTo(expectedFields);
+  }
+
+  @Test
+  public void putQueryParamComplexObject() {
+    Map<String, List<String>> fields = new HashMap<>();
+    requestSerializer.putQueryParam(
+        fields, "optName1", Duration.newBuilder().setSeconds(1).setNanos(1).build());
+    requestSerializer.putQueryParam(
+        fields, "optName2", Timestamp.newBuilder().setSeconds(1).setNanos(1).build());
+    requestSerializer.putQueryParam(
+        fields, "optName3", FieldMask.newBuilder().addPaths("a.b").addPaths("c.d").build());
+    requestSerializer.putQueryParam(fields, "optName4", Int32Value.of(1));
+    requestSerializer.putQueryParam(fields, "optName5", FloatValue.of(1.1f));
+    requestSerializer.putQueryParam(fields, "optName6", field);
+    requestSerializer.putQueryParam(
+        fields, "optName7", Arrays.asList(Cardinality.CARDINALITY_REPEATED));
+
+    Map<String, List<String>> expectedFields = new HashMap<>();
+    expectedFields.put("optName1", Arrays.asList("1.000000001s"));
+    expectedFields.put("optName2", Arrays.asList("1970-01-01T00:00:01.000000001Z"));
+    expectedFields.put("optName3", Arrays.asList("a.b,c.d"));
+    expectedFields.put("optName4", Arrays.asList("1"));
+    expectedFields.put("optName5", Arrays.asList("1.1"));
+    expectedFields.put("optName6.name", Arrays.asList("field_name1"));
+    expectedFields.put("optName6.number", Arrays.asList("2"));
+    expectedFields.put("optName6.options.name", Arrays.asList("opt_name1", "opt_name2"));
+    expectedFields.put("optName6.cardinality", Arrays.asList("1"));
+    expectedFields.put("optName7", Arrays.asList("3"));
 
     Truth.assertThat(fields).isEqualTo(expectedFields);
   }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
@@ -31,7 +31,6 @@
 package com.google.api.gax.httpjson;
 
 import com.google.common.truth.Truth;
-import com.google.protobuf.Any;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Field;
 import com.google.protobuf.Field.Cardinality;
@@ -41,6 +40,8 @@ import com.google.protobuf.Int32Value;
 import com.google.protobuf.Option;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.TypeRegistry;
+import com.google.rpc.RetryInfo;
+import com.google.type.Interval;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Arrays;
@@ -198,34 +199,42 @@ public class ProtoRestSerializerTest {
   @Test
   public void putQueryParamComplexObject() {
     Map<String, List<String>> fields = new HashMap<>();
-    Any fieldMask = Any.pack(FieldMask.newBuilder().addPaths("a.b.c").addPaths("d.e.f").build());
-    Any duration1 = Any.pack(Duration.newBuilder().setSeconds(1).setNanos(1).build());
-    Any duration2 = Any.pack(Duration.newBuilder().setSeconds(2).setNanos(2).build());
-    Field value =
-        Field.newBuilder()
-            .setNumber(2)
-            .setName("well_known_container")
-            .addOptions(Option.newBuilder().setName("duration").setValue(duration1).build())
-            .addOptions(Option.newBuilder().setName("duration").setValue(duration2).build())
-            .addOptions(Option.newBuilder().setName("mask").setValue(fieldMask).build())
-            .setCardinality(Cardinality.CARDINALITY_OPTIONAL)
-            .build();
-    requestSerializer.putQueryParam(fields, "object", value);
+    requestSerializer.putQueryParam(fields, "object", field);
 
     Map<String, List<String>> expectedFields = new HashMap<>();
-    expectedFields.put("object.name", Arrays.asList("well_known_container"));
-    expectedFields.put("object.number", Arrays.asList("2"));
-    expectedFields.put("object.options.name", Arrays.asList("duration", "duration", "mask"));
-    expectedFields.put(
-        "object.options.value.value", Arrays.asList("1.000000001s", "2.000000002s", "a.b.c,d.e.f"));
-    // used by JSON parser to obtain descriptors from this type url
-    expectedFields.put(
-        "object.options.value.@type",
-        Arrays.asList(
-            "type.googleapis.com/google.protobuf.Duration",
-            "type.googleapis.com/google.protobuf.Duration",
-            "type.googleapis.com/google.protobuf.FieldMask"));
     expectedFields.put("object.cardinality", Arrays.asList("1"));
+    expectedFields.put("object.name", Arrays.asList("field_name1"));
+    expectedFields.put("object.number", Arrays.asList("2"));
+    expectedFields.put("object.options.name", Arrays.asList("opt_name1", "opt_name2"));
+
+    Truth.assertThat(fields).isEqualTo(expectedFields);
+  }
+
+  @Test
+  public void putQueryParamComplexObjectDuration() {
+    Map<String, List<String>> fields = new HashMap<>();
+    Duration duration = Duration.newBuilder().setSeconds(1).setNanos(1).build();
+    RetryInfo input = RetryInfo.newBuilder().setRetryDelay(duration).build();
+    requestSerializer.putQueryParam(fields, "retry_info", input);
+
+    Map<String, List<String>> expectedFields = new HashMap<>();
+    expectedFields.put("retry_info.retryDelay", Arrays.asList("1.000000001s"));
+
+    Truth.assertThat(fields).isEqualTo(expectedFields);
+  }
+
+  @Test
+  public void putQueryParamComplexObjectTimestamp() {
+    Map<String, List<String>> fields = new HashMap<>();
+    Timestamp start = Timestamp.newBuilder().setSeconds(1).setNanos(1).build();
+    Timestamp end = Timestamp.newBuilder().setSeconds(2).setNanos(2).build();
+    Interval input = Interval.newBuilder().setStartTime(start).setEndTime(end).build();
+
+    requestSerializer.putQueryParam(fields, "object", input);
+
+    Map<String, List<String>> expectedFields = new HashMap<>();
+    expectedFields.put("object.startTime", Arrays.asList("1970-01-01T00:00:01.000000001Z"));
+    expectedFields.put("object.endTime", Arrays.asList("1970-01-01T00:00:02.000000002Z"));
 
     Truth.assertThat(fields).isEqualTo(expectedFields);
   }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
@@ -31,9 +31,14 @@
 package com.google.api.gax.httpjson;
 
 import com.google.common.truth.Truth;
+import com.google.protobuf.Duration;
 import com.google.protobuf.Field;
 import com.google.protobuf.Field.Cardinality;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.Int32Value;
 import com.google.protobuf.Option;
+import com.google.protobuf.Timestamp;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Arrays;
@@ -170,6 +175,14 @@ public class ProtoRestSerializerTest {
     requestSerializer.putQueryParam(fields, "optName3", "three");
     requestSerializer.putQueryParam(fields, "optName4", "");
     requestSerializer.putQueryParam(fields, "optName5", Arrays.asList("four", "five"));
+    requestSerializer.putQueryParam(
+        fields, "optName6", Duration.newBuilder().setSeconds(1).setNanos(1).build());
+    requestSerializer.putQueryParam(
+        fields, "optName7", Timestamp.newBuilder().setSeconds(1).setNanos(1).build());
+    requestSerializer.putQueryParam(
+        fields, "optName8", FieldMask.newBuilder().addPaths("a.b").addPaths("c.d").build());
+    requestSerializer.putQueryParam(fields, "optName9", Int32Value.of(1));
+    requestSerializer.putQueryParam(fields, "optName10", FloatValue.of(1.1f));
 
     Map<String, List<String>> expectedFields = new HashMap<>();
     expectedFields.put("optName1", Arrays.asList("1"));
@@ -177,6 +190,11 @@ public class ProtoRestSerializerTest {
     expectedFields.put("optName3", Arrays.asList("three"));
     expectedFields.put("optName4", Arrays.asList(""));
     expectedFields.put("optName5", Arrays.asList("four", "five"));
+    expectedFields.put("optName6", Arrays.asList("1.000000001s"));
+    expectedFields.put("optName7", Arrays.asList("1970-01-01T00:00:01.000000001Z"));
+    expectedFields.put("optName8", Arrays.asList("a.b,c.d"));
+    expectedFields.put("optName9", Arrays.asList("1"));
+    expectedFields.put("optName10", Arrays.asList("1.1"));
 
     Truth.assertThat(fields).isEqualTo(expectedFields);
   }

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
@@ -188,15 +188,21 @@ public class ProtoRestSerializerTest {
         fields, "optName8", FieldMask.newBuilder().addPaths("a.b").addPaths("c.d").build());
     requestSerializer.putQueryParam(fields, "optName9", Int32Value.of(1));
     requestSerializer.putQueryParam(fields, "optName10", FloatValue.of(1.1f));
-    com.google.longrunning.Operation operation = Operation.newBuilder()
-        .setDone(true)
-        .setError(Status.newBuilder()
-            .addDetails(Any.newBuilder().setValue(ByteString.copyFrom("error-1",
-              Charset.defaultCharset())).build())
-            .addDetails(Any.newBuilder().setValue(ByteString.copyFrom("error-2",
-              Charset.defaultCharset())).build()))
-        .setName("test")
-        .build();
+    com.google.longrunning.Operation operation =
+        Operation.newBuilder()
+            .setDone(true)
+            .setError(
+                Status.newBuilder()
+                    .addDetails(
+                        Any.newBuilder()
+                            .setValue(ByteString.copyFrom("error-1", Charset.defaultCharset()))
+                            .build())
+                    .addDetails(
+                        Any.newBuilder()
+                            .setValue(ByteString.copyFrom("error-2", Charset.defaultCharset()))
+                            .build()))
+            .setName("test")
+            .build();
     requestSerializer.putQueryParam(fields, "optName11", operation);
 
     Map<String, List<String>> expectedFields = new HashMap<>();

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ProtoRestSerializerTest.java
@@ -198,8 +198,6 @@ public class ProtoRestSerializerTest {
     requestSerializer.putQueryParam(fields, "optName4", Int32Value.of(1));
     requestSerializer.putQueryParam(fields, "optName5", FloatValue.of(1.1f));
     requestSerializer.putQueryParam(fields, "optName6", field);
-    requestSerializer.putQueryParam(
-        fields, "optName7", Arrays.asList(Cardinality.CARDINALITY_REPEATED));
 
     Map<String, List<String>> expectedFields = new HashMap<>();
     expectedFields.put("optName1", Arrays.asList("1.000000001s"));
@@ -211,7 +209,6 @@ public class ProtoRestSerializerTest {
     expectedFields.put("optName6.number", Arrays.asList("2"));
     expectedFields.put("optName6.options.name", Arrays.asList("opt_name1", "opt_name2"));
     expectedFields.put("optName6.cardinality", Arrays.asList("1"));
-    expectedFields.put("optName7", Arrays.asList("3"));
 
     Truth.assertThat(fields).isEqualTo(expectedFields);
   }


### PR DESCRIPTION
Fixes #1783
Some message derived types such as Duration, FieldMask or Int32Value
would not be correctly handled by String.valueOf(). Instead, the
toJson() method is used to make it compliant with the protobuf language
guide