### PR TITLE
doc: fixed links in javadoc

### DIFF
--- a/gax/src/main/java/com/google/api/gax/rpc/StatusCode.java
+++ b/gax/src/main/java/com/google/api/gax/rpc/StatusCode.java
@@ -36,7 +36,7 @@ import com.google.api.core.InternalExtensionOnly;
  *
  * <p>The status codes are modeled after the status codes in grpc. For more information about grpc
  * status codes, see
- * https://github.com/grpc/grpc-java/blob/master/core/src/main/java/io/grpc/Status.java
+ * https://github.com/grpc/grpc-java/blob/master/api/src/main/java/io/grpc/Status.java
  */
 @InternalExtensionOnly
 public interface StatusCode {

--- a/gax/src/test/java/com/google/api/gax/rpc/testing/FakeStatusException.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/testing/FakeStatusException.java
@@ -70,7 +70,7 @@ public class FakeStatusException extends Exception {
    * Returns the status code of the underlying grpc exception. In cases where the underlying
    * exception is not of type StatusException or StatusRuntimeException, the status code will be
    * Status.Code.UNKNOWN. For more information about status codes see
-   * https://github.com/grpc/grpc-java/blob/master/core/src/main/java/io/grpc/Status.java
+   * https://github.com/grpc/grpc-java/blob/master/api/src/main/java/io/grpc/Status.java
    */
   public FakeStatusCode getStatusCode() {
     return fakeStatusCode;


### PR DESCRIPTION
Update in javadoc in com/google/api/gax/rpc/StatusCode.java and com/google/api/gax/rpc/testing/FakeStatusException.java