### PR TITLE
fix(java): address reachability issues in native image compilation with version 22.2.0

### DIFF
--- a/.github/workflows/downstream-native-image.yaml
+++ b/.github/workflows/downstream-native-image.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        graalvm: [22.2.0, 22.1.0]
+        graalvm: [22.2.0]
         java: [11, 17]
         repo:
         # GAPIC library that doesn't use a real GCP project in integration tests

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -71,7 +71,7 @@ maven.com_google_http_client_google_http_client=com.google.http-client:google-ht
 maven.com_google_http_client_google_http_client_gson=com.google.http-client:google-http-client-gson:1.42.0
 maven.org_codehaus_mojo_animal_sniffer_annotations=org.codehaus.mojo:animal-sniffer-annotations:1.18
 maven.javax_annotation_javax_annotation_api=javax.annotation:javax.annotation-api:1.3.2
-maven.org_graalvm_sdk=org.graalvm.sdk:graal-sdk:22.1.0.1
+maven.org_graalvm_sdk=org.graalvm.sdk:graal-sdk:22.2.0
 
 # Testing maven artifacts
 maven.junit_junit=junit:junit:4.13.2

--- a/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/native-image.properties
+++ b/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/native-image.properties
@@ -10,4 +10,5 @@ Args = --initialize-at-run-time=io.grpc.netty.shaded.io.netty.handler.ssl.OpenSs
     io.grpc.netty.shaded.io.netty.handler.ssl,\
     io.grpc.internal.RetriableStream \
   --features=com.google.api.gax.grpc.nativeimage.ProtobufMessageFeature,\
-  com.google.api.gax.grpc.nativeimage.GrpcNettyFeature
+  com.google.api.gax.grpc.nativeimage.GrpcNettyFeature \
+  -H:-RunReachabilityHandlersConcurrently


### PR DESCRIPTION
Reproducer: https://github.com/mpeddada1/graalvm22.2-reachability. There were some changes introduced in GraalVM 22.2 which enabled reachibility handlers to be run concurrently by default. However, concurrent reachability doesn't seem to register classes correctly for reflection, therefore resulting in an error that looks like this for gapic libraries:
```
JUnit Vintage:BaseBigtableTableAdminClientTest:undeleteTableTest
    MethodSource [className = 'com.google.cloud.bigtable.admin.v2.BaseBigtableTableAdminClientTest', methodName = 'undeleteTableTest', methodParameterTypes = '']
    => java.lang.RuntimeException: Generated message class "com.google.bigtable.admin.v2.Table" missing method "getName".
       com.google.protobuf.GeneratedMessageV3.getMethodOrDie(GeneratedMessageV3.java:1929)
       com.google.protobuf.GeneratedMessageV3.access$1000(GeneratedMessageV3.java:79)
       com.google.protobuf.GeneratedMessageV3$FieldAccessorTable$SingularFieldAccessor$ReflectionInvoker.<init>(GeneratedMessageV3.java:2260)
       com.google.protobuf.GeneratedMessageV3$FieldAccessorTable$SingularFieldAccessor.<init>(GeneratedMessageV3.java:2334)
       com.google.protobuf.GeneratedMessageV3$FieldAccessorTable$SingularStringFieldAccessor.<init>(GeneratedMessageV3.java:3012)
       [...]
     Caused by: java.lang.NoSuchMethodException: com.google.bigtable.admin.v2.Table.getName()
       java.lang.Class.getMethod(DynamicHub.java:2108)
       com.google.protobuf.GeneratedMessageV3.getMethodOrDie(GeneratedMessageV3.java:1926)
       [...]
```
This change disables the support until this is fixed upstream. 
**Note**: The `RunReachabilityHandlersConcurrently` option was introduced with GraalVM 22.2 and is unavailable in version 22.1.0. 