### PR TITLE
feat: add api key support via client settings

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/ClientSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientSettings.java
@@ -101,6 +101,10 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
     return stubSettings.getQuotaProjectId();
   }
 
+  public final String getApiKey() {
+    return stubSettings.getApiKey();
+  }
+
   @Nullable
   public final WatchdogProvider getWatchdogProvider() {
     return stubSettings.getStreamWatchdogProvider();
@@ -122,6 +126,7 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
         .add("clock", getClock())
         .add("endpoint", getEndpoint())
         .add("quotaProjectId", getQuotaProjectId())
+        .add("apiKey", getApiKey())
         .add("watchdogProvider", getWatchdogProvider())
         .add("watchdogCheckInterval", getWatchdogCheckInterval())
         .toString();
@@ -245,6 +250,11 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
       return self();
     }
 
+    public B setApiKey(String apiKey) {
+      stubSettings.setApiKey(apiKey);
+      return self();
+    }
+
     public B setWatchdogProvider(@Nullable WatchdogProvider watchdogProvider) {
       stubSettings.setStreamWatchdogProvider(watchdogProvider);
       return self();
@@ -312,6 +322,11 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
       return stubSettings.getQuotaProjectId();
     }
 
+    /** Gets the ApiKey that was previously set on this Builder. */
+    public String getApiKey() {
+      return stubSettings.getApiKey();
+    }
+
     @Nullable
     public WatchdogProvider getWatchdogProvider() {
       return stubSettings.getStreamWatchdogProvider();
@@ -342,6 +357,7 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
           .add("clock", getClock())
           .add("endpoint", getEndpoint())
           .add("quotaProjectId", getQuotaProjectId())
+          .add("apiKey", getApiKey())
           .add("watchdogProvider", getWatchdogProvider())
           .add("watchdogCheckInterval", getWatchdogCheckInterval())
           .toString();

--- a/gax/src/main/java/com/google/api/gax/rpc/ClientSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/ClientSettings.java
@@ -250,6 +250,10 @@ public abstract class ClientSettings<SettingsT extends ClientSettings<SettingsT>
       return self();
     }
 
+    /**
+     * Sets the API key. The API key will be passed to API call request via the x-goog-api-key
+     * header to authenticate the API call.
+     */
     public B setApiKey(String apiKey) {
       stubSettings.setApiKey(apiKey);
       return self();

--- a/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -435,6 +435,10 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       return self();
     }
 
+    /**
+     * Sets the API key. The API key will be passed to API call request via the x-goog-api-key
+     * header to authenticate the API call.
+     */
     public B setApiKey(String apiKey) {
       this.apiKey = apiKey;
       return self();

--- a/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StubSettings.java
@@ -73,6 +73,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
   private final String endpoint;
   private final String mtlsEndpoint;
   private final String quotaProjectId;
+  private final String apiKey;
   @Nullable private final WatchdogProvider streamWatchdogProvider;
   @Nonnull private final Duration streamWatchdogCheckInterval;
   @Nonnull private final ApiTracerFactory tracerFactory;
@@ -99,6 +100,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     this.mtlsEndpoint = builder.mtlsEndpoint;
     this.switchToMtlsEndpointAllowed = builder.switchToMtlsEndpointAllowed;
     this.quotaProjectId = builder.quotaProjectId;
+    this.apiKey = builder.apiKey;
     this.streamWatchdogProvider = builder.streamWatchdogProvider;
     this.streamWatchdogCheckInterval = builder.streamWatchdogCheckInterval;
     this.tracerFactory = builder.tracerFactory;
@@ -152,6 +154,10 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     return quotaProjectId;
   }
 
+  public final String getApiKey() {
+    return apiKey;
+  }
+
   @Nullable
   public final WatchdogProvider getStreamWatchdogProvider() {
     return streamWatchdogProvider;
@@ -185,6 +191,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         .add("mtlsEndpoint", mtlsEndpoint)
         .add("switchToMtlsEndpointAllowed", switchToMtlsEndpointAllowed)
         .add("quotaProjectId", quotaProjectId)
+        .add("apiKey", apiKey)
         .add("streamWatchdogProvider", streamWatchdogProvider)
         .add("streamWatchdogCheckInterval", streamWatchdogCheckInterval)
         .add("tracerFactory", tracerFactory)
@@ -209,6 +216,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
     @Nonnull private Duration streamWatchdogCheckInterval;
     @Nonnull private ApiTracerFactory tracerFactory;
     private boolean deprecatedExecutorProviderSet;
+    private String apiKey;
 
     /**
      * Indicate when creating transport whether it is allowed to use mTLS endpoint instead of the
@@ -230,6 +238,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       this.mtlsEndpoint = settings.mtlsEndpoint;
       this.switchToMtlsEndpointAllowed = settings.switchToMtlsEndpointAllowed;
       this.quotaProjectId = settings.quotaProjectId;
+      this.apiKey = settings.apiKey;
       this.streamWatchdogProvider = settings.streamWatchdogProvider;
       this.streamWatchdogCheckInterval = settings.streamWatchdogCheckInterval;
       this.tracerFactory = settings.tracerFactory;
@@ -264,6 +273,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
         this.endpoint = null;
         this.mtlsEndpoint = null;
         this.quotaProjectId = null;
+        this.apiKey = null;
         this.streamWatchdogProvider = InstantiatingWatchdogProvider.create();
         this.streamWatchdogCheckInterval = Duration.ofSeconds(10);
         this.tracerFactory = BaseApiTracerFactory.getInstance();
@@ -425,6 +435,11 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       return self();
     }
 
+    public B setApiKey(String apiKey) {
+      this.apiKey = apiKey;
+      return self();
+    }
+
     /**
      * Sets how often the {@link Watchdog} will check ongoing streaming RPCs. Defaults to 10 secs.
      * Use {@link Duration#ZERO} to disable.
@@ -502,6 +517,10 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
       return quotaProjectId;
     }
 
+    public String getApiKey() {
+      return apiKey;
+    }
+
     @Nonnull
     public Duration getStreamWatchdogCheckInterval() {
       return streamWatchdogCheckInterval;
@@ -537,6 +556,7 @@ public abstract class StubSettings<SettingsT extends StubSettings<SettingsT>> {
           .add("mtlsEndpoint", mtlsEndpoint)
           .add("switchToMtlsEndpointAllowed", switchToMtlsEndpointAllowed)
           .add("quotaProjectId", quotaProjectId)
+          .add("apiKey", apiKey)
           .add("streamWatchdogProvider", streamWatchdogProvider)
           .add("streamWatchdogCheckInterval", streamWatchdogCheckInterval)
           .add("tracerFactory", tracerFactory)

--- a/gax/src/test/java/com/google/api/gax/rpc/ClientSettingsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ClientSettingsTest.java
@@ -121,6 +121,7 @@ public class ClientSettingsTest {
         .isInstanceOf(InstantiatingWatchdogProvider.class);
     Truth.assertThat(builder.getWatchdogCheckInterval()).isGreaterThan(Duration.ZERO);
     Truth.assertThat(builder.getQuotaProjectId()).isNull();
+    Truth.assertThat(builder.getApiKey()).isNull();
 
     FakeClientSettings settings = builder.build();
     Truth.assertThat(settings.getExecutorProvider())
@@ -139,6 +140,7 @@ public class ClientSettingsTest {
         .isInstanceOf(InstantiatingWatchdogProvider.class);
     Truth.assertThat(settings.getWatchdogCheckInterval()).isGreaterThan(Duration.ZERO);
     Truth.assertThat((settings.getQuotaProjectId())).isSameInstanceAs(builder.getQuotaProjectId());
+    Truth.assertThat((settings.getApiKey())).isSameInstanceAs(builder.getApiKey());
 
     String settingsString = settings.toString();
     Truth.assertThat(settingsString).contains("executorProvider");
@@ -150,6 +152,7 @@ public class ClientSettingsTest {
     Truth.assertThat(settingsString).contains("watchdogProvider");
     Truth.assertThat(settingsString).contains("watchdogCheckInterval");
     Truth.assertThat(settingsString).contains(("quotaProjectId"));
+    Truth.assertThat(settingsString).contains(("apiKey"));
   }
 
   @Test
@@ -165,6 +168,7 @@ public class ClientSettingsTest {
     WatchdogProvider watchdogProvider = Mockito.mock(WatchdogProvider.class);
     Duration watchdogCheckInterval = Duration.ofSeconds(13);
     String quotaProjectId = "test_quota_project_id";
+    String apiKey = "test_api_key";
 
     builder.setExecutorProvider(executorProvider);
     builder.setTransportChannelProvider(transportProvider);
@@ -175,6 +179,7 @@ public class ClientSettingsTest {
     builder.setWatchdogProvider(watchdogProvider);
     builder.setWatchdogCheckInterval(watchdogCheckInterval);
     builder.setQuotaProjectId(quotaProjectId);
+    builder.setApiKey(apiKey);
 
     // For backward compatibility, backgroundExecutorProvider is set to executorProvider
     Truth.assertThat(builder.getExecutorProvider()).isSameInstanceAs(executorProvider);
@@ -187,6 +192,7 @@ public class ClientSettingsTest {
     Truth.assertThat(builder.getWatchdogProvider()).isSameInstanceAs(watchdogProvider);
     Truth.assertThat(builder.getWatchdogCheckInterval()).isSameInstanceAs(watchdogCheckInterval);
     Truth.assertThat(builder.getQuotaProjectId()).isEqualTo(quotaProjectId);
+    Truth.assertThat(builder.getApiKey()).isEqualTo(apiKey);
 
     String builderString = builder.toString();
     Truth.assertThat(builderString).contains("executorProvider");
@@ -199,6 +205,7 @@ public class ClientSettingsTest {
     Truth.assertThat(builderString).contains("watchdogProvider");
     Truth.assertThat(builderString).contains("watchdogCheckInterval");
     Truth.assertThat(builderString).contains("quotaProjectId");
+    Truth.assertThat(builderString).contains("apiKey");
   }
 
   @Test
@@ -259,6 +266,7 @@ public class ClientSettingsTest {
     WatchdogProvider watchdogProvider = Mockito.mock(WatchdogProvider.class);
     Duration watchdogCheckInterval = Duration.ofSeconds(14);
     String quotaProjectId = "test_builder_from_settings_quotaProjectId";
+    String apiKey = "test_builder_from_settings_api_key";
 
     builder.setExecutorProvider(executorProvider);
     builder.setTransportChannelProvider(transportProvider);
@@ -269,6 +277,7 @@ public class ClientSettingsTest {
     builder.setWatchdogProvider(watchdogProvider);
     builder.setWatchdogCheckInterval(watchdogCheckInterval);
     builder.setQuotaProjectId(quotaProjectId);
+    builder.setApiKey(apiKey);
 
     FakeClientSettings settings = builder.build();
     FakeClientSettings.Builder newBuilder = new FakeClientSettings.Builder(settings);
@@ -284,6 +293,7 @@ public class ClientSettingsTest {
     Truth.assertThat(newBuilder.getWatchdogProvider()).isSameInstanceAs(watchdogProvider);
     Truth.assertThat(newBuilder.getWatchdogCheckInterval()).isEqualTo(watchdogCheckInterval);
     Truth.assertThat(newBuilder.getQuotaProjectId()).isEqualTo(quotaProjectId);
+    Truth.assertThat(newBuilder.getApiKey()).isEqualTo(apiKey);
   }
 
   @Test


### PR DESCRIPTION
This PR supports API key via client settings. When an API key is provided via client settings, its value will be passed to API call request via `x-goog-api-key` header and other types of credential is no longer needed. API key is useful for accessing public data anonymously, for instance google maps APIs, see https://cloud.google.com/docs/authentication/api-keys

This feature has been tested with language client, see https://github.com/arithmetic1728/java-language/pull/1