### PR TITLE
chore: Set bom parent as shared-config

### DIFF
--- a/gax-bom/pom.xml
+++ b/gax-bom/pom.xml
@@ -14,10 +14,6 @@
     <version>1.5.4</version>
   </parent>
 
-  <properties>
-    <checkstyle.header.file>${project.basedir}/../java.header</checkstyle.header.file>
-  </properties>
-
   <developers>
     <developer>
       <id>GoogleAPIs</id>
@@ -79,34 +75,15 @@
     </dependencies>
   </dependencyManagement>
 
-  <profiles>
-    <profile>
-      <!-- Only run checkstyle plugin on Java 11+ (checkstyle artifact only supports Java 11+) -->
-      <id>checkstyle-tests</id>
-      <activation>
-        <jdk>[11,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>checkstyle</id>
-                <phase>validate</phase>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-                <configuration>
-                  <headerLocation>${checkstyle.header.file}</headerLocation>
-                  <configLocation>${project.basedir}/../license-checks.xml</configLocation>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/gax-bom/pom.xml
+++ b/gax-bom/pom.xml
@@ -72,4 +72,16 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/gax-bom/pom.xml
+++ b/gax-bom/pom.xml
@@ -14,13 +14,10 @@
     <version>1.5.4</version>
   </parent>
 
-  <url>https://github.com/googleapis/gax-java</url>
-  <licenses>
-    <license>
-      <name>BSD</name>
-      <url>https://github.com/googleapis/gax-java/blob/master/LICENSE</url>
-    </license>
-  </licenses>
+  <properties>
+    <checkstyle.header.file>${project.basedir}/../java.header</checkstyle.header.file>
+  </properties>
+
   <developers>
     <developer>
       <id>GoogleAPIs</id>
@@ -31,10 +28,19 @@
       <organizationUrl>https://www.google.com</organizationUrl>
     </developer>
   </developers>
+
   <scm>
     <connection>scm:git:https://github.com/googleapis/gax-java.git</connection>
     <url>https://github.com/googleapis/gax-java</url>
   </scm>
+
+  <licenses>
+    <license>
+      <name>BSD</name>
+      <url>https://github.com/googleapis/gax-java/blob/master/LICENSE</url>
+    </license>
+  </licenses>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -73,15 +79,34 @@
     </dependencies>
   </dependencyManagement>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+  <profiles>
+    <profile>
+      <!-- Only run checkstyle plugin on Java 11+ (checkstyle artifact only supports Java 11+) -->
+      <id>checkstyle-tests</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>checkstyle</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <configuration>
+                  <headerLocation>${checkstyle.header.file}</headerLocation>
+                  <configLocation>${project.basedir}/../license-checks.xml</configLocation>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/gax-bom/pom.xml
+++ b/gax-bom/pom.xml
@@ -7,6 +7,13 @@
   <packaging>pom</packaging>
   <name>GAX (Google Api eXtensions) for Java (BOM)</name>
   <description>Google Api eXtensions for Java (BOM)</description>
+
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-shared-config</artifactId>
+    <version>1.5.4</version>
+  </parent>
+
   <url>https://github.com/googleapis/gax-java</url>
   <licenses>
     <license>

--- a/license-checks.xml
+++ b/license-checks.xml
@@ -5,6 +5,6 @@
 <module name="Checker">
   <module name="RegexpHeader">
     <property name="fileExtensions" value="java"/>
-    <property name="headerFile" value="java.header"/>
+    <property name="headerFile" value="${checkstyle.header.file}"/>
   </module>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <auto-value.version>1.10</auto-value.version>
+    <checkstyle.header.file>java.header</checkstyle.header.file>
   </properties>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <auto-value.version>1.10</auto-value.version>
-    <checkstyle.header.file>java.header</checkstyle.header.file>
   </properties>
 
   <modules>


### PR DESCRIPTION
Thinking about setting gax's bom parent to be shared-config. This is resolve the issue seen below:

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] GAX (Google Api eXtensions) for Java (Parent) 2.19.5 SUCCESS [07:31 min]
[INFO] GAX (Google Api eXtensions) for Java (Core) 2.19.5 . SUCCESS [01:10 min]
[INFO] GAX (Google Api eXtensions) for Java (gRPC) 2.19.5 . SUCCESS [ 38.031 s]
[INFO] GAX (Google Api eXtensions) for Java (HTTP JSON) 0.104.5 SUCCESS [04:41 min]
[INFO] GAX (Google Api eXtensions) for Java (BOM) 2.19.5 .. FAILURE [  0.817 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  16:31 min
[INFO] Finished at: 2022-11-16T22:02:58Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy (default-deploy) on project gax-bom: Deployment failed: repository element was not specified in the POM inside distributionManagement element or in -DaltDeploymentRepository=id::layout::url parameter -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] [http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException](https://www.google.com/url?q=http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException&sa=D)
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :gax-bom
cleanup
```