### PR TITLE
chore: Fix error_prone issue

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -34,5 +34,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify sonar:sonar -Dsonar.projectKey=googleapis_gax-java -Dsonar.organization=googleapis -Dsonar.host.url=https://sonarcloud.io -Denforcer.skip -Dclirr.skip -Dsonar.verbose=true
+        run: mvn -B verify sonar:sonar -Dsonar.projectKey=googleapis_gax-java -Dsonar.organization=googleapis -Dsonar.host.url=https://sonarcloud.io
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,12 @@
         <groupId>com.google.auth</groupId>
         <artifactId>google-auth-library-oauth2-http</artifactId>
         <version>1.13.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Resolves this issue:
```
[ERROR] Rule 2: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for com.google.errorprone:error_prone_annotations:2.14.0 paths to dependency are:
+-com.google.api:gax-grpc:2.19.5
  +-io.grpc:grpc-api:1.50.2
    +-com.google.errorprone:error_prone_annotations:2.14.0
and
+-com.google.api:gax-grpc:2.19.5
  +-io.grpc:grpc-stub:1.50.2
    +-com.google.errorprone:error_prone_annotations:2.14.0 [runtime]
and
+-com.google.api:gax-grpc:2.19.5
  +-io.grpc:grpc-netty-shaded:1.50.2 [runtime]
    +-com.google.errorprone:error_prone_annotations:2.14.0 [runtime]
and
+-com.google.api:gax-grpc:2.19.5
  +-com.google.auth:google-auth-library-oauth2-http:1.13.0
    +-com.google.http-client:google-http-client:1.42.3 (managed) <-- com.google.http-client:google-http-client:1.42.3
      +-com.google.errorprone:error_prone_annotations:2.16
and
+-com.google.api:gax-grpc:2.19.5
  +-io.grpc:grpc-alts:1.50.2
    +-io.grpc:grpc-grpclb:1.50.2 (managed) <-- io.grpc:grpc-grpclb:1.50.2
      +-com.google.errorprone:error_prone_annotations:2.14.0 [runtime]
and
+-com.google.api:gax-grpc:2.19.5
  +-io.grpc:grpc-netty-shaded:1.50.2 [runtime]
    +-io.grpc:grpc-core:1.50.2 [runtime] (managed) <-- io.grpc:grpc-core:[1.50.2] [runtime]
      +-com.google.errorprone:error_prone_annotations:2.14.0 [runtime]
and
+-com.google.api:gax-grpc:2.19.5
  +-io.grpc:grpc-alts:1.50.2
    +-io.grpc:grpc-grpclb:1.50.2 (managed) <-- io.grpc:grpc-grpclb:1.50.2
      +-com.google.protobuf:protobuf-java-util:3.21.9 [runtime] (managed) <-- com.google.protobuf:protobuf-java-util:3.21.7 [runtime]
        +-com.google.errorprone:error_prone_annotations:2.5.1 [runtime]
and
+-com.google.api:gax-grpc:2.19.5
  +-io.grpc:grpc-googleapis:1.50.2 [runtime]
    +-io.grpc:grpc-xds:1.50.2 [runtime] (managed) <-- io.grpc:grpc-xds:[1.50.2] [runtime]
      +-io.grpc:grpc-services:1.50.2 [runtime] (managed) <-- io.grpc:grpc-services:1.50.2 [runtime]
        +-com.google.errorprone:error_prone_annotations:2.14.0 [runtime]
]
```