### PR TITLE
fix: Watchdog does not does not wait for executor to shutdown on awaitTermination

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
@@ -138,12 +138,12 @@ public final class Watchdog implements Runnable, BackgroundResource {
 
   @Override
   public boolean isShutdown() {
-    return executor.isShutdown();
+    return future.isCancelled();
   }
 
   @Override
   public boolean isTerminated() {
-    return executor.isTerminated();
+    return future.isCancelled();
   }
 
   @Override
@@ -153,7 +153,15 @@ public final class Watchdog implements Runnable, BackgroundResource {
 
   @Override
   public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
-    return executor.awaitTermination(duration, unit);
+    // A simple implementation of awaiting future cancel, we can revisit if we decide to go with
+    // this approach.
+    long milliSecondsWaited = 0;
+    while (!future.isCancelled() && milliSecondsWaited < unit.toMillis(duration)) {
+      int interval = 1000;
+      Thread.sleep(interval);
+      milliSecondsWaited += interval;
+    }
+    return future.isCancelled();
   }
 
   @Override

--- a/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
@@ -151,7 +151,7 @@ public final class Watchdog implements Runnable, BackgroundResource {
 
   @Override
   public boolean isTerminated() {
-    return future.isCancelled() && countDownLatch.getCount() == 0;
+    return countDownLatch.getCount() == 0;
   }
 
   @Override

--- a/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
@@ -36,7 +36,6 @@ import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -87,7 +86,7 @@ public final class Watchdog implements Runnable, BackgroundResource {
     this.clock = Preconditions.checkNotNull(clock, "clock can't be null");
     this.scheduleInterval = scheduleInterval;
     this.executor = executor;
-    //Register the main thread
+    // Register the main thread
     this.phaser = new Phaser(1);
   }
 
@@ -118,14 +117,14 @@ public final class Watchdog implements Runnable, BackgroundResource {
 
   @Override
   public void run() {
-    //Register the current thread
+    // Register the current thread
     phaser.register();
     try {
       runUnsafe();
     } catch (Throwable t) {
       LOG.log(Level.SEVERE, "Caught throwable in periodic Watchdog run. Continuing.", t);
     } finally {
-      //Unregister the current thread
+      // Unregister the current thread
       phaser.arriveAndDeregister();
     }
   }
@@ -144,7 +143,7 @@ public final class Watchdog implements Runnable, BackgroundResource {
   @Override
   public void shutdown() {
     future.cancel(false);
-    //Unregister the main thread
+    // Unregister the main thread
     phaser.arriveAndDeregister();
   }
 
@@ -161,14 +160,15 @@ public final class Watchdog implements Runnable, BackgroundResource {
   @Override
   public void shutdownNow() {
     future.cancel(true);
-    //Unregister the main thread
+    // Unregister the main thread
     phaser.arriveAndDeregister();
   }
 
   @Override
   public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
     try {
-      //Default phase is 0, this method wait until all parties arrive and unregister, then terminate the Phaser
+      // Default phase is 0, this method wait until all parties arrive and unregister, then
+      // terminate the Phaser
       phaser.awaitAdvanceInterruptibly(0, duration, unit);
       return true;
     } catch (TimeoutException e) {

--- a/gax/src/test/java/com/google/api/gax/rpc/WatchdogTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/WatchdogTest.java
@@ -154,6 +154,26 @@ public class WatchdogTest {
   }
 
   @Test
+  public void awaitTermination_shouldReturnFalseIfShutDownIsNotCalledFirst() throws Exception {
+    watchdog.watch(new AccumulatingObserver<>(), waitTime, idleTime);
+    watchdog.watch(new AccumulatingObserver<>(), waitTime, idleTime);
+    boolean awaitTermination = watchdog.awaitTermination(1000, TimeUnit.MILLISECONDS);
+    assertThat(awaitTermination).isFalse();
+  }
+
+  @Test
+  public void awaitTermination_shouldReturnTrue() throws Exception {
+    watchdog.watch(new AccumulatingObserver<>(), waitTime, idleTime);
+    watchdog.watch(new AccumulatingObserver<>(), waitTime, idleTime);
+    // Make sure the run() method is run before calling shutdown()
+    Thread.sleep(2000);
+    watchdog.shutdown();
+    boolean awaitTermination = watchdog.awaitTermination(1000, TimeUnit.MILLISECONDS);
+    assertThat(awaitTermination).isTrue();
+    assertThat(watchdog.isTerminated()).isTrue();
+  }
+
+  @Test
   public void testMultiple() throws Exception {
     // Start stream1
     AccumulatingObserver<String> downstreamObserver1 = new AccumulatingObserver<>();


### PR DESCRIPTION
fixes: https://github.com/googleapis/gax-java/issues/1858

Watchdog does not wait for executor to shutdown on awaitTermination. Instead, use `Phaser` to track the lifecycle of each `run()` execution, wait for the `Phaser` to proceed to next phase(which is terminated phase in our case) in `awaitTermination` and use `phaser.isTerminated()` to determine if Watchdog is terminated or not.