### PR TITLE
chore: Add parallel maven release scripts

### DIFF
--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -13,27 +13,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eo pipefail
+echo "Running `stage.sh`. Invoking stage_gradle and stage_maven"
 
-if [[ -n "${AUTORELEASE_PR}" ]]
-then
-  # Start the releasetool reporter
-  requirementsFile=$(realpath $(dirname "${BASH_SOURCE[0]}")/../requirements.txt)
-  python3 -m pip install --require-hashes -r $requirementsFile
-  python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
-fi
-
-source $(dirname "$0")/common.sh
-MAVEN_SETTINGS_FILE=$(realpath $(dirname "$0")/../../)/settings.xml
-pushd $(dirname "$0")/../../
-
-setup_environment_secrets
-mkdir -p ${HOME}/.gradle
-create_gradle_properties_file "${HOME}/.gradle/gradle.properties"
-
-if [[ -z "${AUTORELEASE_PR}" ]]
-then
-  ./gradlew publishToSonatype
-else
-  ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
-fi
+#set -eo pipefail
+#
+#if [[ -n "${AUTORELEASE_PR}" ]]
+#then
+#  # Start the releasetool reporter
+#  requirementsFile=$(realpath $(dirname "${BASH_SOURCE[0]}")/../requirements.txt)
+#  python3 -m pip install --require-hashes -r $requirementsFile
+#  python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
+#fi
+#
+#source $(dirname "$0")/common.sh
+#MAVEN_SETTINGS_FILE=$(realpath $(dirname "$0")/../../)/settings.xml
+#pushd $(dirname "$0")/../../
+#
+#setup_environment_secrets
+#mkdir -p ${HOME}/.gradle
+#create_gradle_properties_file "${HOME}/.gradle/gradle.properties"
+#
+#if [[ -z "${AUTORELEASE_PR}" ]]
+#then
+#  ./gradlew publishToSonatype
+#else
+#  ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+#fi

--- a/.kokoro/release/stage_gradle.cfg
+++ b/.kokoro/release/stage_gradle.cfg
@@ -4,6 +4,13 @@ env_vars: {
   value: "github/gax-java/.kokoro/release/stage.sh"
 }
 
+action {
+  define_artifacts {
+    regex: "github/gax-java/target/nexus-staging/staging/*.properties"
+    strip_prefix: "github/gax-java"
+  }
+}
+
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"

--- a/.kokoro/release/stage_gradle.cfg
+++ b/.kokoro/release/stage_gradle.cfg
@@ -1,0 +1,10 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+env_vars: {
+  key: "TRAMPOLINE_BUILD_FILE"
+  value: "github/gax-java/.kokoro/release/stage.sh"
+}
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"
+}

--- a/.kokoro/release/stage_gradle.sh
+++ b/.kokoro/release/stage_gradle.sh
@@ -28,26 +28,12 @@ MAVEN_SETTINGS_FILE=$(realpath $(dirname "$0")/../../)/settings.xml
 pushd $(dirname "$0")/../../
 
 setup_environment_secrets
-create_settings_xml_file "settings.xml"
+mkdir -p ${HOME}/.gradle
+create_gradle_properties_file "${HOME}/.gradle/gradle.properties"
 
-mvn clean deploy -B \
-  -DskipTests=true \
-  -Dclirr.skip=true \
-  --settings ${MAVEN_SETTINGS_FILE} \
-  -Dgpg.executable=gpg \
-  -Dgpg.passphrase=${GPG_PASSPHRASE} \
-  -Dgpg.homedir=${GPG_HOMEDIR} \
-  -P release
-
-# TODO: The step below will release the artifact to maven central. Uncomment when ready
-
-## The job triggered by Release Please (release-trigger) has this AUTORELEASE_PR
-## environment variable. Fusion also lets us to specify this variable.
-#if [[ -n "${AUTORELEASE_PR}" ]]
-#then
-#  mvn nexus-staging:release -B \
-#    -DperformRelease=true \
-#    --settings=${MAVEN_SETTINGS_FILE}
-#else
-#  echo "AUTORELEASE_PR is not set. Not releasing."
-#fi
+if [[ -z "${AUTORELEASE_PR}" ]]
+then
+  ./gradlew publishToSonatype
+else
+  ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+fi

--- a/.kokoro/release/stage_maven.cfg
+++ b/.kokoro/release/stage_maven.cfg
@@ -4,6 +4,13 @@ env_vars: {
   value: "github/gax-java/.kokoro/release/stage_maven.sh"
 }
 
+action {
+  define_artifacts {
+    regex: "github/gax-java/target/nexus-staging/staging/*.properties"
+    strip_prefix: "github/gax-java"
+  }
+}
+
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"

--- a/.kokoro/release/stage_maven.cfg
+++ b/.kokoro/release/stage_maven.cfg
@@ -1,0 +1,10 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+env_vars: {
+  key: "TRAMPOLINE_BUILD_FILE"
+  value: "github/gax-java/.kokoro/release/stage_maven.sh"
+}
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"
+}

--- a/.kokoro/release/stage_maven.sh
+++ b/.kokoro/release/stage_maven.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+if [[ -n "${AUTORELEASE_PR}" ]]
+then
+  # Start the releasetool reporter
+  requirementsFile=$(realpath $(dirname "${BASH_SOURCE[0]}")/../requirements.txt)
+  python3 -m pip install --require-hashes -r $requirementsFile
+  python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
+fi
+
+source $(dirname "$0")/common.sh
+MAVEN_SETTINGS_FILE=$(realpath $(dirname "$0")/../../)/settings.xml
+pushd $(dirname "$0")/../../
+
+setup_environment_secrets
+create_settings_xml_file "settings.xml"
+
+mvn clean deploy -B \
+  -DskipTests=true \
+  -Dclirr.skip=true \
+  --settings ${MAVEN_SETTINGS_FILE} \
+  -Dgpg.executable=gpg \
+  -Dgpg.passphrase=${GPG_PASSPHRASE} \
+  -Dgpg.homedir=${GPG_HOMEDIR} \
+  -P release
+
+## The job triggered by Release Please (release-trigger) has this AUTORELEASE_PR
+## environment variable. Fusion also lets us to specify this variable.
+#if [[ -n "${AUTORELEASE_PR}" ]]
+#then
+#  mvn nexus-staging:release -B \
+#    -DperformRelease=true \
+#    --settings=${MAVEN_SETTINGS_FILE}
+#else
+#  echo "AUTORELEASE_PR is not set. Not releasing."
+#fi


### PR DESCRIPTION
Corresponding CL: cl/488441846

This will run two jobs: stage_maven and stage_gradle. Conversation with Deepankar earlier: We can check the logs for find out the `repo-id` for when we stage to sonatype (to check which repo-id is from gradle/maven)