### PR TITLE
fix: remove --allow-incomplete-classpath which has been deprecated as of Graalvm 22.1.0

### DIFF
--- a/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
+++ b/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties
@@ -1,5 +1,4 @@
-Args = --allow-incomplete-classpath \
---enable-url-protocols=https,http \
+Args = --enable-url-protocols=https,http \
 --initialize-at-build-time=org.conscrypt,\
   org.slf4j.LoggerFactory,\
   org.junit.platform.engine.TestTag \


### PR DESCRIPTION
Fixes #1780
This change prevents the following warning from showing up:

```
Warning: Using a deprecated option --allow-incomplete-classpath from 'META-INF/native-image/com.google.api/gax/native-image.properties' in 'file:///home/runner/work/org/repo/jars/gax-2.18.7.jar'. Allowing an incomplete classpath is now the default. Use --link-at-build-time to report linking errors at image build time for a class or package.
```