### PR TITLE
ci: upgrade downstream check to include GraalVM 22.2.0

### DIFF
--- a/.github/workflows/downstream-native-image.yaml
+++ b/.github/workflows/downstream-native-image.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        graalvm: [22.1.0, 22.0.0.2, 21.3.2]
+        graalvm: [22.2.0, 22.1.0]
         java: [11, 17]
         repo:
         # GAPIC library that doesn't use a real GCP project in integration tests


### PR DESCRIPTION
Now that gax brings in graal-sdk 22.2.0 and shared-dependencies has been released with gax 2.19.0, this PR prepares for upgrading our testing to GraalVM 22.2.0. The PR removes checks for 22.0.0.2 and 21.3.2 with the following reasoning - 1) our [official documentation ](https://cloud.google.com/java/docs/compile-native-images) includes instructions starting with 22.1.0 and 2) restricts us to keeping some deprecated options such as [ `--allow-incomplete-classpath`](https://www.graalvm.org/release-notes/22_1/#native-image). For context: https://github.com/googleapis/gax-java/issues/1780