### PR TITLE
fix: Watchdog controls lifecycle of the future, not executor

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/Watchdog.java
@@ -34,7 +34,13 @@ import com.google.api.gax.core.BackgroundResource;
 import com.google.common.base.Preconditions;
 import java.util.Iterator;
 import java.util.Map.Entry;
-import java.util.concurrent.*;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
@@ -57,6 +63,7 @@ import org.threeten.bp.Duration;
  * </ul>
  */
 public final class Watchdog implements Runnable, BackgroundResource {
+
   private static final Logger LOG = Logger.getLogger(Watchdog.class.getName());
 
   // Dummy value to convert the ConcurrentHashMap into a Set

--- a/gax/src/main/java/com/google/api/gax/rpc/WatchdogProvider.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/WatchdogProvider.java
@@ -49,5 +49,6 @@ public interface WatchdogProvider {
 
   Watchdog getWatchdog();
 
+  /** Return true if the watchdog should be automatically unscheduled. */
   boolean shouldAutoClose();
 }


### PR DESCRIPTION
Watchdog should not control the lifecycle of the provided executor. As a `BackgroundResource`, it should only unschedule itself from the executor if asked to be shutdown.
I believe this is more aligned with the intent #828 without surprising side effects on the lifecycle of the executor that is not controlled by the `Watchdog` or the `WatchdogProvider`.

Fixes #1858.

cc/ @igorbernstein2 

Other approaches considered: #1875 , #1883. 
Will add unit tests in a separate PR. 
Further improvement: #1884.