### PR TITLE
fix: Fix the BasicRetryingFuture to catch all throwables include errors

### DIFF
--- a/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
+++ b/gax/src/main/java/com/google/api/gax/retrying/BasicRetryingFuture.java
@@ -206,9 +206,9 @@ class BasicRetryingFuture<ResponseT> extends AbstractFuture<ResponseT>
         // A retry algorithm triggered cancellation.
         tracer.attemptFailedRetriesExhausted(e);
         super.cancel(false);
-      } catch (Exception e) {
+      } catch (Throwable e) {
         // Should never happen, but still possible in case of buggy retry algorithm implementation.
-        // Any bugs/exceptions (except CancellationException) in retry algorithms immediately
+        // Any bugs/throwables (except CancellationException) in retry algorithms immediately
         // terminate retrying future and set the result to the thrown exception.
         tracer.attemptPermanentFailure(e);
         super.setException(e);


### PR DESCRIPTION
This will catch throwable that's not an exception, for example, NoSuchMethodError. In case there's a version mismatch in client libraries, the error will get caught and won't hang the request forever. 