### PR TITLE
chore: Comment out javadoc jobs for 2.6.x

### DIFF
--- a/.kokoro/release/publish_javadoc.sh
+++ b/.kokoro/release/publish_javadoc.sh
@@ -1,52 +1,52 @@
-#!/bin/bash
-# Copyright 2019 Google Inc.
+##!/bin/bash
+## Copyright 2019 Google Inc.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+#set -eo pipefail
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#if [[ -z "${CREDENTIALS}" ]]; then
+#  CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
+#fi
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-set -eo pipefail
-
-if [[ -z "${CREDENTIALS}" ]]; then
-  CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
-fi
-
-if [[ -z "${STAGING_BUCKET}" ]]; then
-  echo "Need to set STAGING_BUCKET environment variable"
-  exit 1
-fi
-
-# work from the git root directory
-pushd $(dirname "$0")/../../
-
-# install docuploader package
-python3 -m pip install gcp-docuploader
-
-NAME=gax
-VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
-
-# build the docs
-./gradlew javadocCombined
-
-pushd tmp_docs
-
-# create metadata
-python3 -m docuploader create-metadata \
-  --name ${NAME} \
-  --version ${VERSION} \
-  --language java
-
-# upload docs
-python3 -m docuploader upload . \
-  --credentials ${CREDENTIALS} \
-  --staging-bucket ${STAGING_BUCKET}
-
-popd
+#if [[ -z "${STAGING_BUCKET}" ]]; then
+#  echo "Need to set STAGING_BUCKET environment variable"
+#  exit 1
+#fi
+#
+## work from the git root directory
+#pushd $(dirname "$0")/../../
+#
+## install docuploader package
+#python3 -m pip install gcp-docuploader
+#
+#NAME=gax
+#VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
+#
+## build the docs
+#./gradlew javadocCombined
+#
+#pushd tmp_docs
+#
+## create metadata
+#python3 -m docuploader create-metadata \
+#  --name ${NAME} \
+#  --version ${VERSION} \
+#  --language java
+#
+## upload docs
+#python3 -m docuploader upload . \
+#  --credentials ${CREDENTIALS} \
+#  --staging-bucket ${STAGING_BUCKET}
+#
+#popd

--- a/.kokoro/release/publish_javadoc11.sh
+++ b/.kokoro/release/publish_javadoc11.sh
@@ -1,59 +1,59 @@
-#!/bin/bash
-# Copyright 2019 Google Inc.
+##!/bin/bash
+## Copyright 2019 Google Inc.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+#set -eo pipefail
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#if [[ -z "${CREDENTIALS}" ]]; then
+#  CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
+#fi
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-set -eo pipefail
-
-if [[ -z "${CREDENTIALS}" ]]; then
-  CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
-fi
-
-if [[ -z "${STAGING_BUCKET_V2}" ]]; then
-  echo "Need to set STAGING_BUCKET environment variable"
-  exit 1
-fi
-
-# work from the git root directory
-pushd $(dirname "$0")/../../
-
-# install docuploader package
-python3 -m pip install gcp-docuploader
-
-NAME=gax
-VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
-
-# build the docs
-./gradlew javadocCombinedV3
-
-# copy README to docfx-yml dir and rename index.md
-cp README.md tmp_docs/docfx-yml/index.md
-
-# copy CHANGELOG to docfx-yml dir and rename history.md
-cp CHANGELOG.md tmp_docs/docfx-yml/history.md
-
-pushd tmp_docs/docfx-yml/
-
-# create metadata
-python3 -m docuploader create-metadata \
-  --name ${NAME} \
-  --version ${VERSION} \
-  --language java
-
-# upload docs
-python3 -m docuploader upload . \
-  --credentials ${CREDENTIALS} \
-  --staging-bucket ${STAGING_BUCKET_V2} \
-  --destination-prefix docfx
-
-popd
+#if [[ -z "${STAGING_BUCKET_V2}" ]]; then
+#  echo "Need to set STAGING_BUCKET environment variable"
+#  exit 1
+#fi
+#
+## work from the git root directory
+#pushd $(dirname "$0")/../../
+#
+## install docuploader package
+#python3 -m pip install gcp-docuploader
+#
+#NAME=gax
+#VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
+#
+## build the docs
+#./gradlew javadocCombinedV3
+#
+## copy README to docfx-yml dir and rename index.md
+#cp README.md tmp_docs/docfx-yml/index.md
+#
+## copy CHANGELOG to docfx-yml dir and rename history.md
+#cp CHANGELOG.md tmp_docs/docfx-yml/history.md
+#
+#pushd tmp_docs/docfx-yml/
+#
+## create metadata
+#python3 -m docuploader create-metadata \
+#  --name ${NAME} \
+#  --version ${VERSION} \
+#  --language java
+#
+## upload docs
+#python3 -m docuploader upload . \
+#  --credentials ${CREDENTIALS} \
+#  --staging-bucket ${STAGING_BUCKET_V2} \
+#  --destination-prefix docfx
+#
+#popd


### PR DESCRIPTION
This is to confirm staging works for LTS branches. `stage.sh` calls `publish_javadoc11.sh` on success.

I want to test this the way release-please would invoke it (simulating it by entering commitish from `2.6.x` branch into the stage job). I'll check the logs and revert this PR.