### PR TITLE
chore: pin versions of transitive dependencies for compatibility with Python 3.6

### DIFF
--- a/.kokoro/requirements.in
+++ b/.kokoro/requirements.in
@@ -16,10 +16,12 @@ pycparser==2.21
 pyperclip==1.8.2
 python-dateutil==2.8.2
 requests==2.27.1
+certifi==2022.9.24
 importlib-metadata==4.8.3
 zipp==3.6.0
 google_api_core==2.8.2
 google-cloud-storage==2.0.0
+google-resumable-media==2.3.3
 google-cloud-core==2.3.1
 typing-extensions==4.1.1
 urllib3==1.26.12

--- a/.kokoro/requirements.txt
+++ b/.kokoro/requirements.txt
@@ -19,7 +19,9 @@ cachetools==4.2.4 \
 certifi==2022.9.24 \
     --hash=sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14 \
     --hash=sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382
-    # via requests
+    # via
+    #   -r requirements.in
+    #   requests
 cffi==1.15.1 \
     --hash=sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5 \
     --hash=sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef \
@@ -215,10 +217,12 @@ google-crc32c==1.3.0 \
     # via
     #   -r requirements.in
     #   google-resumable-media
-google-resumable-media==2.4.0 \
-    --hash=sha256:2aa004c16d295c8f6c33b2b4788ba59d366677c0a25ae7382436cb30f776deaa \
-    --hash=sha256:8d5518502f92b9ecc84ac46779bd4f09694ecb3ba38a3e7ca737a86d15cbca1f
-    # via google-cloud-storage
+google-resumable-media==2.3.3 \
+    --hash=sha256:27c52620bd364d1c8116eaac4ea2afcbfb81ae9139fb3199652fcac1724bfb6c \
+    --hash=sha256:5b52774ea7a829a8cdaa8bd2d4c3d4bc660c91b30857ab2668d0eb830f4ea8c5
+    # via
+    #   -r requirements.in
+    #   google-cloud-storage
 googleapis-common-protos==1.56.3 \
     --hash=sha256:6f1369b58ed6cf3a4b7054a44ebe8d03b29c309257583a2bbdc064cd1e4a1442 \
     --hash=sha256:87955d7b3a73e6e803f2572a33179de23989ebba725e05ea42f24838b792e461


### PR DESCRIPTION
A new version of `google-resumable-media` was released recently which dropped support for Python 3.6,. This resulted in:

```
ERROR: Could not find a version that satisfies the requirement google-resumable-media==2.4.0 (from versions: 0.0.1, 0.0.2, 0.0.3, 0.0.4, 0.0.5, 0.1.0, 0.1.1, 0.2.0, 0.2.1, 0.2.2, 0.2.3, 0.3.0, 0.3.1, 0.3.2, 0.3.3, 0.4.0, 0.4.1, 0.5.0, 0.5.1, 0.6.0, 0.7.0, 0.7.1, 1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.3.1, 1.3.2, 1.3.3, 2.0.0b1, 2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.1.0, 2.2.0, 2.2.1, 2.3.0, 2.3.1, 2.3.2, 2.3.3)
ERROR: No matching distribution found for google-resumable-media==2.4.0
cleanup
```

This PR pins the versions of the transitive dependencies to make the requirements.txt more future proof.